### PR TITLE
Fix ansible-lint line-length violations in compose helper tasks

### DIFF
--- a/roles/docker_services/helpers/compose/caps.yml
+++ b/roles/docker_services/helpers/compose/caps.yml
@@ -57,9 +57,13 @@
                     else
                     (
                       (
-                        ((docker_services_compose_services | default({})).get(docker_services_service_name, {}).get((caps_target | string | trim), []))
-                        | default([], true)
-                        | list
+                        (
+                          (docker_services_compose_services | default({}))
+                          .get(docker_services_service_name, {})
+                          .get((caps_target | string | trim), [])
+                          | default([], true)
+                          | list
+                        )
                       )
                       +
                       (
@@ -68,7 +72,16 @@
                         else
                         (
                           _caps_new
-                          | reject('in', ((docker_services_compose_services | default({})).get(docker_services_service_name, {}).get((caps_target | string | trim), []) | default([], true) | list))
+                          | reject(
+                              'in',
+                              (
+                                (docker_services_compose_services | default({}))
+                                .get(docker_services_service_name, {})
+                                .get((caps_target | string | trim), [])
+                                | default([], true)
+                                | list
+                              )
+                            )
                           | list
                         )
                       )

--- a/roles/docker_services/helpers/compose/command.yml
+++ b/roles/docker_services/helpers/compose/command.yml
@@ -56,7 +56,13 @@
 # Read existing command (may be string/list/undefined) — do NOT use omit here
 - name: Read existing command
   ansible.builtin.set_fact:
-    _cmd_existing: "{{ (docker_services_compose_services | default({})).get(docker_services_service_name, {}).get('command') | default(none, true) }}"
+    _cmd_existing: >-
+      {{
+        (docker_services_compose_services | default({}))
+        .get(docker_services_service_name, {})
+        .get('command')
+        | default(none, true)
+      }}
 
 # Merge rules:
 # - replace: always _cmd_new

--- a/roles/docker_services/helpers/compose/devices.yml
+++ b/roles/docker_services/helpers/compose/devices.yml
@@ -60,7 +60,16 @@
                         else
                         (
                           _devices_new
-                          | reject('in', ((docker_services_compose_services | default({})).get(docker_services_service_name, {}).get('devices', []) | default([], true) | list))
+                          | reject(
+                              'in',
+                              (
+                                (docker_services_compose_services | default({}))
+                                .get(docker_services_service_name, {})
+                                .get('devices', [])
+                                | default([], true)
+                                | list
+                              )
+                            )
                           | list
                         )
                       )

--- a/roles/docker_services/helpers/compose/environment.yml
+++ b/roles/docker_services/helpers/compose/environment.yml
@@ -17,7 +17,13 @@
   ansible.builtin.set_fact:
     _env_action: "{{ environment_action | default('append', true) | string | trim }}"
     _env_new: "{{ environment_vars | default({}, true) }}"
-    _env_existing: "{{ (docker_services_compose_services | default({})).get(docker_services_service_name, {}).get('environment', {}) | default({}, true) }}"
+    _env_existing: >-
+      {{
+        (docker_services_compose_services | default({}))
+        .get(docker_services_service_name, {})
+        .get('environment', {})
+        | default({}, true)
+      }}
 
 - name: Build final environment dict
   ansible.builtin.set_fact:

--- a/roles/docker_services/helpers/compose/labels.yml
+++ b/roles/docker_services/helpers/compose/labels.yml
@@ -26,7 +26,13 @@
   ansible.builtin.set_fact:
     _labels_h_action: "{{ labels_action | default('append', true) | string | trim }}"
     _labels_h_precedence: "{{ labels_precedence | default('new_wins', true) | string | trim }}"
-    _labels_h_existing: "{{ (docker_services_compose_services | default({})).get(docker_services_service_name, {}).get('labels', {}) | default({}, true) }}"
+    _labels_h_existing: >-
+      {{
+        (docker_services_compose_services | default({}))
+        .get(docker_services_service_name, {})
+        .get('labels', {})
+        | default({}, true)
+      }}
     _labels_h_new: >-
       {%- set out = {} -%}
       {%- if (labels_dict is mapping) -%}

--- a/roles/docker_services/helpers/compose/ports.yml
+++ b/roles/docker_services/helpers/compose/ports.yml
@@ -88,7 +88,13 @@
 - name: Compute merged ports list
   ansible.builtin.set_fact:
     _ports_merged: >-
-      {%- set existing = ((docker_services_compose_services | default({})).get(docker_services_service_name, {}).get('ports', []) | default([], true) | list) -%}
+      {%- set existing = (
+            (docker_services_compose_services | default({}))
+            .get(docker_services_service_name, {})
+            .get('ports', [])
+            | default([], true)
+            | list
+          ) -%}
       {%- set existing_canon = [] -%}
       {%- for e in existing -%}
       {%- if e is mapping and e.published is defined and e.target is defined -%}

--- a/roles/docker_services/helpers/compose/secrets.yml
+++ b/roles/docker_services/helpers/compose/secrets.yml
@@ -70,7 +70,13 @@
               (docker_services_compose_services | default({})).get(docker_services_service_name, {})
               | combine({
                   'volumes': (
-                    ((docker_services_compose_services | default({})).get(docker_services_service_name, {}).get('volumes', []) | default([], true) | list)
+                    (
+                      (docker_services_compose_services | default({}))
+                      .get(docker_services_service_name, {})
+                      .get('volumes', [])
+                      | default([], true)
+                      | list
+                    )
                     + _secret_mounts
                   )
                 }, recursive=true)

--- a/roles/docker_services/helpers/compose/security_opt.yml
+++ b/roles/docker_services/helpers/compose/security_opt.yml
@@ -54,9 +54,13 @@
                           _security_opt_new
                           | reject(
                               'in',
-                              ((docker_services_compose_services | default({})).get(docker_services_service_name, {}).get('security_opt', [])
-                               | default([], true)
-                               | list)
+                              (
+                                (docker_services_compose_services | default({}))
+                                .get(docker_services_service_name, {})
+                                .get('security_opt', [])
+                                | default([], true)
+                                | list
+                              )
                             )
                           | list
                         )


### PR DESCRIPTION
### Motivation
- Reduce `ansible-lint` complaints about lines exceeding the 140-character limit in the compose helper tasks while keeping the existing runtime behavior and Jinja data lookups intact.

### Description
- Reflowed and reformatted long Jinja/filter expressions into multiline parenthesized blocks so chained `.get(...)` calls and long filter pipelines no longer exceed line-length limits.
- Applied this pattern consistently across the compose helper files: `security_opt.yml`, `secrets.yml`, `ports.yml`, `labels.yml`, `environment.yml`, `devices.yml`, `command.yml`, and `caps.yml`.
- Maintained the original logic and filters (same `.get` keys, defaults and merges) so the tasks' behavior is unchanged.

### Testing
- Ran a targeted long-line check with `awk 'length($0)>140'` against all touched files and observed no reported lines longer than 140 characters.
- Ran `ansible-lint --offline` on the updated helper files and it completed without failures for the processed files.
- Attempting `ansible-lint` without `--offline` failed in this environment due to external Galaxy/dependency installation/network restrictions and not due to the file changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c3031c9408323b9d4b08be0852f49)