### PR TITLE
Fix ansible-lint no-changed-when / no-handler and line-length violations

### DIFF
--- a/ansible/roles/docker_services/tasks/prep/03_post_filesystem/sub_tasks/plex/_token.yml
+++ b/ansible/roles/docker_services/tasks/prep/03_post_filesystem/sub_tasks/plex/_token.yml
@@ -81,7 +81,9 @@
       X-Plex-Client-Identifier: "{{ hostvars[docker_services_primary_manager].docker_services_plex_client_identifier }}"
       X-Plex-Platform: "linux"
       X-Plex-Platform-Version: "1.0.0"
-      X-Plex-Device: "Debian {{ hostvars[docker_services_primary_manager].ansible_facts['distribution_version'] }} - {{ hostvars[docker_services_primary_manager].ansible_facts['kernel'] }}"
+      X-Plex-Device: >-
+        Debian {{ hostvars[docker_services_primary_manager].ansible_facts['distribution_version'] }}
+        - {{ hostvars[docker_services_primary_manager].ansible_facts['kernel'] }}
       X-Plex-Device-Name: "Media Server"
     body_format: form-urlencoded
     headers:
@@ -111,7 +113,9 @@
           X-Plex-Client-Identifier: "{{ hostvars[docker_services_primary_manager].docker_services_plex_client_identifier }}"
           X-Plex-Platform: "linux"
           X-Plex-Platform-Version: "1.0.0"
-          X-Plex-Device: "Debian {{ hostvars[docker_services_primary_manager].ansible_facts['distribution_version'] }} - {{ hostvars[docker_services_primary_manager].ansible_facts['kernel'] }}"
+          X-Plex-Device: >-
+            Debian {{ hostvars[docker_services_primary_manager].ansible_facts['distribution_version'] }}
+            - {{ hostvars[docker_services_primary_manager].ansible_facts['kernel'] }}
           X-Plex-Device-Name: "Media Server"
         body_format: form-urlencoded
         headers:
@@ -164,7 +168,9 @@
           X-Plex-Client-Identifier: "{{ hostvars[docker_services_primary_manager].docker_services_plex_client_identifier }}"
           X-Plex-Platform: "linux"
           X-Plex-Platform-Version: "1.0.0"
-          X-Plex-Device: "Debian {{ hostvars[docker_services_primary_manager].ansible_facts['distribution_version'] }} - {{ hostvars[docker_services_primary_manager].ansible_facts['kernel'] }}"
+          X-Plex-Device: >-
+            Debian {{ hostvars[docker_services_primary_manager].ansible_facts['distribution_version'] }}
+            - {{ hostvars[docker_services_primary_manager].ansible_facts['kernel'] }}
           X-Plex-Device-Name: "Media Server"
         body_format: form-urlencoded
         headers:
@@ -185,8 +191,16 @@
         option: "client_identifier"
         value: "{{ hostvars[docker_services_primary_manager].docker_services_plex_client_identifier }}"
         create: true
-        owner: "{{ hostvars[docker_services_primary_manager].docker_host_puid | default(hostvars[docker_services_primary_manager].puid | default('1000')) }}"
-        group: "{{ hostvars[docker_services_primary_manager].docker_host_pgid | default(hostvars[docker_services_primary_manager].pgid | default('1000')) }}"
+        owner: >-
+          {{
+            hostvars[docker_services_primary_manager].docker_host_puid
+            | default(hostvars[docker_services_primary_manager].puid | default('1000'))
+          }}
+        group: >-
+          {{
+            hostvars[docker_services_primary_manager].docker_host_pgid
+            | default(hostvars[docker_services_primary_manager].pgid | default('1000'))
+          }}
         mode: "0664"
 
     - name: Token | Add Token to plex.ini
@@ -196,8 +210,16 @@
         option: "token"
         value: "{{ hostvars[docker_services_primary_manager].docker_services_plex_auth_token }}"
         create: true
-        owner: "{{ hostvars[docker_services_primary_manager].docker_host_puid | default(hostvars[docker_services_primary_manager].puid | default('1000')) }}"
-        group: "{{ hostvars[docker_services_primary_manager].docker_host_pgid | default(hostvars[docker_services_primary_manager].pgid | default('1000')) }}"
+        owner: >-
+          {{
+            hostvars[docker_services_primary_manager].docker_host_puid
+            | default(hostvars[docker_services_primary_manager].puid | default('1000'))
+          }}
+        group: >-
+          {{
+            hostvars[docker_services_primary_manager].docker_host_pgid
+            | default(hostvars[docker_services_primary_manager].pgid | default('1000'))
+          }}
         mode: "0664"
 
 - name: Token | Display Token

--- a/ansible/roles/postgres/tasks/sub_tasks/admin/fix_owner.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/admin/fix_owner.yml
@@ -239,3 +239,4 @@
   run_once: true
   delegate_to: "{{ postgres_patroni_leader_member.name }}"
   no_log: true
+  changed_when: true

--- a/ansible/roles/postgres/tasks/sub_tasks/admin/pg_hba.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/admin/pg_hba.yml
@@ -80,6 +80,18 @@
   run_once: true
   delegate_to: "{{ docker_services_primary_manager }}"
 
