### PR TITLE
Add infisical_podman role using Podman Quadlets

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -74,6 +74,19 @@
         - infisical_recreate
         - infisical_remove
 
+    - name: Include Infisical Podman role
+      when:
+        - inventory_hostname == docker_services_primary_manager
+        - infisical_podman_enabled | default(false) | bool
+      ansible.builtin.include_role:
+        name: infisical_podman
+      tags:
+        - infisical_podman_bootstrap
+        - infisical_podman_deploy
+        - infisical_podman_recreate
+        - infisical_podman_remove
+
+
     - name: Include OpenTofu role
       ansible.builtin.include_role:
         name: opentofu

--- a/ansible/roles/infisical_podman/README.md
+++ b/ansible/roles/infisical_podman/README.md
@@ -1,0 +1,10 @@
+# infisical_podman
+
+Deploys Infisical with Podman Quadlet units under `/etc/containers/systemd`.
+
+## Tags
+
+- `infisical_podman_bootstrap`
+- `infisical_podman_deploy`
+- `infisical_podman_recreate`
+- `infisical_podman_remove`

--- a/ansible/roles/infisical_podman/defaults/main.yml
+++ b/ansible/roles/infisical_podman/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+
+infisical_podman_name: infisical
+infisical_podman_image: infisical/infisical:latest-postgres
+infisical_podman_port: 8066
+infisical_podman_path: "/opt/{{ infisical_podman_name }}"
+infisical_podman_enc_key: ""
+infisical_podman_jwt_key: ""
+
+infisical_podman_network: infisical
+
+infisical_podman_postgres_name: infisical-postgres
+infisical_podman_postgres_image: postgres:18
+infisical_podman_postgres_port: 5432
+infisical_podman_postgres_path: "{{ infisical_podman_path }}/postgres"
+infisical_podman_postgres_user: ""
+infisical_podman_postgres_pass: ""
+
+infisical_podman_redis_name: infisical-redis
+infisical_podman_redis_image: redis:8.6-alpine
+infisical_podman_redis_port: 6390
+infisical_podman_redis_path: "{{ infisical_podman_path }}/redis"
+infisical_podman_redis_key: ""
+
+infisical_podman_smtp_email: ""
+infisical_podman_smtp_host: ""
+infisical_podman_smtp_port: ""
+infisical_podman_smtp_user: ""
+infisical_podman_smtp_pass: ""
+infisical_podman_smtp_sender: ""

--- a/ansible/roles/infisical_podman/defaults/main.yml
+++ b/ansible/roles/infisical_podman/defaults/main.yml
@@ -1,26 +1,32 @@
 ---
 
 infisical_podman_name: infisical
-infisical_podman_image: infisical/infisical:latest-postgres
+infisical_podman_image: infisical/infisical:v0.159.1
 infisical_podman_port: 8066
 infisical_podman_path: "/opt/{{ infisical_podman_name }}"
 infisical_podman_enc_key: ""
 infisical_podman_jwt_key: ""
 
+timezone: "UTC"
+puid: 1000
+pgid: 1000
+
 infisical_podman_network: infisical
 
 infisical_podman_postgres_name: infisical-postgres
-infisical_podman_postgres_image: postgres:18
+infisical_podman_postgres_image: postgres:18.3
 infisical_podman_postgres_port: 5432
 infisical_podman_postgres_path: "{{ infisical_podman_path }}/postgres"
 infisical_podman_postgres_user: ""
 infisical_podman_postgres_pass: ""
+infisical_podman_expose_postgres: false
 
 infisical_podman_redis_name: infisical-redis
-infisical_podman_redis_image: redis:8.6-alpine
+infisical_podman_redis_image: redis:8.6.2-alpine3.23
 infisical_podman_redis_port: 6390
 infisical_podman_redis_path: "{{ infisical_podman_path }}/redis"
 infisical_podman_redis_key: ""
+infisical_podman_expose_redis: false
 
 infisical_podman_smtp_email: ""
 infisical_podman_smtp_host: ""
@@ -28,3 +34,5 @@ infisical_podman_smtp_port: ""
 infisical_podman_smtp_user: ""
 infisical_podman_smtp_pass: ""
 infisical_podman_smtp_sender: ""
+
+infisical_podman_site_url: "http://localhost:8080"

