### PR TITLE
Add Alloy host & container metrics pipeline and Grafana resource dashboards

### DIFF
--- a/ansible/group_vars/all/services/alloy.yml
+++ b/ansible/group_vars/all/services/alloy.yml
@@ -33,7 +33,7 @@ alloy:
   volumes:
     data:
       type: bind
-      source: /opt/alloy/data
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/alloy/data"
       target: /etc/alloy/data
       read_only: false
     docker_sock:
@@ -41,10 +41,25 @@ alloy:
       source: /var/run/docker.sock
       target: /var/run/docker.sock
       read_only: true
-    docker_container:
+    host_rootfs:
       type: bind
-      source: /var/lib/docker/containers
-      target: /var/lib/docker/containers
+      source: /
+      target: /host/rootfs
+      read_only: true
+    host_proc:
+      type: bind
+      source: /proc
+      target: /host/proc
+      read_only: true
+    host_sys:
+      type: bind
+      source: /sys
+      target: /host/sys
+      read_only: true
+    docker_lib:
+      type: bind
+      source: /var/lib/docker
+      target: /var/lib/docker
       read_only: true
   traefik:
     enable: true

--- a/ansible/group_vars/all/services/grafana.yml
+++ b/ansible/group_vars/all/services/grafana.yml
@@ -35,6 +35,32 @@ grafana:
     - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana"
       state: directory
       mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/provisioning/datasources"
+      state: directory
+      mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/provisioning/dashboards"
+      state: directory
+      mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/dashboards"
+      state: directory
+      mode: "0755"
+  templates:
+    - src: configs/grafana/provisioning/datasources/prometheus.yml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/provisioning/datasources/prometheus.yml"
+      mode: "0644"
+      force: true
+    - src: configs/grafana/provisioning/dashboards/dashboards.yml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/provisioning/dashboards/dashboards.yml"
+      mode: "0644"
+      force: true
+    - src: configs/grafana/dashboards/host-resource-overview.json.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/dashboards/host-resource-overview.json"
+      mode: "0644"
+      force: true
+    - src: configs/grafana/dashboards/docker-container-overview.json.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/dashboards/docker-container-overview.json"
+      mode: "0644"
+      force: true
   volumes:
     data:
       type: bind

--- a/ansible/roles/docker_services/files/alloy_config.alloy
+++ b/ansible/roles/docker_services/files/alloy_config.alloy
@@ -30,3 +30,32 @@ loki.source.docker "docker" {
   relabel_rules = discovery.relabel.docker_logs.rules
   forward_to    = [loki.write.default.receiver]
 }
+
+prometheus.remote_write "prometheus" {
+  endpoint {
+    url = "http://prometheus:9090/api/v1/write"
+  }
+}
+
+prometheus.exporter.unix "host" {
+  rootfs_path = "/host/rootfs"
+  procfs_path = "/host/proc"
+  sysfs_path  = "/host/sys"
+}
+
+prometheus.scrape "host" {
+  targets         = prometheus.exporter.unix.host.targets
+  scrape_interval = "15s"
+  forward_to      = [prometheus.remote_write.prometheus.receiver]
+}
+
+prometheus.exporter.cadvisor "docker" {
+  docker_host      = "unix:///var/run/docker.sock"
+  storage_duration = "5m"
+}
+
+prometheus.scrape "docker" {
+  targets         = prometheus.exporter.cadvisor.docker.targets
+  scrape_interval = "15s"
+  forward_to      = [prometheus.remote_write.prometheus.receiver]
+}

--- a/ansible/roles/docker_services/templates/configs/grafana/dashboards/docker-container-overview.json.j2
+++ b/ansible/roles/docker_services/templates/configs/grafana/dashboards/docker-container-overview.json.j2
@@ -1,0 +1,17 @@
+{
+  "uid": "docker-container-overview",
+  "title": "Docker Container Overview",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {"from": "now-6h", "to": "now"},
+  "templating": {"list": []},
+  "panels": [
+    {"type":"timeseries","title":"Container CPU Cores Used","gridPos":{"h":8,"w":12,"x":0,"y":0},"targets":[{"expr":"sum by(name) (rate(container_cpu_usage_seconds_total{name!~\"\"}[5m]))","legendFormat":"{{name}}"}]},
+    {"type":"timeseries","title":"Container Memory Working Set","gridPos":{"h":8,"w":12,"x":12,"y":0},"targets":[{"expr":"sum by(name) (container_memory_working_set_bytes{name!~\"\"})","legendFormat":"{{name}}"}]},
+    {"type":"timeseries","title":"Container Network RX/TX Bytes/s","gridPos":{"h":8,"w":12,"x":0,"y":8},"targets":[{"expr":"sum by(name) (rate(container_network_receive_bytes_total{name!~\"\"}[5m]))","legendFormat":"rx {{name}}"},{"expr":"sum by(name) (rate(container_network_transmit_bytes_total{name!~\"\"}[5m]))","legendFormat":"tx {{name}}"}]},
+    {"type":"timeseries","title":"Container Filesystem Usage","gridPos":{"h":8,"w":12,"x":12,"y":8},"targets":[{"expr":"sum by(name) (container_fs_usage_bytes{name!~\"\"})","legendFormat":"{{name}}"}]},
+    {"type":"timeseries","title":"Top 10 Containers by CPU","gridPos":{"h":8,"w":12,"x":0,"y":16},"targets":[{"expr":"topk(10, sum by(name) (rate(container_cpu_usage_seconds_total{name!~\"\"}[5m])))","legendFormat":"{{name}}"}]},
+    {"type":"timeseries","title":"Top 10 Containers by Memory","gridPos":{"h":8,"w":12,"x":12,"y":16},"targets":[{"expr":"topk(10, sum by(name) (container_memory_working_set_bytes{name!~\"\"}))","legendFormat":"{{name}}"}]}
+  ]
+}

