### PR TITLE
docs: add grouped inventory of Ansible modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,69 @@
 ## Helper documentation
 
 Detailed documentation for role helpers is available at `roles/docker_services/helpers/README.md`.
+
+## Ansible module inventory (grouped)
+
+Below is a grouped list of Ansible modules currently used in this repository, with short descriptions.
+
+### `ansible.builtin`
+
+| Module | What it is used for |
+| --- | --- |
+| `ansible.builtin.assert` | Validate assumptions and fail early when inputs/state are invalid. |
+| `ansible.builtin.command` | Run commands without shell expansion. |
+| `ansible.builtin.copy` | Copy rendered/static content to managed hosts. |
+| `ansible.builtin.debug` | Print values/messages for troubleshooting and visibility. |
+| `ansible.builtin.fail` | Stop execution with an explicit failure message. |
+| `ansible.builtin.file` | Manage file/dir/link state, ownership, and permissions. |
+| `ansible.builtin.include_role` | Reuse a role from within another play/task flow. |
+| `ansible.builtin.include_tasks` | Dynamically include task files. |
+| `ansible.builtin.include_vars` | Load variable files at runtime. |
+| `ansible.builtin.package_facts` | Gather installed package information from hosts. |
+| `ansible.builtin.pause` | Wait/prompt (for retries, human steps, or timing gaps). |
+| `ansible.builtin.set_fact` | Build derived variables during execution. |
+| `ansible.builtin.shell` | Run shell commands where shell features are required. |
+| `ansible.builtin.slurp` | Read remote file contents as base64 data. |
+| `ansible.builtin.stat` | Check remote path/file presence and metadata. |
+| `ansible.builtin.template` | Render Jinja2 templates to managed hosts. |
+| `ansible.builtin.uri` | Call HTTP APIs/endpoints (for service setup/queries). |
+| `ansible.builtin.wait_for` | Wait for ports/files/conditions before continuing. |
+
+### `community.docker`
+
+| Module | What it is used for |
+| --- | --- |
+| `community.docker.docker_compose_v2` | Manage Docker Compose v2 projects. |
+| `community.docker.docker_config` | Manage Docker Swarm configs. |
+| `community.docker.docker_container` | Manage one-off or helper containers. |
+| `community.docker.docker_secret` | Manage Docker Swarm secrets. |
+| `community.docker.docker_stack` | Deploy/update/remove Docker Swarm stacks. |
+| `community.docker.docker_volume` | Manage Docker volumes. |
+
+### `community.general`
+
+| Module | What it is used for |
+| --- | --- |
+| `community.general.cloudflare_dns` | Create/update/delete Cloudflare DNS records. |
+| `community.general.ini_file` | Update INI-style configuration files. |
+| `community.general.ipify_facts` | Fetch public IP facts via ipify. |
+| `community.general.ipinfoio_facts` | Fetch network/location facts via ipinfo.io. |
+| `community.general.xml` | Read/update XML documents. |
+
+### `community.postgresql`
+
+| Module | What it is used for |
+| --- | --- |
+| `community.postgresql.postgresql_db` | Create/drop/manage PostgreSQL databases. |
+| `community.postgresql.postgresql_ping` | Check PostgreSQL connectivity/availability. |
+
+### Custom / non-FQCN modules in use
+
+| Module | What it is used for |
+| --- | --- |
+| `qbittorrent_passwd` | Generate qBittorrent-compatible password hashes in prep tasks. |
+| `yedit` | Edit YAML keys/values in-place in existing config files. |
+
+> Notes:
+> - This list is derived from module invocations in playbooks and role task files.
+> - `qbittorrent_passwd` and `yedit` are used in short-form names in this repo (non-FQCN form).


### PR DESCRIPTION
### Motivation

- Provide a quick reference of Ansible modules used across the repo to make audits and onboarding easier. 
- Clarify which collections are relied on and highlight short-form/custom module names seen in tasks.

### Description

- Added a new "Ansible module inventory (grouped)" section to `README.md` that groups modules by collection and gives a one-line purpose for each module. 
- Included entries for `ansible.builtin`, `community.docker`, `community.general`, and `community.postgresql` modules. 
- Added a "Custom / non-FQCN modules in use" subsection documenting `qbittorrent_passwd` and `yedit`. 
- Included a short notes block describing derivation and short-form naming used in the repo.

### Testing

- Verified the new content exists with `rg -n "Ansible module inventory|ansible\.builtin\.assert|community\.docker\.docker_stack|qbittorrent_passwd|yedit" README.md`, which succeeded. 
- Confirmed working tree status with `git status --short` and committed the change using a repo commit, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac5b2f5ec8323959f8e17cf6f00e5)