--- a/ansible/roles/infisical_podman/tasks/main.yml
+++ b/ansible/roles/infisical_podman/tasks/main.yml
@@ -1,0 +1,138 @@
+---
+
+################################
+# CLEAN UP
+################################
+
+- name: Stop Infisical quadlet services
+  ansible.builtin.systemd_service:
+    name: "{{ _infisical_podman_unit }}"
+    state: stopped
+    enabled: false
+  failed_when: false
+  loop:
+    - "{{ infisical_podman_name }}.service"
+    - "{{ infisical_podman_postgres_name }}.service"
+    - "{{ infisical_podman_redis_name }}.service"
+  loop_control:
+    loop_var: _infisical_podman_unit
+  tags:
+    - infisical_podman_recreate
+    - infisical_podman_remove
+
+- name: Remove Infisical quadlet files
+  ansible.builtin.file:
+    path: "/etc/containers/systemd/{{ _infisical_podman_quadlet }}"
+    state: absent
+  loop:
+    - "{{ infisical_podman_name }}.container"
+    - "{{ infisical_podman_postgres_name }}.container"
+    - "{{ infisical_podman_redis_name }}.container"
+    - "{{ infisical_podman_network }}.network"
+  loop_control:
+    loop_var: _infisical_podman_quadlet
+  tags:
+    - infisical_podman_recreate
+    - infisical_podman_remove
+
+################################
+# DIRECTORIES
+################################
+
+- name: Create Infisical quadlet directories
+  ansible.builtin.file:
+    path: "{{ _infisical_podman_dir.path }}"
+    state: directory
+    owner: "{{ _infisical_podman_dir.owner }}"
+    group: "{{ _infisical_podman_dir.group }}"
+    mode: "{{ _infisical_podman_dir.mode }}"
+  loop:
+    - path: "{{ infisical_podman_path }}"
+      owner: "{{ puid }}"
+      group: "{{ pgid }}"
+      mode: "0755"
+    - path: "{{ infisical_podman_postgres_path }}"
+      owner: "999"
+      group: "999"
+      mode: "0700"
+    - path: "{{ infisical_podman_redis_path }}"
+      owner: "{{ puid }}"
+      group: "{{ pgid }}"
+      mode: "0755"
+    - path: /etc/containers/systemd
+      owner: root
+      group: root
+      mode: "0755"
+  loop_control:
+    loop_var: _infisical_podman_dir
+  tags:
+    - infisical_podman_bootstrap
+    - infisical_podman_deploy
+    - infisical_podman_recreate
+
+################################
+# CONFIG
+################################
+
+- name: Template Infisical Podman env file
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/infisical.env.j2"
+    dest: "{{ infisical_podman_path }}/.env"
+    force: true
+    owner: "{{ puid }}"
+    group: "{{ pgid }}"
+    mode: "0600"
+  no_log: true
+  tags:
+    - infisical_podman_bootstrap
+    - infisical_podman_deploy
+    - infisical_podman_recreate
+
+################################
+# DEPLOY
+################################
+
+- name: Template Infisical Podman quadlets
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/{{ _infisical_podman_template.src }}"
+    dest: "/etc/containers/systemd/{{ _infisical_podman_template.dest }}"
+    force: true
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - src: "infisical.network.j2"
+      dest: "{{ infisical_podman_network }}.network"
+    - src: "postgres.container.j2"
+      dest: "{{ infisical_podman_postgres_name }}.container"
+    - src: "redis.container.j2"
+      dest: "{{ infisical_podman_redis_name }}.container"
+    - src: "infisical.container.j2"
+      dest: "{{ infisical_podman_name }}.container"
+  loop_control:
+    loop_var: _infisical_podman_template
+  tags:
+    - infisical_podman_deploy
+    - infisical_podman_recreate
+
+- name: Reload systemd for quadlet generator
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  tags:
+    - infisical_podman_deploy
+    - infisical_podman_recreate
+
+- name: Start Infisical quadlet services
+  ansible.builtin.systemd_service:
+    name: "{{ _infisical_podman_service }}"
+    state: started
+    enabled: true
+  loop:
+    - "{{ infisical_podman_postgres_name }}.service"
+    - "{{ infisical_podman_redis_name }}.service"
+    - "{{ infisical_podman_name }}.service"
+  loop_control:
+    loop_var: _infisical_podman_service
+  tags:
+    - infisical_podman_deploy
+    - infisical_podman_recreate

--- a/ansible/roles/infisical_podman/tasks/main.yml
+++ b/ansible/roles/infisical_podman/tasks/main.yml
@@ -35,6 +35,12 @@
     - infisical_podman_recreate
     - infisical_podman_remove
 
+- name: Reload systemd after quadlet removal
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  tags:
+    - infisical_podman_remove
+
 ################################
 # DIRECTORIES
 ################################
@@ -56,8 +62,8 @@
       group: "999"
       mode: "0700"
     - path: "{{ infisical_podman_redis_path }}"
