### PR TITLE
Enable Prometheus scraping and Grafana provisioning; bind host paths for exporters

### DIFF
--- a/ansible/group_vars/all/services/alloy.yml
+++ b/ansible/group_vars/all/services/alloy.yml
@@ -33,7 +33,7 @@ alloy:
   volumes:
     data:
       type: bind
-      source: /opt/alloy/data
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/alloy/data"
       target: /etc/alloy/data
       read_only: false
     docker_sock:
@@ -41,10 +41,25 @@ alloy:
       source: /var/run/docker.sock
       target: /var/run/docker.sock
       read_only: true
-    docker_container:
+    host_rootfs:
       type: bind
-      source: /var/lib/docker/containers
-      target: /var/lib/docker/containers
+      source: /
+      target: /host/rootfs
+      read_only: true
+    host_proc:
+      type: bind
+      source: /proc
+      target: /host/proc
+      read_only: true
+    host_sys:
+      type: bind
+      source: /sys
+      target: /host/sys
+      read_only: true
+    docker_lib:
+      type: bind
+      source: /var/lib/docker
+      target: /var/lib/docker
       read_only: true
   traefik:
     enable: true

--- a/ansible/group_vars/all/services/grafana.yml
+++ b/ansible/group_vars/all/services/grafana.yml
@@ -35,6 +35,32 @@ grafana:
     - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana"
       state: directory
       mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/provisioning/datasources"
+      state: directory
+      mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/provisioning/dashboards"
+      state: directory
+      mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/dashboards"
+      state: directory
+      mode: "0755"
+  templates:
+    - src: configs/grafana/provisioning/datasources/prometheus.yml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/provisioning/datasources/prometheus.yml"
+      mode: "0644"
+      force: true
+    - src: configs/grafana/provisioning/dashboards/dashboards.yml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/provisioning/dashboards/dashboards.yml"
+      mode: "0644"
+      force: true
+    - src: configs/grafana/dashboards/host-resource-overview.json.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/dashboards/host-resource-overview.json"
+      mode: "0644"
+      force: true
+    - src: configs/grafana/dashboards/docker-container-overview.json.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/grafana/dashboards/docker-container-overview.json"
+      mode: "0644"
+      force: true
   volumes:
     data:
       type: bind

--- a/ansible/roles/docker_services/files/alloy_config.alloy
+++ b/ansible/roles/docker_services/files/alloy_config.alloy
@@ -30,3 +30,32 @@ loki.source.docker "docker" {
   relabel_rules = discovery.relabel.docker_logs.rules
   forward_to    = [loki.write.default.receiver]
 }
+
+prometheus.remote_write "prometheus" {
+  endpoint {
+    url = "http://prometheus:9090/api/v1/write"
+  }
+}
+
+prometheus.exporter.unix "host" {
+  rootfs_path = "/host/rootfs"
+  procfs_path = "/host/proc"
+  sysfs_path  = "/host/sys"
+}
+
+prometheus.scrape "host" {
+  targets         = prometheus.exporter.unix.host.targets
+  scrape_interval = "15s"
+  forward_to      = [prometheus.remote_write.prometheus.receiver]
+}
+
+prometheus.exporter.cadvisor "docker" {
+  docker_host      = "unix:///var/run/docker.sock"
+  storage_duration = "5m"
+}
+
+prometheus.scrape "docker" {
+  targets         = prometheus.exporter.cadvisor.docker.targets
+  scrape_interval = "15s"
+  forward_to      = [prometheus.remote_write.prometheus.receiver]
+}

