### PR TITLE
Add per-role Ansible module inventory docs

### DIFF
--- a/ansible/roles/docker/docs/ansible-modules.md
+++ b/ansible/roles/docker/docs/ansible-modules.md
@@ -1,0 +1,22 @@
+## `docker` role: Ansible module inventory
+
+This file lists the Ansible modules invoked by this role's task and handler files.
+
+### `ansible.builtin`
+
+- `ansible.builtin.apt`
+- `ansible.builtin.apt_repository`
+- `ansible.builtin.assert`
+- `ansible.builtin.command`
+- `ansible.builtin.file`
+- `ansible.builtin.get_url`
+- `ansible.builtin.group`
+- `ansible.builtin.include_tasks`
+- `ansible.builtin.set_fact`
+
+### `community.docker`
+
+- `community.docker.docker_network`
+- `community.docker.docker_network_info`
+- `community.docker.docker_node`
+- `community.docker.docker_swarm`

--- a/ansible/roles/docker_services/docs/ansible-modules.md
+++ b/ansible/roles/docker_services/docs/ansible-modules.md
@@ -1,0 +1,43 @@
+## `docker_services` role: Ansible module inventory
+
+This file lists the Ansible modules invoked by this role's task and handler files.
+
+### `ansible.builtin`
+
+- `ansible.builtin.assert`
+- `ansible.builtin.command`
+- `ansible.builtin.copy`
+- `ansible.builtin.debug`
+- `ansible.builtin.fail`
+- `ansible.builtin.file`
+- `ansible.builtin.include_tasks`
+- `ansible.builtin.pause`
+- `ansible.builtin.set_fact`
+- `ansible.builtin.slurp`
+- `ansible.builtin.stat`
+- `ansible.builtin.template`
+- `ansible.builtin.uri`
+- `ansible.builtin.wait_for`
+
+### `community.docker`
+
+- `community.docker.docker_compose_v2`
+- `community.docker.docker_config`
+- `community.docker.docker_container`
+- `community.docker.docker_secret`
+- `community.docker.docker_stack`
+- `community.docker.docker_volume`
+
+### `community.general`
+
+- `community.general.cloudflare_dns`
+- `community.general.git_config`
+- `community.general.ini_file`
+- `community.general.ipify_facts`
+- `community.general.ipinfoio_facts`
+- `community.general.xml`
+
+### `custom`
+
+- `qbittorrent_passwd`
+- `yedit`

--- a/ansible/roles/infisical/docs/ansible-modules.md
+++ b/ansible/roles/infisical/docs/ansible-modules.md
@@ -1,0 +1,14 @@
+## `infisical` role: Ansible module inventory
+
+This file lists the Ansible modules invoked by this role's task and handler files.
+
+### `ansible.builtin`
+
+- `ansible.builtin.copy`
+- `ansible.builtin.file`
+- `ansible.builtin.stat`
+- `ansible.builtin.template`
+
+### `community.docker`
+
+- `community.docker.docker_compose_v2`

--- a/ansible/roles/opentofu/docs/ansible-modules.md
+++ b/ansible/roles/opentofu/docs/ansible-modules.md
@@ -1,0 +1,22 @@
+## `opentofu` role: Ansible module inventory
+
+This file lists the Ansible modules invoked by this role's task and handler files.
+
+### `ansible.builtin`
+
+- `ansible.builtin.apt`
+- `ansible.builtin.apt_repository`
+- `ansible.builtin.assert`
+- `ansible.builtin.command`
+- `ansible.builtin.debug`
+- `ansible.builtin.file`
+- `ansible.builtin.get_url`
+- `ansible.builtin.include_tasks`
+- `ansible.builtin.pause`
+- `ansible.builtin.set_fact`
+
+### `community.proxmox`
+
+- `community.proxmox.proxmox_access_acl`
+- `community.proxmox.proxmox_role`
+- `community.proxmox.proxmox_user`

--- a/ansible/roles/postgres/docs/ansible-modules.md
+++ b/ansible/roles/postgres/docs/ansible-modules.md
@@ -1,0 +1,21 @@
+## `postgres` role: Ansible module inventory
+
+This file lists the Ansible modules invoked by this role's task and handler files.
+
+### `ansible.builtin`
+
+- `ansible.builtin.apt`
+- `ansible.builtin.apt_repository`
+- `ansible.builtin.assert`
+- `ansible.builtin.file`
+- `ansible.builtin.get_url`
+- `ansible.builtin.include_tasks`
+- `ansible.builtin.set_fact`
+- `ansible.builtin.systemd_service`
+- `ansible.builtin.template`
+- `ansible.builtin.uri`
+- `ansible.builtin.wait_for`
+
+### `community.postgresql`
+
+- `community.postgresql.postgresql_user`

--- a/ansible/roles/ubuntu/docs/ansible-modules.md
+++ b/ansible/roles/ubuntu/docs/ansible-modules.md
@@ -1,0 +1,29 @@
+## `ubuntu` role: Ansible module inventory
+
+This file lists the Ansible modules invoked by this role's task and handler files.
+
+### `ansible.builtin`
+
+- `ansible.builtin.apt`
+- `ansible.builtin.assert`
+- `ansible.builtin.command`
+- `ansible.builtin.copy`
+- `ansible.builtin.fail`
+- `ansible.builtin.file`
+- `ansible.builtin.find`
+- `ansible.builtin.git`
+- `ansible.builtin.include_tasks`
+- `ansible.builtin.lineinfile`
+- `ansible.builtin.pip`
+- `ansible.builtin.stat`
+- `ansible.builtin.systemd`
+- `ansible.builtin.systemd_service`
+- `ansible.builtin.template`
+
+### `ansible.posix`
+
+- `ansible.posix.sysctl`
+
+### `community.general`
+
+- `community.general.pam_limits`


### PR DESCRIPTION
### Motivation
- Provide role-local documentation that mirrors the repository-wide `docs/ansible-modules.md` so each Ansible role documents the exact modules it uses. 
- Make it easier to audit collection usage and custom modules at the role level for maintainability and dependency review.

### Description
- Added `ansible-modules.md` under `docs/` for each role: `ansible/roles/docker`, `ansible/roles/docker_services`, `ansible/roles/infisical`, `ansible/roles/opentofu`, `ansible/roles/postgres`, and `ansible/roles/ubuntu`.
- Each file lists modules discovered in that role's `tasks` and `handlers` files and groups entries by namespace/collection (`ansible.builtin`, `community.*`, `ansible.posix`, and `custom`) for readability.
- The module lists were generated by a small parser script that scans role task/handler YAML and emits the per-role markdown files without changing any role behavior or task logic.

### Testing
- Ran the generator script (`python - <<'PY' ...`) to discover modules and write `ansible/roles/*/docs/ansible-modules.md`, which completed successfully.
- Verified generated file contents with a shell check (`for f in ansible/roles/*/docs/ansible-modules.md; do sed -n '1,220p' $f; done`) and reviewed the outputs.
- Committed the new files and verified repository state with `git status --short` and the commit hash, all steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc20e4d3dc8323b3db1caa4de81df3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added module reference documentation for six Ansible roles: docker, docker_services, infisical, opentofu, postgres, and ubuntu. Each guide enumerates the Ansible modules used by the respective role, organized by collection namespace for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->