### PR TITLE
Fix yamllint line-length warnings in docker_services YAML helpers

### DIFF
--- a/roles/docker_services/helpers/compose/stack_networks.yml
+++ b/roles/docker_services/helpers/compose/stack_networks.yml
@@ -50,7 +50,10 @@
       {%- set st = (hostvars['localhost'].docker_services_compose_stacks | default({})) -%}
       {%- set existing_stack = st.get(docker_services_stack_name, {}) -%}
       {%- set existing_nets = existing_stack.get('networks', {}) | default({}, true) -%}
-      {%- set merged_stack = existing_stack | combine({'networks': (existing_nets | combine(_stack_networks_new, recursive=true))}, recursive=true) -%}
+      {%- set merged_stack = existing_stack | combine(
+        {'networks': (existing_nets | combine(_stack_networks_new, recursive=true))},
+        recursive=true
+      ) -%}
       {{ st | combine({ docker_services_stack_name: merged_stack }, recursive=true) }}
   delegate_to: localhost
   delegate_facts: true

--- a/roles/docker_services/helpers/compose/stack_volumes.yml
+++ b/roles/docker_services/helpers/compose/stack_volumes.yml
@@ -50,7 +50,10 @@
       {%- set st = (hostvars['localhost'].docker_services_compose_stacks | default({})) -%}
       {%- set existing_stack = st.get(docker_services_stack_name, {}) -%}
       {%- set existing_vols = existing_stack.get('volumes', {}) | default({}, true) -%}
-      {%- set merged_stack = existing_stack | combine({'volumes': (existing_vols | combine(_stack_volumes_new, recursive=true))}, recursive=true) -%}
+      {%- set merged_stack = existing_stack | combine(
+        {'volumes': (existing_vols | combine(_stack_volumes_new, recursive=true))},
+        recursive=true
+      ) -%}
       {{ st | combine({ docker_services_stack_name: merged_stack }, recursive=true) }}
   delegate_to: localhost
   delegate_facts: true

--- a/roles/docker_services/helpers/compose/validate_service.yml
+++ b/roles/docker_services/helpers/compose/validate_service.yml
@@ -50,8 +50,15 @@
   ansible.builtin.assert:
     that:
       - (docker_services_svc.directories | select('mapping') | list | length) == (docker_services_svc.directories | length)
-      - (docker_services_svc.directories | map(attribute='path') | select('defined') | list | length) == (docker_services_svc.directories | length)
-      - (docker_services_svc.directories | map(attribute='path') | map('string') | map('trim') | reject('equalto','') | list | length) == (docker_services_svc.directories | length)
+      - >-
+        (docker_services_svc.directories | map(attribute='path') | select('defined') | list | length)
+        ==
+        (docker_services_svc.directories | length)
+      - >-
+        (docker_services_svc.directories | map(attribute='path') | map('string') | map('trim') |
+        reject('equalto','') | list | length)
+        ==
+        (docker_services_svc.directories | length)
     fail_msg: >-
       docker_services_svc.directories must be a list of dicts and each entry must contain a non-empty 'path'.
 
@@ -99,10 +106,24 @@
   ansible.builtin.assert:
     that:
       - (docker_services_svc.templates | select('mapping') | list | length) == (docker_services_svc.templates | length)
-      - (docker_services_svc.templates | map(attribute='src') | select('defined') | list | length) == (docker_services_svc.templates | length)
-      - (docker_services_svc.templates | map(attribute='dest') | select('defined') | list | length) == (docker_services_svc.templates | length)
-      - (docker_services_svc.templates | map(attribute='src') | map('string') | map('trim') | reject('equalto','') | list | length) == (docker_services_svc.templates | length)
-      - (docker_services_svc.templates | map(attribute='dest') | map('string') | map('trim') | reject('equalto','') | list | length) == (docker_services_svc.templates | length)
+      - >-
+        (docker_services_svc.templates | map(attribute='src') | select('defined') | list | length)
+        ==
+        (docker_services_svc.templates | length)
+      - >-
+        (docker_services_svc.templates | map(attribute='dest') | select('defined') | list | length)
+        ==
+        (docker_services_svc.templates | length)
+      - >-
+        (docker_services_svc.templates | map(attribute='src') | map('string') | map('trim') |
+        reject('equalto','') | list | length)
+        ==
+        (docker_services_svc.templates | length)
+      - >-
+        (docker_services_svc.templates | map(attribute='dest') | map('string') | map('trim') |
+        reject('equalto','') | list | length)
+        ==
+        (docker_services_svc.templates | length)
     fail_msg: >-
       docker_services_svc.templates must be a list of dicts and each entry must contain non-empty 'src' and 'dest'.
 