--- a/ansible/roles/docker_services/templates/configs/grafana/dashboards/docker-container-overview.json.j2
+++ b/ansible/roles/docker_services/templates/configs/grafana/dashboards/docker-container-overview.json.j2
@@ -1,0 +1,29 @@
+{
+  "uid": "docker-container-overview",
+  "title": "Docker Container Overview",
+  "schemaVersion": 39,
+  "version": 2,
+  "refresh": "30s",
+  "time": {"from": "now-6h", "to": "now"},
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "query": "label_values(container_cpu_usage_seconds_total, instance)",
+        "multi": true,
+        "includeAll": true,
+        "current": {"selected": true, "text": "All", "value": "$__all"}
+      }
+    ]
+  },
+  "panels": [
+    {"type":"timeseries","title":"Container CPU Cores Used","gridPos":{"h":8,"w":12,"x":0,"y":0},"targets":[{"expr":"sum by(container) (rate(container_cpu_usage_seconds_total{container!~\"^$|POD\",image!=\"\",instance=~\"$instance\"}[5m]))","legendFormat":"{{container}}"}]},
+    {"type":"timeseries","title":"Container Memory Working Set","gridPos":{"h":8,"w":12,"x":12,"y":0},"targets":[{"expr":"sum by(container) (container_memory_working_set_bytes{container!~\"^$|POD\",image!=\"\",instance=~\"$instance\"})","legendFormat":"{{container}}"}]},
+    {"type":"timeseries","title":"Container Network RX/TX Bytes/s","gridPos":{"h":8,"w":12,"x":0,"y":8},"targets":[{"expr":"sum by(container) (rate(container_network_receive_bytes_total{container!~\"^$|POD\",image!=\"\",instance=~\"$instance\"}[5m]))","legendFormat":"rx {{container}}"},{"expr":"sum by(container) (rate(container_network_transmit_bytes_total{container!~\"^$|POD\",image!=\"\",instance=~\"$instance\"}[5m]))","legendFormat":"tx {{container}}"}]},
+    {"type":"timeseries","title":"Container FS Usage","gridPos":{"h":8,"w":12,"x":12,"y":8},"targets":[{"expr":"sum by(container) (container_fs_usage_bytes{container!~\"^$|POD\",image!=\"\",instance=~\"$instance\"})","legendFormat":"{{container}}"}]},
+    {"type":"timeseries","title":"Top 10 Containers by CPU","gridPos":{"h":8,"w":12,"x":0,"y":16},"targets":[{"expr":"topk(10, sum by(container) (rate(container_cpu_usage_seconds_total{container!~\"^$|POD\",image!=\"\",instance=~\"$instance\"}[5m])))","legendFormat":"{{container}}"}]},
+    {"type":"timeseries","title":"Top 10 Containers by Memory","gridPos":{"h":8,"w":12,"x":12,"y":16},"targets":[{"expr":"topk(10, sum by(container) (container_memory_working_set_bytes{container!~\"^$|POD\",image!=\"\",instance=~\"$instance\"}))","legendFormat":"{{container}}"}]}
+  ]
+}

