### PR TITLE
Split Cloudflare DNS prep from Traefik middleware config

### DIFF
--- a/group_vars/all/services/adminer.yml
+++ b/group_vars/all/services/adminer.yml
@@ -11,6 +11,8 @@ adminer:
     enable: true
     port: 8080
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/alloy.yml
+++ b/group_vars/all/services/alloy.yml
@@ -82,6 +82,8 @@ alloy:
     enable: true
     port: 12345
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/autobrr.yml
+++ b/group_vars/all/services/autobrr.yml
@@ -61,6 +61,8 @@ autobrr:
     internal_api: true
     internal_api_rules:
       - "PathPrefix(`/api`)"
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/autopulse-ui.yml
+++ b/group_vars/all/services/autopulse-ui.yml
@@ -13,6 +13,8 @@ autopulse_ui:
     enable: true
     port: 2880
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/bazarr.yml
+++ b/group_vars/all/services/bazarr.yml
@@ -90,6 +90,8 @@ bazarr:
     internal_api: true
     internal_api_rules:
       - "PathPrefix(`/api`)"
+  cloudflare:
+    enable: true
   themepark:
     app: bazarr
     theme: hotline

--- a/group_vars/all/services/czkawka.yml
+++ b/group_vars/all/services/czkawka.yml
@@ -35,6 +35,8 @@ czkawka:
     enable: true
     port: 5800
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/gitea.yml
+++ b/group_vars/all/services/gitea.yml
@@ -57,6 +57,8 @@ gitea:
     enable: true
     port: 3000
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/grafana.yml
+++ b/group_vars/all/services/grafana.yml
@@ -57,6 +57,8 @@ grafana:
     enable: true
     port: 3000
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/homepage.yml
+++ b/group_vars/all/services/homepage.yml
@@ -134,6 +134,8 @@ homepage:
     enable: true
     port: 3000
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/jellyseerr.yml
+++ b/group_vars/all/services/jellyseerr.yml
@@ -105,6 +105,8 @@ jellyseerr:
     enable: true
     port: 5055
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/lidarr.yml
+++ b/group_vars/all/services/lidarr.yml
@@ -89,6 +89,8 @@ lidarr:
       - "PathPrefix(`/api`)"
       - "PathPrefix(`/feed`)"
       - "PathPrefix(`/ping`)"
+  cloudflare:
+    enable: true
   themepark:
     app: lidarr
     theme: hotline

--- a/group_vars/all/services/nzbhydra2.yml
+++ b/group_vars/all/services/nzbhydra2.yml
@@ -75,6 +75,8 @@ nzbhydra2:
       - "PathPrefix(`/gettorrent`)"
       - "PathPrefix(`/rss`)"
       - "PathPrefix(`/torznab/api`)"
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/obsidian.yml
+++ b/group_vars/all/services/obsidian.yml
@@ -48,6 +48,8 @@ obsidian:
     enable: true
     port: 1314
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/ombi.yml
+++ b/group_vars/all/services/ombi.yml
@@ -61,6 +61,8 @@ ombi:
     enable: true
     port: 3579
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/portainer.yml
+++ b/group_vars/all/services/portainer.yml
@@ -37,6 +37,8 @@ portainer:
     internal_api: true
     internal_api_paths: /api
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/prometheus.yml
+++ b/group_vars/all/services/prometheus.yml
@@ -53,6 +53,8 @@ prometheus:
     enable: true
     port: 9090
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/prowlarr.yml
+++ b/group_vars/all/services/prowlarr.yml
@@ -92,6 +92,8 @@ prowlarr:
       - "PathRegexp(`^/[0-9]+/download`)"
       - "PathPrefix(`/api`)"
       - "PathPrefix(`/ping`)"
+  cloudflare:
+    enable: true
   themepark:
     app: prowlarr
     theme: hotline

--- a/group_vars/all/services/qbittorrent.yml
+++ b/group_vars/all/services/qbittorrent.yml
@@ -143,6 +143,8 @@ qbittorrent:
           - "PathPrefix(`/query`)"
           - "PathPrefix(`/login`)"
           - "PathPrefix(`/sync`)"