@@ -170,10 +191,25 @@
     that:
       - docker_services_svc.infisical.secrets_map is sequence
       - docker_services_svc.infisical.secrets_map is not string
-      - (docker_services_svc.infisical.secrets_map | select('mapping') | list | length) == (docker_services_svc.infisical.secrets_map | length)
-      - (docker_services_svc.infisical.secrets_map | map(attribute='var')  | select('defined') | list | length) == (docker_services_svc.infisical.secrets_map | length)
-      - (docker_services_svc.infisical.secrets_map | map(attribute='path') | select('defined') | list | length) == (docker_services_svc.infisical.secrets_map | length)
-      - (docker_services_svc.infisical.secrets_map | map(attribute='name') | select('defined') | list | length) == (docker_services_svc.infisical.secrets_map | length)
+      - >-
+        (docker_services_svc.infisical.secrets_map | select('mapping') | list | length)
+        ==
+        (docker_services_svc.infisical.secrets_map | length)
+      - >-
+        (docker_services_svc.infisical.secrets_map | map(attribute='var') | select('defined') |
+        list | length)
+        ==
+        (docker_services_svc.infisical.secrets_map | length)
+      - >-
+        (docker_services_svc.infisical.secrets_map | map(attribute='path') | select('defined') |
+        list | length)
+        ==
+        (docker_services_svc.infisical.secrets_map | length)
+      - >-
+        (docker_services_svc.infisical.secrets_map | map(attribute='name') | select('defined') |
+        list | length)
+        ==
+        (docker_services_svc.infisical.secrets_map | length)
     fail_msg: "docker_services_svc.infisical.secrets_map must be a list of dicts each containing var/path/name."
 
 - name: Validate | docker_services_svc.infisical.fail_on_empty is boolean-ish (optional)
@@ -483,8 +519,16 @@
   when: _svc.cap_add is defined or _svc.cap_drop is defined
   ansible.builtin.assert:
     that:
-      - (_svc.cap_add is not defined) or ((_svc.cap_add | map('string') | map('trim') | reject('equalto','') | list | length) == (_svc.cap_add | length))
-      - (_svc.cap_drop is not defined) or ((_svc.cap_drop | map('string') | map('trim') | reject('equalto','') | list | length) == (_svc.cap_drop | length))
+      - >-
+        (_svc.cap_add is not defined)
+        or
+        ((_svc.cap_add | map('string') | map('trim') | reject('equalto','') | list | length)
+        == (_svc.cap_add | length))
+      - >-
+        (_svc.cap_drop is not defined)
+        or
+        ((_svc.cap_drop | map('string') | map('trim') | reject('equalto','') | list | length)
+        == (_svc.cap_drop | length))
     fail_msg: "Service '{{ _svc_name }}' cap_add/cap_drop must be lists of non-empty strings."
 
 ################################
@@ -512,22 +556,39 @@
         - name: Validate secrets list items are strings or dicts
           ansible.builtin.assert:
             that:
-              - (_svc.secrets | select('string') | list | length) + (_svc.secrets | select('mapping') | list | length) == (_svc.secrets | length)
+              - >-
+                (_svc.secrets | select('string') | list | length)
+                +
+                (_svc.secrets | select('mapping') | list | length)
+                ==
+                (_svc.secrets | length)
             fail_msg: "Service '{{ _svc_name }}' secrets entries must be strings or dicts."
 
         - name: Validate secret strings are non-empty
           when: (_svc.secrets | select('string') | list | length) > 0
           ansible.builtin.assert:
             that:
-              - (_svc.secrets | select('string') | map('trim') | reject('equalto','') | list | length) == (_svc.secrets | select('string') | list | length)
+              - >-
+                (_svc.secrets | select('string') | map('trim') | reject('equalto','') |
+                list | length)
+                ==
+                (_svc.secrets | select('string') | list | length)
             fail_msg: "Service '{{ _svc_name }}' secrets string entries must be non-empty."
 
         - name: Validate secret dicts have source and target
           when: (_svc.secrets | select('mapping') | list | length) > 0
           ansible.builtin.assert:
             that:
-              - (_svc.secrets | select('mapping') | map(attribute='source') | select('defined') | list | length) == (_svc.secrets | select('mapping') | list | length)
-              - (_svc.secrets | select('mapping') | map(attribute='target') | select('defined') | list | length) == (_svc.secrets | select('mapping') | list | length)
+              - >-
+                (_svc.secrets | select('mapping') | map(attribute='source') |
+                select('defined') | list | length)
+                ==
+                (_svc.secrets | select('mapping') | list | length)
+              - >-
+                (_svc.secrets | select('mapping') | map(attribute='target') |
+                select('defined') | list | length)
+                ==
+                (_svc.secrets | select('mapping') | list | length)
             fail_msg: "Service '{{ _svc_name }}' secrets dict entries must include source and target."
 
 ################################

--- a/roles/docker_services/helpers/compose/validate_svc.yml
+++ b/roles/docker_services/helpers/compose/validate_svc.yml
@@ -70,7 +70,10 @@
     fail_msg: "docker_services_svc.deploy.host must be a non-empty string when provided."
 
 - name: Validate | docker_services_svc.deploy.constraints (optional - string or list)
-  when: docker_services_svc.deploy is defined and docker_services_svc.deploy is mapping and docker_services_svc.deploy.constraints is defined
+  when:
+    - docker_services_svc.deploy is defined
+    - docker_services_svc.deploy is mapping
+    - docker_services_svc.deploy.constraints is defined
   ansible.builtin.assert:
     that:
       - docker_services_svc.deploy.constraints is string
@@ -112,8 +115,15 @@
   ansible.builtin.assert:
     that:
       - (docker_services_svc.directories | select('mapping') | list | length) == (docker_services_svc.directories | length)
-      - (docker_services_svc.directories | map(attribute='path') | select('defined') | list | length) == (docker_services_svc.directories | length)
-      - (docker_services_svc.directories | map(attribute='path') | map('string') | map('trim') | reject('equalto','') | list | length) == (docker_services_svc.directories | length)
+      - >-
+        (docker_services_svc.directories | map(attribute='path') | select('defined') | list | length)
+        ==
+        (docker_services_svc.directories | length)
+      - >-
+        (docker_services_svc.directories | map(attribute='path') | map('string') | map('trim') |
+        reject('equalto','') | list | length)
+        ==
+        (docker_services_svc.directories | length)
     fail_msg: "docker_services_svc.directories must be a list of dicts and each entry must contain a non-empty 'path'."
 
 - name: Validate | docker_services_svc.directories mode formatting (optional)
@@ -153,10 +163,24 @@
   ansible.builtin.assert:
     that:
       - (docker_services_svc.templates | select('mapping') | list | length) == (docker_services_svc.templates | length)