--- a/ansible/roles/docker_services/templates/configs/grafana/dashboards/host-resource-overview.json.j2
+++ b/ansible/roles/docker_services/templates/configs/grafana/dashboards/host-resource-overview.json.j2
@@ -1,0 +1,17 @@
+{
+  "uid": "host-resource-overview",
+  "title": "Host Resource Overview",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {"from": "now-6h", "to": "now"},
+  "templating": {"list": []},
+  "panels": [
+    {"type":"timeseries","title":"CPU Usage %","gridPos":{"h":8,"w":12,"x":0,"y":0},"targets":[{"expr":"100 - (avg by(instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)","legendFormat":"{{instance}}"}]},
+    {"type":"timeseries","title":"Memory Usage %","gridPos":{"h":8,"w":12,"x":12,"y":0},"targets":[{"expr":"(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100","legendFormat":"{{instance}}"}]},
+    {"type":"timeseries","title":"Filesystem Usage %","gridPos":{"h":8,"w":12,"x":0,"y":8},"targets":[{"expr":"100 * (1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay\"}))","legendFormat":"{{instance}} {{mountpoint}}"}]},
+    {"type":"timeseries","title":"Disk I/O Bytes/s","gridPos":{"h":8,"w":12,"x":12,"y":8},"targets":[{"expr":"rate(node_disk_read_bytes_total[5m])","legendFormat":"read {{instance}} {{device}}"},{"expr":"rate(node_disk_written_bytes_total[5m])","legendFormat":"write {{instance}} {{device}}"}]},
+    {"type":"timeseries","title":"Network RX/TX Bytes/s","gridPos":{"h":8,"w":12,"x":0,"y":16},"targets":[{"expr":"rate(node_network_receive_bytes_total{device!~\"lo\"}[5m])","legendFormat":"rx {{instance}} {{device}}"},{"expr":"rate(node_network_transmit_bytes_total{device!~\"lo\"}[5m])","legendFormat":"tx {{instance}} {{device}}"}]},
+    {"type":"timeseries","title":"Load Average (1m)","gridPos":{"h":8,"w":12,"x":12,"y":16},"targets":[{"expr":"node_load1","legendFormat":"{{instance}}"}]}
+  ]
+}

--- a/ansible/roles/docker_services/templates/configs/grafana/provisioning/dashboards/dashboards.yml.j2
+++ b/ansible/roles/docker_services/templates/configs/grafana/provisioning/dashboards/dashboards.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: "Homelab"
+    orgId: 1
+    folder: "Homelab"
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/ansible/roles/docker_services/templates/configs/grafana/provisioning/datasources/prometheus.yml.j2
+++ b/ansible/roles/docker_services/templates/configs/grafana/provisioning/datasources/prometheus.yml.j2
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true


### PR DESCRIPTION
### Motivation
- Enable collection of host and Docker/container resource metrics via Grafana Alloy and forward them to Prometheus for storage and Grafana visualization.
- Keep existing Loki Docker log ingestion intact while extending Alloy to provide metrics (no Glances or Beszel added).
- Provide repo-managed Grafana provisioning and dashboards so resource views are available on deploy without external downloads.

### Description
- Extended `ansible/roles/docker_services/files/alloy_config.alloy` to add `prometheus.remote_write` to `http://prometheus:9090/api/v1/write` and configured `prometheus.exporter.unix` + `prometheus.exporter.cadvisor` with corresponding `prometheus.scrape` blocks to forward metrics to Prometheus.
- Updated `ansible/group_vars/all/services/alloy.yml` to use the repo `docker_host_appdata_root` path for Alloy data and added bind mounts for `/` -> `/host/rootfs`, `/proc`, `/sys`, `/var/lib/docker`, and preserved `/var/run/docker.sock`, while keeping the service private behind Traefik.
- Added Grafana provisioning and dashboards under `ansible/roles/docker_services/templates/configs/grafana/`, including datasource provisioning `prometheus.yml.j2`, dashboard provider `dashboards.yml.j2`, and two dashboards `host-resource-overview.json.j2` and `docker-container-overview.json.j2`.
- Wired Grafana templates in `ansible/group_vars/all/services/grafana.yml` so provisioning files and dashboards are rendered into the Grafana appdata folder on deploy, and left Prometheus service unchanged (it already contains `--web.enable-remote-write-receiver`).
- Files changed: `ansible/roles/docker_services/files/alloy_config.alloy`, `ansible/group_vars/all/services/alloy.yml`, `ansible/group_vars/all/services/grafana.yml`, and new Grafana templates under `ansible/roles/docker_services/templates/configs/grafana/`.

### Testing
- Validated both dashboard JSON templates with `python -m json.tool` and they parsed successfully.
- Verified the changes were committed locally (commit message: "Add Alloy host/container metrics and Grafana resource dashboards").
- Attempted `ansible-playbook --syntax-check`, but it could not run in this environment because `ansible-playbook` is not installed, so full Ansible syntax validation was not executed.
- Confirmed `prometheus` service already contains `--web.enable-remote-write-receiver` and was not modified (no breakage expected for remote_write ingestion).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c33db0f48323a11bd13f775e02f7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics collection from host system and Docker containers for enhanced observability.
  * Added "Docker Container Overview" dashboard displaying CPU, memory, network, and filesystem metrics.
  * Added "Host Resource Overview" dashboard monitoring CPU, memory, disk I/O, network, and system load.
  * Configured Grafana datasource provisioning for Prometheus integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->