+      cloudflare:
+        enable: true
     unraid_xs:
       name: qbittorrent-xs
       hostname: qbittorrent-xs.internal
@@ -260,3 +262,5 @@ qbittorrent:
           - "PathPrefix(`/query`)"
           - "PathPrefix(`/login`)"
           - "PathPrefix(`/sync`)"
+      cloudflare:
+        enable: true

--- a/group_vars/all/services/qui.yml
+++ b/group_vars/all/services/qui.yml
@@ -38,6 +38,8 @@ qui:
     enable: true
     port: 7476
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/radarr.yml
+++ b/group_vars/all/services/radarr.yml
@@ -15,6 +15,8 @@ radarr:
       - "PathPrefix(`/api`)"
       - "PathPrefix(`/feed`)"
       - "PathPrefix(`/ping`)"
+  cloudflare:
+    enable: true
   themepark:
     app: radarr
     theme: hotline

--- a/group_vars/all/services/sabnzbd.yml
+++ b/group_vars/all/services/sabnzbd.yml
@@ -155,6 +155,8 @@ sabnzbd:
     enable: true
     port: 8080
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/sonarr.yml
+++ b/group_vars/all/services/sonarr.yml
@@ -15,6 +15,8 @@ sonarr:
       - "PathPrefix(`/api`)"
       - "PathPrefix(`/feed`)"
       - "PathPrefix(`/ping`)"
+  cloudflare:
+    enable: true
   themepark:
     app: sonarr
     theme: hotline

--- a/group_vars/all/services/sportarr.yml
+++ b/group_vars/all/services/sportarr.yml
@@ -43,6 +43,8 @@ sportarr:
       - "PathPrefix(`/api`)"
       - "PathPrefix(`/feed`)"
       - "PathPrefix(`/ping`)"
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/stash.yml
+++ b/group_vars/all/services/stash.yml
@@ -84,6 +84,8 @@ stash:
     enable: true
     port: 9999
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/syncthing.yml
+++ b/group_vars/all/services/syncthing.yml
@@ -49,6 +49,8 @@ syncthing:
     enable: true
     port: 8384
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/tautulli.yml
+++ b/group_vars/all/services/tautulli.yml
@@ -60,6 +60,8 @@ tautulli:
       - "PathPrefix(`/newsletter`)"
       - "PathPrefix(`/image`)"
       - "PathPrefix(`/pms_image_proxy`)"
+  cloudflare:
+    enable: true
   themepark:
     app: tautulli
     theme: hotpink

--- a/group_vars/all/services/thelounge.yml
+++ b/group_vars/all/services/thelounge.yml
@@ -31,6 +31,8 @@ thelounge:
     internal_api: true
     internal_api_rules:
       - "PathPrefix(`/uploads`)"
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/unifi.yml
+++ b/group_vars/all/services/unifi.yml
@@ -65,6 +65,8 @@ unifi:
     enable: true
     port: 8443
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/vaultwarden.yml
+++ b/group_vars/all/services/vaultwarden.yml
@@ -69,6 +69,8 @@ vaultwarden:
     enable: true
     port: 80
     sso: authelia
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/group_vars/all/services/whisparr.yml
+++ b/group_vars/all/services/whisparr.yml
@@ -89,6 +89,8 @@ whisparr:
       - "PathPrefix(`/api`)"
       - "PathPrefix(`/feed`)"
       - "PathPrefix(`/ping`)"
+  cloudflare:
+    enable: true
   themepark:
     app: whisparr
     theme: hotline

--- a/group_vars/all/services/znc.yml
+++ b/group_vars/all/services/znc.yml
@@ -31,6 +31,8 @@ znc:
     internal_api: true
     internal_api_rules:
       - "PathPrefix(`/uploads`)"
+  cloudflare:
+    enable: true
   deploy:
     type: swarm
     mode: replicated

--- a/roles/docker_services/helpers/prep/cloudflare_creds.yml
+++ b/roles/docker_services/helpers/prep/cloudflare_creds.yml
@@ -23,6 +23,13 @@
         (cloudflare_zone | default('') | string | trim | length == 0)
       }}
 