+- name: Patroni dynamic pg_hba | Determine whether pg_hba update is needed
+  ansible.builtin.set_fact:
+    postgres_patroni_pg_hba_needs_restart: >-
+      {{
+        (
+          postgres_patroni_dynamic_config.json.postgresql.pg_hba
+          | default([])
+        ) != postgres_patroni_pg_hba_desired
+      }}
+  run_once: true
+  delegate_to: "{{ docker_services_primary_manager }}"
+
 - name: Patroni dynamic pg_hba | Patch DCS config with desired pg_hba
   ansible.builtin.uri:
     url: "http://{{ postgres_patroni_leader_member.host }}:{{ postgres_patroni_restapi_port }}/config"
@@ -93,17 +105,13 @@
   register: postgres_patroni_dynamic_config_patch
   run_once: true
   delegate_to: "{{ docker_services_primary_manager }}"
-  when: >-
-    (
-      postgres_patroni_dynamic_config.json.postgresql.pg_hba
-      | default([])
-    ) != postgres_patroni_pg_hba_desired
+  when: postgres_patroni_pg_hba_needs_restart | bool
 
 - name: Patroni dynamic pg_hba | Restart patroni on all postgres nodes if DCS config changed
   ansible.builtin.service:
     name: patroni
     state: restarted
-  when: postgres_patroni_dynamic_config_patch.changed | default(false)
+  when: postgres_patroni_pg_hba_needs_restart | bool
   delegate_to: "{{ inventory_hostname }}"
 
 - name: Patroni dynamic pg_hba | Wait for Patroni REST API on all postgres nodes
@@ -112,7 +120,7 @@
     port: "{{ postgres_patroni_restapi_port }}"
     timeout: 60
     delay: 2
-  when: postgres_patroni_dynamic_config_patch.changed | default(false)
+  when: postgres_patroni_pg_hba_needs_restart | bool
   delegate_to: "{{ docker_services_primary_manager }}"
 
 - name: Patroni dynamic pg_hba | Wait for live pg_hba.conf to contain HAProxy rules on all nodes

--- a/ansible/roles/postgres/tasks/sub_tasks/backup.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/backup.yml
@@ -87,6 +87,7 @@
   run_once: true
   delegate_to: "{{ postgres_patroni_leader_member.name }}"
   no_log: true
+  changed_when: true
 
 - name: Backup DBs | Dump each database in plain SQL format
   ansible.builtin.shell: |
@@ -105,6 +106,7 @@
   run_once: true
   delegate_to: "{{ postgres_patroni_leader_member.name }}"
   no_log: true
+  changed_when: true
 
 - name: Backup DBs | Show result
   ansible.builtin.debug:

--- a/ansible/roles/postgres/tasks/sub_tasks/restore.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/restore.yml
@@ -131,6 +131,7 @@
   run_once: true
   delegate_to: "{{ postgres_patroni_leader_member.name }}"
   no_log: true
+  changed_when: true
 
 - name: Restore DBs | Create databases
   community.postgresql.postgresql_db:
@@ -167,6 +168,7 @@
   run_once: true
   delegate_to: "{{ postgres_patroni_leader_member.name }}"
   no_log: true
+  changed_when: true
 
 - name: Restore DBs | Show result
   ansible.builtin.debug:


### PR DESCRIPTION
### Motivation
- Resolve `ansible-lint` findings for `no-changed-when`, `no-handler`, and `line-length` across Postgres and Plex task files.  
- Ensure shell-based tasks do not trigger spurious lint warnings about commands that must declare change behavior.  
- Wrap long YAML values to comply with a 140-character line-length rule.

### Description
- Added explicit `changed_when: true` to shell-based PostgreSQL tasks for backup and restore to satisfy `no-changed-when`.  
- Added `changed_when: true` to the PostgreSQL owner-fix shell task to resolve the related lint finding.  
- Introduced a `postgres_patroni_pg_hba_needs_restart` set_fact and used it in downstream `when` clauses to gate the Patroni `pg_hba` update and restarts, avoiding checks on `.changed` and addressing `no-handler`.  
- Reflowed long lines in the Plex token task (`X-Plex-Device`, `owner`, and `group`) using folded YAML scalars to eliminate line-length violations.

### Testing
- Attempted to run `ansible-lint` against the changed files, but the `ansible-lint` binary is not installed in this environment (so lint could not be executed here).  
- Verified via a Python-based line-length check that `_token.yml` contains no lines longer than 140 characters.  
- Verified presence of the new `changed_when` and `postgres_patroni_pg_hba_needs_restart` changes via quick `rg`/file inspection checks which confirmed the intended edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fc25d0108323a5321aa20c920844)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved task execution status reporting accuracy for backup, restore, and database configuration management operations.
  * Enhanced explicit change detection markers across service configuration and administrative maintenance tasks.

* **Refactor**
  * Optimized change divergence detection logic for database configuration synchronization, eliminating redundant comparisons between desired and current states.
  * Refined YAML configuration formatting for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->