### PR TITLE
chore(deps): update traefik docker tag to v3.7.0

### DIFF
--- a/ansible/group_vars/all/services/traefik.yml
+++ b/ansible/group_vars/all/services/traefik.yml
@@ -3,7 +3,7 @@
 traefik:
   name: traefik
   stack: traefik
-  image: traefik:v3.6.17
+  image: traefik:v3.7.0
   named_networks:
     overlay:
       external: true


### PR DESCRIPTION
Manual PR created from Renovate branch because Renovate created the branch but errored before opening the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Traefik service upgraded from version 3.6.17 to 3.7.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lebowski89/homelab/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->