+- name: Cloudflare | Apply service-level Cloudflare overrides
+  ansible.builtin.set_fact:
+    cloudflare_zone: "{{ docker_services_svc.cloudflare.zone }}"
+  when:
+    - docker_services_svc.cloudflare is defined
+    - (docker_services_svc.cloudflare.zone | default('') | string | trim | length) > 0
+
 - name: Cloudflare | Select Infisical path/name (hugo override)
   when: _cf_creds_missing | bool
   ansible.builtin.set_fact:
@@ -86,11 +93,29 @@
     - not (_is_hugo | bool)
   ansible.builtin.include_tasks: "{{ role_path }}/helpers/prep/cloudflare_dns.yml"
   vars:
-    cloudflare_record: "{{ docker_services_svc.name }}"
-    cloudflare_record_value: "{{ public_ip }}"
-    cloudflare_record_type: "A"
-    cloudflare_proxy: false
-    cloudflare_solo: true
+    cloudflare_record: >-
+      {{
+        docker_services_svc.cloudflare.record
+        | default(docker_services_svc.name, true)
+      }}
+    cloudflare_record_value: >-
+      {{
+        docker_services_svc.cloudflare.value
+        | default(public_ip, true)
+      }}
+    cloudflare_record_type: >-
+      {{
+        docker_services_svc.cloudflare.type
+        | default('A', true)
+      }}
+    cloudflare_proxy: >-
+      {{
+        (docker_services_svc.cloudflare.proxy | default(false, true)) | bool
+      }}
+    cloudflare_solo: >-
+      {{
+        (docker_services_svc.cloudflare.solo | default(true, true)) | bool
+      }}
 
 # Hugo: root (@) records -> GitHub Pages IPs (A + AAAA)
 - name: Configure Cloudflare DNS (hugo root records)

--- a/roles/docker_services/tasks/_prep.yml
+++ b/roles/docker_services/tasks/_prep.yml
@@ -157,8 +157,8 @@
   when:
     - inventory_hostname == "localhost"
     - not (ci_mode | default(false)) | bool
-    - docker_services_svc.traefik is defined
-    - (docker_services_svc.traefik.enable | default(false)) | bool
+    - docker_services_svc.cloudflare is defined
+    - (docker_services_svc.cloudflare.enable | default(false)) | bool
   ansible.builtin.include_tasks: "{{ role_path }}/helpers/prep/cloudflare_creds.yml"
 
 ################################


### PR DESCRIPTION
### Motivation
- Decouple DNS bootstrap from middleware/router generation so Traefik templating and Cloudflare DNS operations can be enabled independently.
- Allow per-service DNS configuration and overrides so services can customize zone/record/type/value/proxy/solo without touching global defaults.
- Ensure services that previously relied on Traefik for DNS now explicitly opt in to Cloudflare behavior via a `svc.cloudflare` scope.

### Description
- Change the DNS prep gating in `roles/docker_services/tasks/_prep.yml` to run when `docker_services_svc.cloudflare.enable` is set, leaving Traefik templating on `docker_services_svc.traefik.enable`.
- Extend `roles/docker_services/helpers/prep/cloudflare_creds.yml` to accept service-level overrides and apply `docker_services_svc.cloudflare.zone` when present, and to pass per-service `record`, `value`, `type`, `proxy`, and `solo` into the Cloudflare DNS include while preserving previous defaults.
- Add `cloudflare:
    enable: true` to existing service definitions that enable Traefik so services carry both `svc.traefik` and `svc.cloudflare` scopes (including multi-target services like qBittorrent).
- Updated ~33 service variable files and the two role helper/task files to implement the above behavior.

### Testing
- Parsed all updated YAML files using `python` + `yaml.safe_load` to validate syntax, which completed successfully for the modified files.
- Ran a consistency check script that verifies every `traefik.enable: true` block has a sibling `cloudflare` block, and the check passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f6d54bc1c83238c97dfd44a694972)