### PR TITLE
Add CrowdSec service vars and host log mounts

### DIFF
--- a/ansible/group_vars/all/docker_services.yml
+++ b/ansible/group_vars/all/docker_services.yml
@@ -60,6 +60,8 @@ docker_services:
   ## services (monitoring)
   - name: alloy
     tags: [apps, monitoring, alloy]
+  - name: crowdsec
+    tags: [apps, monitoring, crowdsec]
   - name: gotify
     tags: [apps, monitoring, pgsql, gotify]
   - name: grafana

--- a/ansible/group_vars/all/services/authelia.yml
+++ b/ansible/group_vars/all/services/authelia.yml
@@ -119,6 +119,9 @@ authelia:
         - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/authelia"
           state: directory
           mode: "0755"
+        - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/authelia/logs"
+          state: directory
+          mode: "0755"
       templates:
         - src: configs/proxy/authelia/config.yml.j2
           dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/authelia/configuration.yml"

--- a/ansible/group_vars/all/services/crowdsec.yml
+++ b/ansible/group_vars/all/services/crowdsec.yml
@@ -44,6 +44,12 @@ crowdsec:
       group: "0"
       mode: "0644"
       force: true
+    - src: configs/crowdsec/acquis.d/authelia.yaml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/config/acquis.d/authelia.yaml"
+      owner: "0"
+      group: "0"
+      mode: "0644"
+      force: true
   volumes:
     crowdsec_data:
       type: bind
@@ -69,6 +75,11 @@ crowdsec:
       type: bind
       source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/traefik/logs"
       target: /var/log/traefik
+      read_only: true
+    authelia_logs:
+      type: bind
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/authelia/logs"
+      target: /var/log/authelia
       read_only: true
   deploy:
     type: swarm

--- a/ansible/group_vars/all/services/crowdsec.yml
+++ b/ansible/group_vars/all/services/crowdsec.yml
@@ -22,6 +22,22 @@ crowdsec:
     - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/config"
       state: directory
       mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/config/acquis.d"
+      state: directory
+      mode: "0755"
+  templates:
+    - src: configs/crowdsec/acquis.d/docker.yaml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/config/acquis.d/docker.yaml"
+      owner: "0"
+      group: "0"
+      mode: "0644"
+      force: true
+    - src: configs/crowdsec/acquis.d/syslog.yaml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/config/acquis.d/syslog.yaml"
+      owner: "0"
+      group: "0"
+      mode: "0644"
+      force: true
   volumes:
     crowdsec_data:
       type: bind

--- a/ansible/group_vars/all/services/crowdsec.yml
+++ b/ansible/group_vars/all/services/crowdsec.yml
@@ -1,0 +1,57 @@
+---
+
+crowdsec:
+  name: crowdsec
+  stack: crowdsec
+  image: crowdsecurity/crowdsec:v1.7.0
+  named_networks:
+    overlay:
+      external: true
+  environment:
+    TZ: "{{ timezone }}"
+    COLLECTIONS: "crowdsecurity/linux crowdsecurity/traefik crowdsecurity/docker"
+    GID: "{{ hostvars[docker_services_primary_manager].docker_host_pgid }}"
+  user: "0:0"
+  paths:
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec"
+      state: directory
+      mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/data"
+      state: directory
+      mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/config"
+      state: directory
+      mode: "0755"
+  volumes:
+    crowdsec_data:
+      type: bind
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/data"
+      target: /var/lib/crowdsec/data
+      read_only: false
+    crowdsec_config:
+      type: bind
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/config"
+      target: /etc/crowdsec
+      read_only: false
+    docker_logs:
+      type: bind
+      source: /var/lib/docker/containers
+      target: /var/lib/docker/containers
+      read_only: true
+    syslog:
+      type: bind
+      source: /var/log
+      target: /var/log
+      read_only: true
+  deploy:
+    type: swarm
+    mode: replicated
+    replicas: 1
+    host: "{{ docker_services_primary_manager }}"
+    constraints:
+      - node.labels.docker_services_host == docker_services_primary_manager
+    restart_policy:
+      condition: on-failure
+      delay: 10s
+      max_attempts: 5
+      window: 2m

--- a/ansible/group_vars/all/services/crowdsec.yml
+++ b/ansible/group_vars/all/services/crowdsec.yml
@@ -38,6 +38,12 @@ crowdsec:
       group: "0"
       mode: "0644"
       force: true
+    - src: configs/crowdsec/acquis.d/traefik.yaml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/config/acquis.d/traefik.yaml"
+      owner: "0"
+      group: "0"
+      mode: "0644"
+      force: true
   volumes:
     crowdsec_data:
       type: bind