-      - (docker_services_svc.templates | map(attribute='src') | select('defined') | list | length) == (docker_services_svc.templates | length)
-      - (docker_services_svc.templates | map(attribute='dest') | select('defined') | list | length) == (docker_services_svc.templates | length)
-      - (docker_services_svc.templates | map(attribute='src') | map('string') | map('trim') | reject('equalto','') | list | length) == (docker_services_svc.templates | length)
-      - (docker_services_svc.templates | map(attribute='dest') | map('string') | map('trim') | reject('equalto','') | list | length) == (docker_services_svc.templates | length)
+      - >-
+        (docker_services_svc.templates | map(attribute='src') | select('defined') | list | length)
+        ==
+        (docker_services_svc.templates | length)
+      - >-
+        (docker_services_svc.templates | map(attribute='dest') | select('defined') | list | length)
+        ==
+        (docker_services_svc.templates | length)
+      - >-
+        (docker_services_svc.templates | map(attribute='src') | map('string') | map('trim') |
+        reject('equalto','') | list | length)
+        ==
+        (docker_services_svc.templates | length)
+      - >-
+        (docker_services_svc.templates | map(attribute='dest') | map('string') | map('trim') |
+        reject('equalto','') | list | length)
+        ==
+        (docker_services_svc.templates | length)
     fail_msg: "docker_services_svc.templates must be a list of dicts and each entry must contain non-empty 'src' and 'dest'."
 
 - name: Validate | docker_services_svc.templates mode formatting (optional)
@@ -198,8 +222,16 @@
       - (docker_services_svc.copies | select('mapping') | list | length) == (docker_services_svc.copies | length)
       - (docker_services_svc.copies | map(attribute='src') | select('defined') | list | length) == (docker_services_svc.copies | length)
       - (docker_services_svc.copies | map(attribute='dest') | select('defined') | list | length) == (docker_services_svc.copies | length)
-      - (docker_services_svc.copies | map(attribute='src') | map('string') | map('trim') | reject('equalto','') | list | length) == (docker_services_svc.copies | length)
-      - (docker_services_svc.copies | map(attribute='dest') | map('string') | map('trim') | reject('equalto','') | list | length) == (docker_services_svc.copies | length)
+      - >-
+        (docker_services_svc.copies | map(attribute='src') | map('string') | map('trim') |
+        reject('equalto','') | list | length)
+        ==
+        (docker_services_svc.copies | length)
+      - >-
+        (docker_services_svc.copies | map(attribute='dest') | map('string') | map('trim') |
+        reject('equalto','') | list | length)
+        ==
+        (docker_services_svc.copies | length)
     fail_msg: "docker_services_svc.copies must be a list of dicts and each entry must contain non-empty 'src' and 'dest'."
 
 ################################
@@ -219,10 +251,25 @@
     that:
       - docker_services_svc.infisical.secrets_map is sequence
       - docker_services_svc.infisical.secrets_map is not string
-      - (docker_services_svc.infisical.secrets_map | select('mapping') | list | length) == (docker_services_svc.infisical.secrets_map | length)
-      - (docker_services_svc.infisical.secrets_map | map(attribute='var')  | select('defined') | list | length) == (docker_services_svc.infisical.secrets_map | length)
-      - (docker_services_svc.infisical.secrets_map | map(attribute='path') | select('defined') | list | length) == (docker_services_svc.infisical.secrets_map | length)
-      - (docker_services_svc.infisical.secrets_map | map(attribute='name') | select('defined') | list | length) == (docker_services_svc.infisical.secrets_map | length)
+      - >-
+        (docker_services_svc.infisical.secrets_map | select('mapping') | list | length)
+        ==
+        (docker_services_svc.infisical.secrets_map | length)
+      - >-
+        (docker_services_svc.infisical.secrets_map | map(attribute='var') | select('defined') |
+        list | length)
+        ==
+        (docker_services_svc.infisical.secrets_map | length)
+      - >-
+        (docker_services_svc.infisical.secrets_map | map(attribute='path') | select('defined') |
+        list | length)
+        ==
+        (docker_services_svc.infisical.secrets_map | length)
+      - >-
+        (docker_services_svc.infisical.secrets_map | map(attribute='name') | select('defined') |
+        list | length)
+        ==
+        (docker_services_svc.infisical.secrets_map | length)
     fail_msg: "docker_services_svc.infisical.secrets_map must be a list of dicts each containing var/path/name."
 
 - name: Validate | docker_services_svc.infisical.fail_on_empty is boolean-ish (optional)
@@ -244,7 +291,10 @@
     fail_msg: "docker_services_svc.postgres must be a mapping when provided."
 
 - name: Validate | docker_services_svc.postgres.databases (optional - string or list)
