### PR TITLE
ci: tighten workflow permissions, move write perms to jobs, and pin actions/deps

### DIFF
--- a/.github/workflows/ansible-docs.yml
+++ b/.github/workflows/ansible-docs.yml
@@ -12,9 +12,6 @@ on:
       - '.github/workflows/ansible-docs.yml'
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 concurrency:
   group: ansible-docs-${{ github.ref }}
   cancel-in-progress: true
@@ -24,21 +21,24 @@ jobs:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@42375524fcd1f42e9d11bf7e59e9f4a432f15993
         with:
           python-version: '3.14.5'
 
       - name: Install Docsible
         run: |
           python -m pip install --upgrade pip
-          pip install docsible
+          pip install docsible==0.7.6
 
       - name: Generate documentation for all supported roles
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,22 +10,25 @@ on:
     paths:
       - "ansible/**"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@42375524fcd1f42e9d11bf7e59e9f4a432f15993
         with:
           python-version: "3.14.5"
 
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          pip install ansible-core ansible-lint yamllint
+          pip install ansible-core==2.19.0 ansible-lint==25.8.0 yamllint==1.37.1
           if [ -f ansible/requirements.txt ]; then
             pip install -r ansible/requirements.txt
           fi

--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Fail if private files are tracked
         shell: bash
@@ -54,11 +54,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@44c8a6527197d2f6580c8ca5365f576a7ff15f5a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tofu-check.yml
+++ b/.github/workflows/tofu-check.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@4f92f65dc804f13090f8f642b58c212cd4d0b0a1
+        uses: opentofu/setup-opentofu@847eaa4afeb791b06daa46e8eafa8b1b68d7cfb4
 
       - name: Show version
         run: tofu version

--- a/.github/workflows/tofu-check.yml
+++ b/.github/workflows/tofu-check.yml
@@ -18,6 +18,9 @@ on:
       - "terraform/**/*.tftest.hcl"
       - ".github/workflows/tofu-check.yml"
 
+permissions:
+  contents: read
+
 concurrency:
   group: tofu-check-${{ github.ref }}
   cancel-in-progress: true
@@ -49,10 +52,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@v2
+        uses: opentofu/setup-opentofu@4f92f65dc804f13090f8f642b58c212cd4d0b0a1
 
       - name: Show version
         run: tofu version

--- a/.github/workflows/tofu-docs.yml
+++ b/.github/workflows/tofu-docs.yml
@@ -14,9 +14,6 @@ on:
       - "terraform/**/*.tf"
       - ".github/workflows/tofu-docs.yml"
 
-permissions:
-  contents: write
-
 concurrency:
   group: tofu-docs-${{ github.ref }}
   cancel-in-progress: true
@@ -25,15 +22,18 @@ jobs:
   docs:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Render OpenTofu docs
-        uses: terraform-docs/gh-actions@v1.4.1
+        uses: terraform-docs/gh-actions@90d7d172a97c5c65dfdb856ffdc7ba13e7d30d4d
         with:
           working-dir: .
           find-dir: terraform


### PR DESCRIPTION
### Motivation
- Reduce workflow blast radius by restricting `contents` permission where full write is not required. 
- Move write permissions down to the specific jobs that perform repository writes to follow least privilege. 
- Improve CI reproducibility and supply-chain safety by pinning third-party and official actions to immutable references. 
- Stabilize Python tooling by pinning pip-installed packages used in ansible linting and docs generation.

### Description
- Added `permissions: contents: read` at the workflow level in `.github/workflows/lint.yml` and `.github/workflows/tofu-check.yml`.
- Removed top-level `permissions: contents: write` from `tofu-docs.yml` and `ansible-docs.yml` and added `permissions: contents: write` to the specific jobs (`docs` and `generate_docs`) that need it.
- Pinned third-party actions to fixed references: `terraform-docs/gh-actions` in `tofu-docs.yml`, `opentofu/setup-opentofu` in `tofu-check.yml`, and `gitleaks/gitleaks-action` in `secrets-check.yml`.
- Pinned official GitHub actions to fixed refs in the affected workflows: `actions/checkout` and `actions/setup-python` were updated across the workflows.
- Pinned pip installs where practical: `ansible-core==2.19.0`, `ansible-lint==25.8.0`, `yamllint==1.37.1` in `lint.yml`, and `docsible==0.7.6` in `ansible-docs.yml`.
- Files modified: `.github/workflows/lint.yml`, `.github/workflows/tofu-check.yml`, `.github/workflows/tofu-docs.yml`, `.github/workflows/ansible-docs.yml`, and `.github/workflows/secrets-check.yml`.

### Testing
- Ran `git diff -- .github/workflows/*.yml` to review the workflow changes, which produced the expected diffs and succeeded. 
- Verified working tree with `git status --short`, which reported the updated workflow files and succeeded. 
- Committed the changes with `git add .github/workflows/*.yml && git commit -m "ci: tighten workflow permissions and pin actions"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4b3261c08323889aba116d196b18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use pinned commit references for improved build reproducibility and security across CI/CD pipelines.
  * Dependencies in automation workflows now use explicit versions for consistent, reliable builds.
  * Refined permission scoping in certain workflows for better security configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lebowski89/homelab/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->