@@ -58,6 +64,11 @@ crowdsec:
       type: bind
       source: /var/log
       target: /var/log
+      read_only: true
+    traefik_logs:
+      type: bind
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/traefik/logs"
+      target: /var/log/traefik
       read_only: true
   deploy:
     type: swarm

--- a/ansible/group_vars/all/services/traefik.yml
+++ b/ansible/group_vars/all/services/traefik.yml
@@ -49,6 +49,9 @@ traefik:
     - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/traefik/dynamic"
       state: directory
       mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/traefik/logs"
+      state: directory
+      mode: "0755"
     - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/traefik/acme.json"
       state: touch
       mode: "0600"

--- a/ansible/roles/docker_services/templates/configs/crowdsec/acquis.d/authelia.yaml.j2
+++ b/ansible/roles/docker_services/templates/configs/crowdsec/acquis.d/authelia.yaml.j2
@@ -1,0 +1,5 @@
+---
+filenames:
+  - /var/log/authelia/authelia.log
+labels:
+  type: authelia

--- a/ansible/roles/docker_services/templates/configs/crowdsec/acquis.d/docker.yaml.j2
+++ b/ansible/roles/docker_services/templates/configs/crowdsec/acquis.d/docker.yaml.j2
@@ -1,0 +1,6 @@
+---
+source: docker
+filenames:
+  - /var/lib/docker/containers/*/*.log
+labels:
+  type: docker

--- a/ansible/roles/docker_services/templates/configs/crowdsec/acquis.d/syslog.yaml.j2
+++ b/ansible/roles/docker_services/templates/configs/crowdsec/acquis.d/syslog.yaml.j2
@@ -1,0 +1,7 @@
+---
+filenames:
+  - /var/log/*.log
+  - /var/log/syslog
+  - /var/log/auth.log
+labels:
+  type: syslog

--- a/ansible/roles/docker_services/templates/configs/crowdsec/acquis.d/traefik.yaml.j2
+++ b/ansible/roles/docker_services/templates/configs/crowdsec/acquis.d/traefik.yaml.j2
@@ -1,0 +1,5 @@
+---
+filenames:
+  - /var/log/traefik/access.log
+labels:
+  type: traefik

--- a/ansible/roles/docker_services/templates/configs/proxy/authelia/config.yml.j2
+++ b/ansible/roles/docker_services/templates/configs/proxy/authelia/config.yml.j2
@@ -42,3 +42,9 @@ notifier:
     username: "{{ smtp_username }}"
     password: "{{ smtp_password }}"
     sender: "{{ smtp_sender }}"
+
+log:
+  level: info
+  format: text
+  file_path: /config/logs/authelia.log
+  keep_stdout: true

--- a/ansible/roles/docker_services/templates/configs/proxy/traefik/config.yml.j2
+++ b/ansible/roles/docker_services/templates/configs/proxy/traefik/config.yml.j2
@@ -10,6 +10,12 @@ api:
 log:
   level: DEBUG
 
+accessLog:
+  filePath: /etc/traefik/logs/access.log
+  bufferingSize: 100
+  fields:
+    defaultMode: keep
+
 entryPoints:
   internal:
     address: ":8080"


### PR DESCRIPTION
### Motivation
- Deploy CrowdSec so it can ingest and parse both Docker and host logs by exposing host log paths to the container. 
- Ensure CrowdSec has persistent storage for its data and configuration so it can be managed by the existing swarm orchestration. 
- Register CrowdSec as a monitoring service so it is included in the existing `docker_services` deployment flow. 

### Description
- Added `ansible/group_vars/all/services/crowdsec.yml` which defines the `crowdsecurity/crowdsec:v1.7.0` image, environment (including `COLLECTIONS`), and runs as `root` (`user: "0:0"`).
- Configured persistent bind mounts for data and config at `{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/crowdsec/{data,config}` and read-only bind mounts for Docker logs (`/var/lib/docker/containers`) and host logs (`/var/log`).
- Updated `ansible/group_vars/all/docker_services.yml` to register `crowdsec` under the monitoring services and included swarm `deploy` settings (replicated, 1 replica, node constraint, and restart policy). 

### Testing
- Attempted a YAML load using `python` with `yaml.safe_load`, which failed because `PyYAML` is not installed in the environment. 
- Attempted `ansible-playbook --syntax-check playbook.yml` in `ansible/`, which could not run because `ansible-playbook` is not available in this environment. 
- Performed a file content inspection (`nl`/`sed`) to verify the new `crowdsec.yml` file contents and that `crowdsec` was inserted into `docker_services.yml` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e130f3dc832382cd77ae093789b8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CrowdSec monitoring service to the infrastructure, configured with version 1.7.0 deployment on the primary manager node with data persistence and Docker log ingestion capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->