### PR TITLE
Prepare Ansible path references for ansible/ directory move

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,15 +22,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ansible-core ansible-lint yamllint
-          if [ -f requirements.txt ]; then
-            pip install -r requirements.txt
+          if [ -f ansible/requirements.txt ]; then
+            pip install -r ansible/requirements.txt
           fi
 
       - name: Install Galaxy requirements (if present)
         run: |
-          if [ -f requirements.yml ]; then
-            ansible-galaxy collection install -r requirements.yml -p collections
-            ansible-galaxy role install -r requirements.yml -p roles || true
+          if [ -f ansible/requirements.yml ]; then
+            ansible-galaxy collection install -r ansible/requirements.yml -p ansible/collections
+            ansible-galaxy role install -r ansible/requirements.yml -p ansible/roles || true
           fi
 
       - name: yamllint (tracked YAML files only)
@@ -47,7 +47,7 @@ jobs:
 
       - name: ansible-lint
         env:
-          ANSIBLE_LIBRARY: ${{ github.workspace }}/roles/docker_services/library
-          ANSIBLE_CONFIG: ansible.cfg
+          ANSIBLE_LIBRARY: ${{ github.workspace }}/ansible/roles/docker_services/library
+          ANSIBLE_CONFIG: ansible/ansible.cfg
         run: |
           ansible-lint --format=pep8

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,14 +1,14 @@
 ## Requirements
 
-- `requirements.yml` is for **Ansible Galaxy collections/roles**.
+- `ansible/requirements.yml` is for **Ansible Galaxy collections/roles**.
 - Some modules also need **Python libraries on the Ansible control node** (for example `community.postgresql.*` needs `psycopg2`).
-- Controller-side Python dependencies are listed in `requirements.txt`.
+- Controller-side Python dependencies are listed in `ansible/requirements.txt`.
 
 Install both before running playbooks:
 
 ```bash
-ansible-galaxy collection install -r requirements.yml
-pip install -r requirements.txt
+ansible-galaxy collection install -r ansible/requirements.yml
+pip install -r ansible/requirements.txt
 ```
 
 You can also simply run the playbook without installing requirements, with each run fail accompanied with a list of commands for you to run to install those required. Rinse and repeat until you have all the requirements.

--- a/roles/ubuntu/defaults/main.yml
+++ b/roles/ubuntu/defaults/main.yml
@@ -7,6 +7,8 @@ ubuntu_apt_env_vars:
 ubuntu_ansible_repo_root: /opt
 ubuntu_ansible_repo_dirname: homelab
 ubuntu_ansible_repo_path: "{{ ubuntu_ansible_repo_root }}/{{ ubuntu_ansible_repo_dirname }}"
+ubuntu_ansible_dirname: ansible
+ubuntu_ansible_path: "{{ ubuntu_ansible_repo_path }}/{{ ubuntu_ansible_dirname }}"
 
 ubuntu_manage_repo_clone: true
 ubuntu_repo_url: "https://github.com/Lebowski89/homelab.git"
@@ -21,7 +23,7 @@ ubuntu_ansible_vault_pass_file: "{{ ubuntu_ansible_secrets_path }}/.ansible_vaul
 ubuntu_skynet_install: true
 ubuntu_skynet_install_path: /usr/local/bin/skynet
 ubuntu_skynet_doctor_ping_target: skynet
-ubuntu_skynet_docker_services_vars: "{{ ubuntu_ansible_repo_path }}/group_vars/all/docker_services.yml"
+ubuntu_skynet_docker_services_vars: "{{ ubuntu_ansible_path }}/group_vars/all/docker_services.yml"
 
 ubuntu_sysctl_file: /etc/sysctl.d/99-ubuntu-tuning.conf
 

--- a/roles/ubuntu/tasks/sub_tasks/requirements.yml
+++ b/roles/ubuntu/tasks/sub_tasks/requirements.yml
@@ -2,28 +2,28 @@
 
 - name: Assert requirements.txt exists
   ansible.builtin.stat:
-    path: "{{ ubuntu_ansible_repo_path }}/requirements.txt"
+    path: "{{ ubuntu_ansible_path }}/requirements.txt"
   register: ubuntu_requirements_txt
 
 - name: Fail if requirements.txt is missing
   ansible.builtin.fail:
-    msg: "Missing requirements.txt at {{ ubuntu_ansible_repo_path }}/requirements.txt"
+    msg: "Missing requirements.txt at {{ ubuntu_ansible_path }}/requirements.txt"
   when: not ubuntu_requirements_txt.stat.exists
 
 - name: Install Python packages from requirements.txt
   ansible.builtin.pip:
-    requirements: "{{ ubuntu_ansible_repo_path }}/requirements.txt"
+    requirements: "{{ ubuntu_ansible_path }}/requirements.txt"
     state: present
     virtualenv: "{{ ubuntu_ansible_venv_path }}"
 
 - name: Assert Ansible collections requirements file exists
   ansible.builtin.stat:
-    path: "{{ ubuntu_ansible_repo_path }}/requirements.yml"
+    path: "{{ ubuntu_ansible_path }}/requirements.yml"
   register: ubuntu_ansible_requirements_yml
 
 - name: Fail if Ansible collections requirements file is missing
   ansible.builtin.fail:
-    msg: "Missing requirements.yml at {{ ubuntu_ansible_repo_path }}/requirements.yml"
+    msg: "Missing requirements.yml at {{ ubuntu_ansible_path }}/requirements.yml"
   when: not ubuntu_ansible_requirements_yml.stat.exists
 
 - name: Install Ansible collections from requirements.yml
@@ -33,7 +33,7 @@
       - collection
       - install
       - -r
-      - "{{ ubuntu_ansible_repo_path }}/requirements.yml"
+      - "{{ ubuntu_ansible_path }}/requirements.yml"
       - --force
   changed_when: false
   become: false

--- a/roles/ubuntu/templates/skynet.j2
+++ b/roles/ubuntu/templates/skynet.j2
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PLAYBOOK="${PLAYBOOK:-{{ ubuntu_ansible_repo_path }}/playbook.yml}"
-INVENTORY="${INVENTORY:-{{ ubuntu_ansible_repo_path }}/hosts.ini}"
-ANSIBLE_CONFIG="${ANSIBLE_CONFIG:-{{ ubuntu_ansible_repo_path }}/ansible.cfg}"
+PLAYBOOK="${PLAYBOOK:-{{ ubuntu_ansible_path }}/playbook.yml}"
+INVENTORY="${INVENTORY:-{{ ubuntu_ansible_path }}/hosts.ini}"
+ANSIBLE_CONFIG="${ANSIBLE_CONFIG:-{{ ubuntu_ansible_path }}/ansible.cfg}"
 BECOME_PASS_FILE="${BECOME_PASS_FILE:-{{ ubuntu_ansible_become_pass_file }}}"
 VAULT_PASS_FILE="${VAULT_PASS_FILE:-{{ ubuntu_ansible_vault_pass_file }}}"
 DOCTOR_PING_TARGET="${SKYNET_DOCTOR_PING_TARGET:-{{ ubuntu_skynet_doctor_ping_target }}}"


### PR DESCRIPTION
### Motivation
- Reorganize repository so all Ansible content lives under an `ansible/` subtree and ensure code, templates, tasks, CI, and docs reference the new locations. 
- Prevent runtime failures from hard-coded paths that assumed Ansible files were at the repo root.

### Description
- Added `ubuntu_ansible_dirname` and `ubuntu_ansible_path` defaults and switched `ubuntu_skynet_docker_services_vars` to use `{{ ubuntu_ansible_path }}` in `roles/ubuntu/defaults/main.yml`.
- Updated `roles/ubuntu/tasks/sub_tasks/requirements.yml` to assert and install `requirements.txt` and `requirements.yml` from `{{ ubuntu_ansible_path }}` instead of the repo root.
- Changed `roles/ubuntu/templates/skynet.j2` so default `PLAYBOOK`, `INVENTORY`, and `ANSIBLE_CONFIG` point to the `ansible/` subtree.
- Updated CI lint workflow `(.github/workflows/lint.yml)` to install deps from `ansible/requirements.*`, set `ANSIBLE_CONFIG` to `ansible/ansible.cfg`, and point `ANSIBLE_LIBRARY` to `ansible/roles/docker_services/library`.
- Updated documentation (`docs/requirements.md`) to reference `ansible/requirements.yml` and `ansible/requirements.txt`.

### Testing
- Ran `git diff --check` to ensure there are no whitespace or diff errors, which passed.
- Ran `git status --short` to verify the expected files were modified, which showed only the intended changes and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da97e71fb08323955ea0c4252cf340)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect new Ansible file paths and installation commands.

* **Chores**
  * Reorganized Ansible requirements and configuration files into a dedicated `ansible/` subdirectory.
  * Updated CI/CD workflows and project configuration to reference files in the new location.
  * Updated environment variable defaults to point to the restructured directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->