### PR TITLE
Add helper reference documentation for docker_services role

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@
 + Authelia and Traefik for SSO/Reverse Proxy
 + HA PostgreSQL (Patroni + etcd) as primary database storage
 + A large focus on media-centric services (especially arrs and companion apps)
+## Helper documentation
+
+Detailed documentation for role helpers is available at `roles/docker_services/helpers/README.md`.

--- a/roles/docker_services/helpers/README.md
+++ b/roles/docker_services/helpers/README.md
@@ -1,0 +1,51 @@
+# Docker Services Helper Reference
+
+This directory contains task-file helpers that are included by the `docker_services` role to build, validate, prepare, and deploy stacks.
+
+## `compose/`
+
+- `caps.yml`: Adds or replaces Linux capabilities (`cap_add` / `cap_drop`) for a service, with append and unique-append merge modes.
+- `command.yml`: Sets a service `command` with normalization for string/list input and optional append semantics when list-based commands are used.
+- `configs.yml`: Attaches Docker configs to a service definition.
+- `depends_on.yml`: Normalizes and sets service `depends_on` entries.
+- `deploy.yml`: Builds the `deploy` section for a service (mode, replicas, resources, constraints, restart/update/rollback policies, labels).
+- `devices.yml`: Adds device mappings to a service with append/replace behavior.
+- `env_file.yml`: Normalizes and attaches one or more `env_file` entries to a service.
+- `environment.yml`: Merges environment variables into a service, with configurable precedence and merge strategy.
+- `healthcheck.yml`: Builds and attaches a service `healthcheck` block, including normalized `test` command format.
+- `labels.yml`: Merges and assigns labels to a service with precedence and merge controls.
+- `ports.yml`: Normalizes port mappings and applies them differently for compose/container vs swarm deploy modes.
+- `secrets.yml`: Attaches secrets for swarm mode and converts secret references into bind-mounted secret files for compose/container mode.
+- `security_opt.yml`: Adds or replaces `security_opt` entries for a service.
+- `service_base.yml`: Creates the baseline service definition (name, image/build, hostname/container name, restart policy, pull policy, and optional metadata).
+- `shm.yml`: Sets `shm_size` for a service.
+- `stack_networks.yml`: Defines top-level compose networks for a stack and normalizes list/map input.
+- `stack_volumes.yml`: Defines top-level compose volumes for a stack and normalizes list/map input.
+- `user.yml`: Sets the runtime `user` for a service.
+- `validate.yml`: Performs top-level compose validation across all generated services before rendering/deploy.
+- `validate_service.yml`: Validates a service object shape (directories, env, compose extras, deploy host, etc.).
+- `validate_svc.yml`: Validates normalized service fields (name/image/deploy/environment/ports/etc.) for schema correctness.
+- `volumes.yml`: Normalizes, validates, and merges service volume mounts from mapping, list, or legacy inputs.
+
+## `deploy/`
+
+- `deploy_all.yml`: Iterates through all prepared stacks and deploys each one.
+- `deploy_one.yml`: Renders stack compose artifacts and deploys a single stack on the effective deploy host.
+
+## `infisical/`
+
+- `distribute.yml`: Copies fetched secret values from a source host into host variables, either from flattened keys or a source dictionary.
+- `fetch.yml`: Looks up secrets from Infisical based on a `secrets_map`, outputting flattened vars and/or a dictionary.
+
+## `prep/`
+
+- `cleanup.yml`: Removes old stack artifacts/resources for the current deploy mode (compose/container or swarm).
+- `cloudflare_creds.yml`: Ensures Cloudflare credentials/zone values exist, fetching from Infisical when needed.
+- `cloudflare_dns.yml`: Creates or updates Cloudflare DNS records for a target domain/host.
+- `copies.yml`: Copies role-relative files to target destinations on the deploy host.
+- `paths.yml`: Ensures filesystem paths exist with expected ownership, permissions, and state.
+- `postgres.yml`: Ensures Postgres credentials/secrets are available and can create/check requested databases.
+- `resolve_env.yml`: Resolves environment placeholders (e.g., `${VAR}` style references) into concrete service environment values.
+- `secrets.yml`: Normalizes secret inputs and materializes Docker secrets (swarm) or secret files (compose/container).
+- `swarm_configs.yml`: Creates/removes Docker Swarm configs from inline data or source files/templates.
+- `templates.yml`: Renders Jinja templates to destination paths on the deploy host.


### PR DESCRIPTION
### Motivation

- Provide a concise, discoverable reference for the task-file helpers used by the `docker_services` role so maintainers and contributors can quickly understand each helper's purpose and behavior.

### Description

- Add `roles/docker_services/helpers/README.md` that documents each helper task file under `compose/`, `deploy/`, `infisical/`, and `prep/` with a one-line summary of what it does.
- Update the repository root `README.md` to add a `Helper documentation` section linking to the new helper reference for discoverability.

### Testing

- Ran `git status --short` and inspected the modified files to confirm the new helper reference and README update were present and staged successfully.
- Ran `git show --stat --oneline --decorate=short HEAD` to verify the diff summary and file statistics, and both verification commands completed without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998340db2b48323baf0243ad7db1ab9)