### PR TITLE
Migrate terraform role package installation to OpenTofu

### DIFF
--- a/roles/terraform/defaults/main.yml
+++ b/roles/terraform/defaults/main.yml
@@ -1,15 +1,18 @@
 ---
 
 terraform_prereq_packages:
+  - apt-transport-https
+  - ca-certificates
+  - curl
   - gnupg
   - software-properties-common
 
-terraform_repo_url: "https://apt.releases.hashicorp.com"
-terraform_keyring_dir: /usr/share/keyrings
-terraform_keyring_file_ascii: /usr/share/keyrings/hashicorp-archive-keyring.asc
-terraform_keyring_file: /usr/share/keyrings/hashicorp-archive-keyring.gpg
-terraform_repo_filename: hashicorp
-terraform_apt_arch: "{{ 'amd64' if ansible_facts['architecture'] in ['x86_64', 'amd64'] else ansible_facts['architecture'] }}"
+terraform_opentofu_source_url: "https://packages.opentofu.org/opentofu/tofu/any/"
+terraform_opentofu_source_suite: any
+terraform_keyring_dir: /etc/apt/keyrings
+terraform_keyring_file_opentofu: /etc/apt/keyrings/opentofu.gpg
+terraform_keyring_file_repo: /etc/apt/keyrings/opentofu-repo.gpg
+terraform_repo_filename: opentofu
 
 terraform_packages:
-  - terraform
+  - tofu

--- a/roles/terraform/tasks/sub_tasks/install.yml
+++ b/roles/terraform/tasks/sub_tasks/install.yml
@@ -13,7 +13,7 @@
     state: present
     update_cache: true
 
-- name: Ensure HashiCorp keyring directory exists
+- name: Ensure OpenTofu keyring directory exists
   ansible.builtin.file:
     path: "{{ terraform_keyring_dir }}"
     state: directory
@@ -21,34 +21,47 @@
     group: root
     mode: "0755"
 
-- name: Download HashiCorp GPG key
+- name: Download OpenTofu package signing key
   ansible.builtin.get_url:
-    url: "{{ terraform_repo_url }}/gpg"
-    dest: "{{ terraform_keyring_file_ascii }}"
+    url: https://get.opentofu.org/opentofu.gpg
+    dest: "{{ terraform_keyring_file_opentofu }}"
     owner: root
     group: root
     mode: "0644"
 
-- name: Dearmor HashiCorp GPG key
+- name: Download OpenTofu repository key
+  ansible.builtin.get_url:
+    url: https://packages.opentofu.org/opentofu/tofu/gpgkey
+    dest: /tmp/opentofu-repo.gpg.asc
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Dearmor OpenTofu repository key
   ansible.builtin.command:
     cmd: >-
       gpg --dearmor
-      -o {{ terraform_keyring_file }}
-      {{ terraform_keyring_file_ascii }}
+      -o {{ terraform_keyring_file_repo }}
+      /tmp/opentofu-repo.gpg.asc
   args:
-    creates: "{{ terraform_keyring_file }}"
+    creates: "{{ terraform_keyring_file_repo }}"
 
-- name: Add HashiCorp apt repository
+- name: Remove temporary OpenTofu repository key file
+  ansible.builtin.file:
+    path: /tmp/opentofu-repo.gpg.asc
+    state: absent
+
+- name: Add OpenTofu apt repository
   ansible.builtin.apt_repository:
     repo: >-
-      deb [arch={{ terraform_apt_arch }} signed-by={{ terraform_keyring_file }}]
-      {{ terraform_repo_url }}
-      {{ ansible_facts["distribution_release"] }} main
+      deb [signed-by={{ terraform_keyring_file_opentofu }},{{ terraform_keyring_file_repo }}]
+      {{ terraform_opentofu_source_url }}
+      {{ terraform_opentofu_source_suite }} main
     filename: "{{ terraform_repo_filename }}"
     state: present
     update_cache: true
 
-- name: Install Terraform packages
+- name: Install OpenTofu packages
   ansible.builtin.apt:
     name: "{{ terraform_packages }}"
     state: present


### PR DESCRIPTION
### Motivation
- Replace HashiCorp Terraform package installation with OpenTofu to enable using the OpenTofu `tofu` package and repository.
- Update apt keyring and repository handling to follow Debian/Ubuntu packaging advice for OpenTofu (keyrings under `/etc/apt/keyrings`).

### Description
- Changed role defaults in `roles/terraform/defaults/main.yml` to add OpenTofu-specific variables including `terraform_opentofu_source_url`, `terraform_opentofu_source_suite`, keyring paths under `/etc/apt/keyrings`, and changed the package from `terraform` to `tofu`.
- Added common apt prerequisites `apt-transport-https`, `ca-certificates`, and `curl` to `terraform_prereq_packages`.
- Reworked `roles/terraform/tasks/sub_tasks/install.yml` to fetch the OpenTofu signing key and repository key, dearmor the repo key into the keyring, remove the temporary key file, register the OpenTofu apt repository, and install the `tofu` package.
- Renamed a few task titles and adapted apt repository `signed-by` entries to reference the new OpenTofu key files and source URL.

### Testing
- Ran `ansible-playbook --syntax-check -i hosts.ini.sample playbook.yml` to validate playbook syntax but it failed in this environment because `ansible-playbook` is not installed, so syntax-check could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5529565188323b3281461fe2f1754)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Transitioned infrastructure provisioning configuration from Terraform to OpenTofu, including updated repository and package source settings
- Added prerequisite system packages for installation support: apt-transport-https, ca-certificates, and curl
- Updated signing key management and verification procedures to align with OpenTofu requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->