-      owner: "{{ puid }}"
-      group: "{{ pgid }}"
+      owner: "999"
+      group: "999"
       mode: "0755"
     - path: /etc/containers/systemd
       owner: root

--- a/ansible/roles/infisical_podman/templates/infisical.container.j2
+++ b/ansible/roles/infisical_podman/templates/infisical.container.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=Infisical container
+After=network-online.target {{ infisical_podman_network }}-network.service {{ infisical_podman_postgres_name }}.service {{ infisical_podman_redis_name }}.service
+Wants=network-online.target
+Requires={{ infisical_podman_network }}-network.service {{ infisical_podman_postgres_name }}.service {{ infisical_podman_redis_name }}.service
+
+[Container]
+ContainerName={{ infisical_podman_name }}
+Image={{ infisical_podman_image }}
+Network={{ infisical_podman_network }}
+PublishPort={{ infisical_podman_port }}:8080
+Environment=TZ={{ timezone }}
+Environment=NODE_ENV=production
+EnvironmentFile={{ infisical_podman_path }}/.env
+
+[Service]
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/infisical_podman/templates/infisical.env.j2
+++ b/ansible/roles/infisical_podman/templates/infisical.env.j2
@@ -14,7 +14,7 @@ INFISICAL_REDIS_KEY='{{ infisical_podman_redis_key }}'
 REDIS_URL='redis://:{{ infisical_podman_redis_key }}@{{ infisical_podman_redis_name }}:6379'
 
 # Website URL
-SITE_URL='http://localhost:8080'
+SITE_URL='{{ infisical_podman_site_url }}'
 
 # Mail/SMTP
 SMTP_HOST='{{ infisical_podman_smtp_host }}'

--- a/ansible/roles/infisical_podman/templates/infisical.env.j2
+++ b/ansible/roles/infisical_podman/templates/infisical.env.j2
@@ -1,0 +1,25 @@
+# Keys
+ENCRYPTION_KEY='{{ infisical_podman_enc_key }}'
+
+# JWT
+AUTH_SECRET='{{ infisical_podman_jwt_key }}'
+
+# Postgres
+POSTGRES_USER='{{ infisical_podman_postgres_user }}'
+POSTGRES_PASSWORD='{{ infisical_podman_postgres_pass }}'
+DB_CONNECTION_URI='postgres://{{ infisical_podman_postgres_user }}:{{ infisical_podman_postgres_pass }}@{{ infisical_podman_postgres_name }}:5432/infisical?sslmode=disable'
+
+# Redis
+INFISICAL_REDIS_KEY='{{ infisical_podman_redis_key }}'
+REDIS_URL='redis://:{{ infisical_podman_redis_key }}@{{ infisical_podman_redis_name }}:6379'
+
+# Website URL
+SITE_URL='http://localhost:8080'
+
+# Mail/SMTP
+SMTP_HOST='{{ infisical_podman_smtp_host }}'
+SMTP_PORT='{{ infisical_podman_smtp_port }}'
+SMTP_FROM_ADDRESS='{{ infisical_podman_smtp_email }}'
+SMTP_FROM_NAME='{{ infisical_podman_smtp_sender }}'
+SMTP_USERNAME='{{ infisical_podman_smtp_user }}'
+SMTP_PASSWORD='{{ infisical_podman_smtp_pass }}'

--- a/ansible/roles/infisical_podman/templates/infisical.network.j2
+++ b/ansible/roles/infisical_podman/templates/infisical.network.j2
@@ -1,0 +1,5 @@
+[Unit]
+Description=Infisical Podman Network
+
+[Network]
+NetworkName={{ infisical_podman_network }}

--- a/ansible/roles/infisical_podman/templates/postgres.container.j2
+++ b/ansible/roles/infisical_podman/templates/postgres.container.j2
@@ -8,12 +8,14 @@ Requires={{ infisical_podman_network }}-network.service
 ContainerName={{ infisical_podman_postgres_name }}
 Image={{ infisical_podman_postgres_image }}
 Network={{ infisical_podman_network }}
+{% if infisical_podman_expose_postgres %}
 PublishPort={{ infisical_podman_postgres_port }}:5432
+{% endif %}
 Environment=TZ={{ timezone }}
 EnvironmentFile={{ infisical_podman_path }}/.env
 Environment=POSTGRES_DB=infisical
 Volume={{ infisical_podman_postgres_path }}:/var/lib/postgresql/data:Z
-HealthCmd=pg_isready -U ${POSTGRES_USER}
+HealthCmd=pg_isready -U {{ infisical_podman_postgres_user }}
 HealthInterval=30s
 HealthRetries=10
 HealthStartPeriod=30s

