### PR TITLE
Fix docker_services compose template variable regression

### DIFF
--- a/roles/docker_services/templates/compose.yml.j2
+++ b/roles/docker_services/templates/compose.yml.j2
@@ -16,8 +16,10 @@
 {%- set _stack_networks = (stack_networks | default({}, true)) -%}
 {%- set _stack_volumes  = (stack_volumes  | default({}, true)) -%}
 
+{%- set _compose_services = (docker_services_compose_services | default(compose_services | default({}, true), true)) -%}
+
 services:
-{% for service_name, svc in compose_services.items() %}
+{% for service_name, svc in _compose_services.items() %}
   {{ service_name }}:
     image: "{{ svc.image }}"
 {% if svc.hostname is defined and (svc.hostname | string | trim | length > 0) %}
@@ -353,7 +355,7 @@ volumes:
 {# Top-level Configs               #}
 {# ------------------------------- #}
 {%- set all_service_configs = [] -%}
-{%- for _svc_name, _svc in compose_services.items() -%}
+{%- for _svc_name, _svc in _compose_services.items() -%}
 {%- if _svc.configs is defined and (_svc.configs | length > 0) -%}
 {%- for c in _svc.configs -%}
 {%- if c.source is defined and (c.source not in all_service_configs) -%}
@@ -375,7 +377,7 @@ configs:
 {# Top-level Secrets               #}
 {# ------------------------------- #}
 {%- set all_service_secrets = [] -%}
-{%- for _svc_name, _svc in compose_services.items() -%}
+{%- for _svc_name, _svc in _compose_services.items() -%}
 {%- if _svc.secrets is defined and (_svc.secrets | length > 0) -%}
 {%- for secret_name in _svc.secrets -%}
 {%- if secret_name not in all_service_secrets -%}


### PR DESCRIPTION
### Motivation
- The compose template started referencing a legacy variable name and could fail when the deploy path supplies `docker_services_compose_services` instead of `compose_services`. 
- The change intends to ensure the compose template renders reliably for the current deploy flow while remaining backward-compatible with older call sites.

### Description
- Updated `roles/docker_services/templates/compose.yml.j2` to introduce a normalized local variable `_compose_services` that prefers `docker_services_compose_services` and falls back to legacy `compose_services` and `{}`. 
- Replaced all iterations over `compose_services` with iterations over `_compose_services` including service rendering and top-level `configs`/`secrets` collection. 
- No behavior changes to the deploy task inputs; the validation in `roles/docker_services/helpers/deploy/deploy_one.yml` still expects `docker_services_compose_services` as before.

### Testing
- Rendered the updated template with an inventory-playbook that defines only `docker_services_compose_services` using `ansible-playbook /tmp/compose_render_test.yml`, which completed successfully. 
- Rendered the updated template with a playbook that defines only legacy `compose_services` using `ansible-playbook /tmp/compose_render_legacy_test.yml`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f28b097208323ac3d5a639d62a8a6)