-  when: docker_services_svc.postgres is defined and docker_services_svc.postgres is mapping and docker_services_svc.postgres.databases is defined
+  when:
+    - docker_services_svc.postgres is defined
+    - docker_services_svc.postgres is mapping
+    - docker_services_svc.postgres.databases is defined
   ansible.builtin.assert:
     that:
       - docker_services_svc.postgres.databases is string

--- a/roles/docker_services/helpers/deploy/deploy_all.yml
+++ b/roles/docker_services/helpers/deploy/deploy_all.yml
@@ -15,7 +15,10 @@
     _compose_stacks_effective: >-
       {{
         hostvars['localhost'].docker_services_compose_stacks
-        if (hostvars['localhost'].docker_services_compose_stacks is defined and hostvars['localhost'].docker_services_compose_stacks is mapping)
+        if (
+          hostvars['localhost'].docker_services_compose_stacks is defined
+          and hostvars['localhost'].docker_services_compose_stacks is mapping
+        )
         else {}
       }}
   run_once: true

--- a/roles/docker_services/helpers/prep/infisical.yml
+++ b/roles/docker_services/helpers/prep/infisical.yml
@@ -47,7 +47,9 @@
   ansible.builtin.assert:
     that:
       - (vars[infisical_secret_item.var] | default('') | string | trim | length) > 0
-    fail_msg: "Infisical secret {{ infisical_secret_item.path }}/{{ infisical_secret_item.name }} (var {{ infisical_secret_item.var }}) is empty"
+    fail_msg: >-
+      Infisical secret {{ infisical_secret_item.path }}/{{ infisical_secret_item.name }}
+      (var {{ infisical_secret_item.var }}) is empty
   loop: "{{ secrets_map }}"
   loop_control:
     loop_var: infisical_secret_item
@@ -82,7 +84,9 @@
   ansible.builtin.assert:
     that:
       - (vars[infisical_out_var | default('infisical_secrets')][infisical_secret_item.var] | default('') | string | trim | length) > 0
-    fail_msg: "Infisical secret {{ infisical_secret_item.path }}/{{ infisical_secret_item.name }} (key {{ infisical_secret_item.var }}) is empty"
+    fail_msg: >-
+      Infisical secret {{ infisical_secret_item.path }}/{{ infisical_secret_item.name }}
+      (key {{ infisical_secret_item.var }}) is empty
   loop: "{{ secrets_map }}"
   loop_control:
     loop_var: infisical_secret_item