--- a/ansible/roles/infisical_podman/templates/postgres.container.j2
+++ b/ansible/roles/infisical_podman/templates/postgres.container.j2
@@ -1,0 +1,26 @@
+[Unit]
+Description=Infisical Postgres container
+After=network-online.target {{ infisical_podman_network }}-network.service
+Wants=network-online.target
+Requires={{ infisical_podman_network }}-network.service
+
+[Container]
+ContainerName={{ infisical_podman_postgres_name }}
+Image={{ infisical_podman_postgres_image }}
+Network={{ infisical_podman_network }}
+PublishPort={{ infisical_podman_postgres_port }}:5432
+Environment=TZ={{ timezone }}
+EnvironmentFile={{ infisical_podman_path }}/.env
+Environment=POSTGRES_DB=infisical
+Volume={{ infisical_podman_postgres_path }}:/var/lib/postgresql/data:Z
+HealthCmd=pg_isready -U ${POSTGRES_USER}
+HealthInterval=30s
+HealthRetries=10
+HealthStartPeriod=30s
+
+[Service]
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/infisical_podman/templates/redis.container.j2
+++ b/ansible/roles/infisical_podman/templates/redis.container.j2
@@ -8,7 +8,9 @@ Requires={{ infisical_podman_network }}-network.service
 ContainerName={{ infisical_podman_redis_name }}
 Image={{ infisical_podman_redis_image }}
 Network={{ infisical_podman_network }}
+{% if infisical_podman_expose_redis %}
 PublishPort={{ infisical_podman_redis_port }}:6379
+{% endif %}
 Environment=TZ={{ timezone }}
 EnvironmentFile={{ infisical_podman_path }}/.env
 Volume={{ infisical_podman_redis_path }}:/data:Z

--- a/ansible/roles/infisical_podman/templates/redis.container.j2
+++ b/ansible/roles/infisical_podman/templates/redis.container.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=Infisical Redis container
+After=network-online.target {{ infisical_podman_network }}-network.service
+Wants=network-online.target
+Requires={{ infisical_podman_network }}-network.service
+
+[Container]
+ContainerName={{ infisical_podman_redis_name }}
+Image={{ infisical_podman_redis_image }}
+Network={{ infisical_podman_network }}
+PublishPort={{ infisical_podman_redis_port }}:6379
+Environment=TZ={{ timezone }}
+EnvironmentFile={{ infisical_podman_path }}/.env
+Volume={{ infisical_podman_redis_path }}:/data:Z
+Exec=sh -c 'redis-server --appendonly yes --requirepass "$INFISICAL_REDIS_KEY"'
+
+[Service]
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### Motivation
- Provide an alternative Podman-based deployment for Infisical that runs as Podman Quadlet systemd units instead of the existing docker-compose stack. 
- Keep the new implementation alongside the existing `infisical` role so existing deployments are unaffected unless explicitly enabled.

### Description
- Added a new Ansible role at `ansible/roles/infisical_podman` containing `defaults/main.yml`, `tasks/main.yml`, templates, and a short `README.md` to manage Infisical via Podman Quadlets. 
- Created templates for a Podman network unit (`infisical.network.j2`), PostgreSQL container unit (`postgres.container.j2`), Redis container unit (`redis.container.j2`), the Infisical app container unit (`infisical.container.j2`), and a shared `.env` template (`infisical.env.j2`).
- Role tasks create required directories, render the `.env`, write quadlet files to `/etc/containers/systemd`, run a systemd daemon-reload, and start/enable the generated services; cleanup tasks stop services and remove quadlet files. 
- Wired the role into `ansible/playbook.yml` behind the conditional `infisical_podman_enabled | default(false) | bool` so it is opt-in and does not change current behavior by default.

### Testing
- Attempted to run `python -m yamllint ansible/playbook.yml ansible/roles/infisical_podman/defaults/main.yml ansible/roles/infisical_podman/tasks/main.yml`, but `yamllint` was not available in the environment so the check did not run. 
- Attempted `ansible-playbook --syntax-check ansible/playbook.yml -i ansible/hosts.ini.sample`, but `ansible-playbook` was not available in the environment so the syntax check did not run. 
- No automated deployment or runtime tests were executed in this environment due to missing tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd6d0a4adc8323a0998d5986b953f7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Infisical deployment via Podman with systemd/Quadlet units
  * Integrated Postgres and Redis containers for a complete stack
  * Configurable SMTP and site URL for email and web access
  * Automated health checks and automatic service restart on failure
  * Flexible lifecycle operations via tags: bootstrap, deploy, recreate, remove
  * Role inclusion is conditional so Podman deployment can be enabled/disabled
<!-- end of auto-generated comment: release notes by coderabbit.ai -->