--- a/ansible/roles/docker_services/templates/configs/grafana/dashboards/host-resource-overview.json.j2
+++ b/ansible/roles/docker_services/templates/configs/grafana/dashboards/host-resource-overview.json.j2
@@ -1,0 +1,29 @@
+{
+  "uid": "host-resource-overview",
+  "title": "Host Resource Overview",
+  "schemaVersion": 39,
+  "version": 2,
+  "refresh": "30s",
+  "time": {"from": "now-6h", "to": "now"},
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "query": "label_values(node_cpu_seconds_total, instance)",
+        "multi": true,
+        "includeAll": true,
+        "current": {"selected": true, "text": "All", "value": "$__all"}
+      }
+    ]
+  },
+  "panels": [
+    {"type":"timeseries","title":"CPU Usage %","gridPos":{"h":8,"w":12,"x":0,"y":0},"targets":[{"expr":"100 - (avg by(instance) (rate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$instance\"}[5m])) * 100)","legendFormat":"{{instance}}"}]},
+    {"type":"timeseries","title":"Memory Usage %","gridPos":{"h":8,"w":12,"x":12,"y":0},"targets":[{"expr":"(1 - (node_memory_MemAvailable_bytes{instance=~\"$instance\"} / node_memory_MemTotal_bytes{instance=~\"$instance\"})) * 100","legendFormat":"{{instance}}"}]},
+    {"type":"timeseries","title":"Filesystem Usage %","gridPos":{"h":8,"w":12,"x":0,"y":8},"targets":[{"expr":"100 * (1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay\",mountpoint!~\"/run.*\",instance=~\"$instance\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay\",mountpoint!~\"/run.*\",instance=~\"$instance\"}))","legendFormat":"{{instance}} {{mountpoint}}"}]},
+    {"type":"timeseries","title":"Disk I/O Bytes/s","gridPos":{"h":8,"w":12,"x":12,"y":8},"targets":[{"expr":"rate(node_disk_read_bytes_total{instance=~\"$instance\"}[5m])","legendFormat":"read {{instance}} {{device}}"},{"expr":"rate(node_disk_written_bytes_total{instance=~\"$instance\"}[5m])","legendFormat":"write {{instance}} {{device}}"}]},
+    {"type":"timeseries","title":"Network RX/TX Bytes/s","gridPos":{"h":8,"w":12,"x":0,"y":16},"targets":[{"expr":"rate(node_network_receive_bytes_total{device!~\"lo\",instance=~\"$instance\"}[5m])","legendFormat":"rx {{instance}} {{device}}"},{"expr":"rate(node_network_transmit_bytes_total{device!~\"lo\",instance=~\"$instance\"}[5m])","legendFormat":"tx {{instance}} {{device}}"}]},
+    {"type":"timeseries","title":"Load Average (1m)","gridPos":{"h":8,"w":12,"x":12,"y":16},"targets":[{"expr":"node_load1{instance=~\"$instance\"}","legendFormat":"{{instance}}"}]}
+  ]
+}

--- a/ansible/roles/docker_services/templates/configs/grafana/provisioning/dashboards/dashboards.yml.j2
+++ b/ansible/roles/docker_services/templates/configs/grafana/provisioning/dashboards/dashboards.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: "Homelab"
+    orgId: 1
+    folder: "Homelab"
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/ansible/roles/docker_services/templates/configs/grafana/provisioning/datasources/prometheus.yml.j2
+++ b/ansible/roles/docker_services/templates/configs/grafana/provisioning/datasources/prometheus.yml.j2
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true


### PR DESCRIPTION
### Motivation

- Add host-level metrics collection and dashboard provisioning so Prometheus can scrape host and container metrics and Grafana can be auto-provisioned with useful dashboards.
- Replace hard-coded host paths with configurable `docker_host_appdata_root` to unify data locations across services.

### Description

- Update `ansible/group_vars/all/services/alloy.yml` to use `{{ docker_host_appdata_root }}` for Alloy data volume and add bind mounts for host rootfs, `/proc`, `/sys`, and `/var/lib/docker` to expose host filesystems and docker lib to exporters.
- Update `ansible/group_vars/all/services/grafana.yml` to create provisioning and dashboards directories under the host appdata root and add templates to render Prometheus datasource and dashboard files into the host volume.
- Add an Alloy configuration file `roles/docker_services/files/alloy_config.alloy` enhancements to configure `prometheus.remote_write`, a unix exporter for the host, a `cadvisor` exporter for Docker, and corresponding `scrape` jobs forwarding to Prometheus.
- Add Grafana provisioning and dashboard templates under `roles/docker_services/templates/configs/grafana/` including `prometheus.yml.j2`, `dashboards.yml.j2`, and two dashboard JSON templates (`host-resource-overview.json.j2` and `docker-container-overview.json.j2`).

### Testing

- Ran `ansible-playbook --syntax-check` against the playbooks and variable files and it completed successfully.
- Validated YAML templates with `yamllint` and `ansible-lint`, both of which returned no critical issues.
- Validated dashboard JSON templates with `jq` to ensure they are syntactically valid JSON and they passed validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c33db0f48323a11bd13f775e02f7)