### PR TITLE
docs(docker_services): complete ansible module inventory

### DIFF
--- a/ansible/roles/docker_services/docs/ansible-modules.md
+++ b/ansible/roles/docker_services/docs/ansible-modules.md
@@ -13,6 +13,7 @@ This file lists the Ansible modules invoked by this role's task and handler file
 - `ansible.builtin.include_tasks`
 - `ansible.builtin.pause`
 - `ansible.builtin.set_fact`
+- `ansible.builtin.shell`
 - `ansible.builtin.slurp`
 - `ansible.builtin.stat`
 - `ansible.builtin.template`
@@ -36,6 +37,11 @@ This file lists the Ansible modules invoked by this role's task and handler file
 - `community.general.ipify_facts`
 - `community.general.ipinfoio_facts`
 - `community.general.xml`
+
+### `community.postgresql`
+
+- `community.postgresql.postgresql_db`
+- `community.postgresql.postgresql_ping`
 
 ### `custom`
 


### PR DESCRIPTION
### Motivation
- Ensure the role documentation accurately lists all Ansible modules used by the `docker_services` role because a few modules invoked from task files were missing from the inventory.

### Description
- Updated `ansible/roles/docker_services/docs/ansible-modules.md` to add `ansible.builtin.shell` and a new `community.postgresql` section containing `community.postgresql.postgresql_db` and `community.postgresql.postgresql_ping`.

### Testing
- Ran an automated verification scan using a `ruby` YAML walker to inspect `ansible/roles/docker_services/tasks/**/*.yml` (and `rg` checks) which returned `missing=[]`, confirming the docs now match the modules used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc24fcc6288323b450a7134d95b8b4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated module documentation to include additional deployment configuration modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->