### PR TITLE
Add Beszel service to docker_services catalog

### DIFF
--- a/ansible/group_vars/all/docker_services.yml
+++ b/ansible/group_vars/all/docker_services.yml
@@ -61,6 +61,8 @@ docker_services:
   ## services (monitoring)
   - name: alloy
     tags: [apps, monitoring, alloy]
+  - name: beszel
+    tags: [apps, monitoring, beszel]
   - name: crowdsec
     tags: [apps, monitoring, crowdsec]
   - name: gotify

--- a/ansible/group_vars/all/services/beszel.yml
+++ b/ansible/group_vars/all/services/beszel.yml
@@ -1,0 +1,37 @@
+---
+
+beszel:
+  name: beszel
+  stack: beszel
+  image: henrygd/beszel:latest
+  named_networks:
+    overlay:
+      external: true
+  environment:
+    TZ: "{{ timezone }}"
+  paths:
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/beszel"
+      state: directory
+      mode: "0755"
+  volumes:
+    data:
+      type: bind
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/beszel"
+      target: /beszel_data
+      read_only: false
+  traefik:
+    enable: true
+    exposure: private
+    port: 8090
+  deploy:
+    type: swarm
+    mode: replicated
+    replicas: 1
+    host: "{{ docker_services_primary_manager }}"
+    constraints:
+      - node.labels.docker_services_host == docker_services_primary_manager
+    restart_policy:
+      condition: on-failure
+      delay: 10s
+      max_attempts: 5
+      window: 2m


### PR DESCRIPTION
### Motivation

- Add Beszel (a monitoring/hub service) to the repository so it can be deployed via the existing `docker_services` workflows.
- Provide a standard service definition that follows the repo conventions for networking, persistent storage, Traefik exposure, and Swarm deployment.

### Description

- Added `ansible/group_vars/all/services/beszel.yml` which defines the `beszel` service using image `henrygd/beszel:latest`, an overlay network, a bind-mounted persistent data path, Traefik private exposure on port `8090`, and a Swarm `replicated` deploy policy pinned to the primary manager.
- Registered `beszel` in `ansible/group_vars/all/docker_services.yml` under the monitoring section with tags `[apps, monitoring, beszel]` so existing role logic picks it up for deploys.
- Service definition mirrors patterns used by other services in the repo (paths, volumes, `traefik`, and `deploy` blocks) for consistency with automation.

### Testing

- Confirmed the intended file additions and modifications by inspecting the generated diff for `ansible/group_vars/all/services/beszel.yml` and `ansible/group_vars/all/docker_services.yml` (files present and changed as expected).
- Attempted to validate YAML by running a Python `yaml` load, but the environment lacks `PyYAML` which caused the check to fail (`ModuleNotFoundError`).
- Checked for Ansible presence via `ansible-playbook --version` and the environment reported `ansible-missing`, so no `ansible-lint` or playbook dry-run was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e08cbc4c8323b58bc0ef5eefa91d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Beszel monitoring service for real-time system visibility and performance tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->