### PR TITLE
Add Wallos service, Technitium DNS record, and Uptime Kuma monitors

### DIFF
--- a/ansible/group_vars/all/docker_services.yml
+++ b/ansible/group_vars/all/docker_services.yml
@@ -51,6 +51,8 @@ docker_services:
     tags: [apps, media, pgsql, ombi]
   - name: opencloud
     tags: [apps, opencloud]
+  - name: wallos
+    tags: [apps, media, wallos]
   - name: stash
     tags: [apps, media, pgsql, stash]
   - name: thelounge

--- a/ansible/group_vars/all/services/wallos.yml
+++ b/ansible/group_vars/all/services/wallos.yml
@@ -1,0 +1,55 @@
+---
+
+wallos:
+  name: wallos
+  stack: wallos
+  image: bellamy/wallos:latest
+  named_networks:
+    overlay:
+      external: true
+  healthcheck:
+    test:
+      - "CMD"
+      - "wget"
+      - "--spider"
+      - "-q"
+      - "http://127.0.0.1/"
+  environment:
+    TZ: "{{ timezone }}"
+  paths:
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/wallos"
+      state: directory
+      mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/wallos/db"
+      state: directory
+      mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/wallos/logos"
+      state: directory
+      mode: "0755"
+  volumes:
+    db:
+      type: bind
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/wallos/db"
+      target: /var/www/html/db
+      read_only: false
+    logos:
+      type: bind
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/wallos/logos"
+      target: /var/www/html/images/uploads/logos
+      read_only: false
+  traefik:
+    enable: true
+    exposure: private
+    port: 80
+  deploy:
+    type: swarm
+    mode: replicated
+    replicas: 1
+    host: "{{ docker_services_primary_manager }}"
+    constraints:
+      - node.labels.docker_services_host == docker_services_primary_manager
+    restart_policy:
+      condition: on-failure
+      delay: 10s
+      max_attempts: 5
+      window: 2m

--- a/terraform/technitium/internal-dns/main.tf
+++ b/terraform/technitium/internal-dns/main.tf
@@ -38,6 +38,7 @@ locals {
     "traefik",
     "uptime-kuma",
     "vaultwarden",
+    "wallos",
     "whisparr",
     "znc",
   ]

--- a/terraform/uptime-kuma/locals.tf
+++ b/terraform/uptime-kuma/locals.tf
@@ -46,6 +46,7 @@ locals {
     seerr     = { group = "media", tag_keys = ["media"] }
     stash     = { group = "media", tag_keys = ["media"] }
     thelounge = { group = "media", tag_keys = ["media"] }
+    wallos    = { group = "media", tag_keys = ["media"] }
     znc       = { group = "media", tag_keys = ["media"] }
 
     # Monitoring
@@ -182,6 +183,7 @@ locals {
     stash     = { category = "media", port = 9999 }
     thelounge = { category = "media", port = 9000 }
     znc       = { category = "media", port = 6501 }
+    wallos    = { category = "media", port = 80 }
 
     # Monitoring
     alloy = {


### PR DESCRIPTION
### Motivation
- Add Wallos as a managed Docker service so it can be deployed by the existing `docker_services` role. 
- Ensure internal DNS and monitoring are updated so `wallos` is resolvable and monitored like other services.

### Description
- Added a new service definition at `ansible/group_vars/all/services/wallos.yml` using the `bellamy/wallos:latest` image with persistent `db` and `logos` bind mounts, a simple HTTP healthcheck, and Traefik private exposure on port `80`.
- Registered `wallos` in the `docker_services` list in `ansible/group_vars/all/docker_services.yml` so the role will include it during deploy runs.
- Added `"wallos"` to the Technitium IPv4 record list in `terraform/technitium/internal-dns/main.tf` so an A record for `wallos.<internal_zone>` is generated.
- Added `wallos` entries to Uptime Kuma configuration in `terraform/uptime-kuma/locals.tf` by inserting it into `private_http_services` and `direct_http_services` (direct monitor uses port `80`).

### Testing
- Attempted `terraform -chdir=terraform/technitium/internal-dns fmt`, but the `terraform` CLI is not available in this environment so formatting could not be run (failed).
- Attempted `tofu -chdir=terraform/uptime-kuma fmt` as an alternative, but the `tofu` CLI is not available in this environment so formatting could not be run (failed).
- No further automated tests were run in this environment due to missing Terraform/OpenTofu tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a13e8f96483239501e1ccb847f69f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallos media service added with integrated health monitoring and automatic DNS configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lebowski89/homelab/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->