--- a/roles/docker_services/helpers/prep/postgres.yml
+++ b/roles/docker_services/helpers/prep/postgres.yml
@@ -66,7 +66,11 @@
     _postgres_databases: >-
       {{
         (docker_services_svc.postgres.databases | list)
-        if (docker_services_svc.postgres.databases is defined and docker_services_svc.postgres.databases is sequence and docker_services_svc.postgres.databases is not string)
+        if (
+          docker_services_svc.postgres.databases is defined
+          and docker_services_svc.postgres.databases is sequence
+          and docker_services_svc.postgres.databases is not string
+        )
         else
         ([ (docker_services_svc.postgres.databases | string | trim) ]
           if (docker_services_svc.postgres.databases is defined and (docker_services_svc.postgres.databases | string | trim | length > 0))

--- a/roles/docker_services/helpers/prep/secrets.yml
+++ b/roles/docker_services/helpers/prep/secrets.yml
@@ -27,7 +27,12 @@
 # In your setup that is localhost (control host / manager).
 - name: Secrets | Resolve effective secrets host (swarm -> localhost, else deploy host)
   ansible.builtin.set_fact:
-    _secrets_host_effective: "{{ 'localhost' if (docker_services_stack_deploy_type | default('swarm', true)) == 'swarm' else _secrets_deploy_host }}"
+    _secrets_host_effective: >-
+      {{
+        'localhost'
+        if (docker_services_stack_deploy_type | default('swarm', true)) == 'swarm'
+        else _secrets_deploy_host
+      }}
 
 - name: Ensure docker_services_svc.infisical.secrets_map exists
   ansible.builtin.assert:

--- a/roles/docker_services/tasks/_compose.yml
+++ b/roles/docker_services/tasks/_compose.yml
@@ -66,11 +66,20 @@
         [] if docker_services_svc_has_network_mode else
         (
           (docker_services_svc.networks | default([], true))
-          if (docker_services_svc.networks is defined and docker_services_svc.networks is sequence and docker_services_svc.networks is not string and (docker_services_svc.networks | length > 0))
+          if (
+            docker_services_svc.networks is defined
+            and docker_services_svc.networks is sequence
+            and docker_services_svc.networks is not string
+            and (docker_services_svc.networks | length > 0)
+          )
           else
           (
             (docker_services_svc.named_networks.keys() | list)
-            if (docker_services_svc.named_networks is defined and docker_services_svc.named_networks is mapping and (docker_services_svc.named_networks | length > 0))
+            if (
+              docker_services_svc.named_networks is defined
+              and docker_services_svc.named_networks is mapping
+              and (docker_services_svc.named_networks | length > 0)
+            )
             else
             [docker_network]
           )
@@ -235,7 +244,11 @@
     - docker_services_svc.healthcheck is defined
     - docker_services_svc.healthcheck.test is defined
     - (
-        (docker_services_svc.healthcheck.test is sequence and docker_services_svc.healthcheck.test is not string and (docker_services_svc.healthcheck.test | length > 0))
+        (
+          docker_services_svc.healthcheck.test is sequence
+          and docker_services_svc.healthcheck.test is not string
+          and (docker_services_svc.healthcheck.test | length > 0)
+        )
         or
         (docker_services_svc.healthcheck.test is string and (docker_services_svc.healthcheck.test | trim | length > 0))
       )

--- a/roles/docker_services/tasks/sub_tasks/prep/nzbhydra2.yml
+++ b/roles/docker_services/tasks/sub_tasks/prep/nzbhydra2.yml
@@ -5,8 +5,20 @@
     docker_services_nh_host: "{{ (docker_services_svc.deploy.host | default('unraid', true)) | string | trim }}"
     docker_services_nh_config_dir: "/mnt/user/appdata/nzbhydra2"
     docker_services_nh_config_path: "/mnt/user/appdata/nzbhydra2/nzbhydra.yml"
-    docker_services_nh_puid: "{{ (docker_services_svc.environment.PUID | default(hostvars[(docker_services_svc.deploy.host | default('unraid', true))].puid | default('99'))) | string }}"
-    docker_services_nh_pgid: "{{ (docker_services_svc.environment.PGID | default(hostvars[(docker_services_svc.deploy.host | default('unraid', true))].pgid | default('100'))) | string }}"
+    docker_services_nh_puid: >-
+      {{
+        (docker_services_svc.environment.PUID |
+        default(hostvars[(docker_services_svc.deploy.host | default('unraid', true))].puid |
+        default('99')))
+        | string
+      }}
+    docker_services_nh_pgid: >-
+      {{
+        (docker_services_svc.environment.PGID |
+        default(hostvars[(docker_services_svc.deploy.host | default('unraid', true))].pgid |
+        default('100')))
+        | string
+      }}
   when: inventory_hostname == "localhost"
   run_once: true
 
@@ -217,6 +229,8 @@
     that:
       - (docker_services_nh_cfg.indexers | default([])) is sequence
       - (docker_services_nh_cfg.indexers | length) >= 3
-    fail_msg: "Expected >= 3 indexers in {{ docker_services_nh_config_path }}, got {{ (docker_services_nh_cfg.indexers | default([])) | length }}"
+    fail_msg: >-
+      Expected >= 3 indexers in {{ docker_services_nh_config_path }}, got
+      {{ (docker_services_nh_cfg.indexers | default([])) | length }}
   when: inventory_hostname == "localhost"
   run_once: true

--- a/roles/docker_services/tasks/sub_tasks/prep/plex/token.yml
+++ b/roles/docker_services/tasks/sub_tasks/prep/plex/token.yml
@@ -35,9 +35,16 @@
       delegate_facts: true
 
 - name: Token | Generate new identifier
-  when: (not docker_services_plex_ini.stat.exists) or (hostvars['localhost'].docker_services_plex_client_identifier_missing | default(false))
+  when: >-
+    (not docker_services_plex_ini.stat.exists)
+    or
+    (hostvars['localhost'].docker_services_plex_client_identifier_missing | default(false))
   ansible.builtin.set_fact:
-    docker_services_plex_client_identifier: "{{ 'plex' + (lookup('password', '/dev/null', chars=['ascii_lowercase', 'digits'], length=8)) }}"
+    docker_services_plex_client_identifier: >-
+      {{
+        'plex' +
+        (lookup('password', '/dev/null', chars=['ascii_lowercase', 'digits'], length=8))
+      }}
   delegate_to: localhost
   delegate_facts: true
   run_once: true
@@ -119,7 +126,13 @@
     - name: Token | Login prompt
       ansible.builtin.pause:
         prompt: >-
-          Please open https://app.plex.tv/auth#?clientID={{ docker_services_plex_pin.json.clientIdentifier }}&code={{ docker_services_plex_pin.json.code }}&context%5Bdevice%5D%5Bproduct%5D={{ docker_services_plex_pin.json.product }}
+          {% set plex_auth_url =
+            'https://app.plex.tv/auth#?clientID=' ~ docker_services_plex_pin.json.clientIdentifier
+            ~ '&code=' ~ docker_services_plex_pin.json.code
+            ~ '&context%5Bdevice%5D%5Bproduct%5D=' ~ docker_services_plex_pin.json.product
+          %}
+          Please open
+          {{ plex_auth_url }}
           and login. Hit enter after having logged in
 
     - name: Token | Check PIN

--- a/roles/docker_services/tasks/sub_tasks/prep/vaultwarden.yml
+++ b/roles/docker_services/tasks/sub_tasks/prep/vaultwarden.yml
@@ -111,6 +111,8 @@
   ansible.builtin.assert:
     that:
       - docker_services_vaultwarden_token is match('^\\$argon2(id|i|d)\\$.*')
-    fail_msg: "docker_services_vaultwarden_token does not look like an argon2 PHC string. Check argon2 availability on {{ docker_services_vw_fs_host }}."
+    fail_msg: >-
+      docker_services_vaultwarden_token does not look like an argon2 PHC string.
+      Check argon2 availability on {{ docker_services_vw_fs_host }}.
   when: inventory_hostname == "localhost"
   run_once: true


### PR DESCRIPTION
### Motivation
- Reduce and eliminate `yamllint` line-length warnings by reformatting overly long lines in docker service helper and task YAML files. 
- Improve readability of long Jinja expressions, `when` conditions and assertion messages while preserving existing validation logic.

### Description
- Reflowed long Jinja/combine expressions and other single-line constructs into multi-line blocks using folded style (`>-`) and explicit multi-line mapping/condition layouts to respect the 140 character limit. 
- Broke up long `when`/conditional expressions into YAML list items for clarity and lint compliance. 
- Converted long `fail_msg` and other long strings to folded multiline style and introduced a local `plex_auth_url` variable to shorten the pause prompt. 
- Changes applied across helper and task files including `roles/docker_services/helpers/compose/stack_networks.yml`, `stack_volumes.yml`, `validate_service.yml`, `validate_svc.yml`, `helpers/deploy/deploy_all.yml`, `helpers/prep/*`, and `tasks/*/prep/*` to only modify formatting (no logic changes).

### Testing
- Ran a `python` line-length checker that asserts no lines exceed 140 characters in the targeted files and it returned no violations. 
- Ran `yamllint` against the modified files (`roles/docker_services/helpers/...` and `roles/docker_services/tasks/...`) and it produced no line-length warnings.
- All automated lint checks mentioned above completed successfully with no remaining complaints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3dbeaf9108323be88342b1ca857b1)