### PR TITLE
Add Dozzle to docker services, DNS, Uptime Kuma, and Homepage

### DIFF
--- a/ansible/group_vars/all/docker_services.yml
+++ b/ansible/group_vars/all/docker_services.yml
@@ -71,6 +71,8 @@ docker_services:
     tags: [apps, monitoring, beszel]
   - name: crowdsec
     tags: [apps, monitoring, crowdsec]
+  - name: dozzle
+    tags: [apps, monitoring, dozzle]
   - name: gotify
     tags: [apps, monitoring, pgsql, gotify]
   - name: grafana

--- a/ansible/group_vars/all/services/dozzle.yml
+++ b/ansible/group_vars/all/services/dozzle.yml
@@ -1,0 +1,35 @@
+---
+
+dozzle:
+  name: dozzle
+  stack: dozzle
+  image: amir20/dozzle:v8.14.7
+  named_networks:
+    overlay:
+      external: true
+  environment:
+    TZ: "{{ timezone }}"
+    DOZZLE_NO_ANALYTICS: true
+    DOZZLE_ENABLE_ACTIONS: false
+  volumes:
+    docker_sock:
+      type: bind
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      read_only: true
+  traefik:
+    enable: true
+    exposure: private
+    port: 8080
+  deploy:
+    type: swarm
+    mode: replicated
+    replicas: 1
+    host: "{{ docker_services_primary_manager }}"
+    constraints:
+      - node.labels.docker_services_host == docker_services_primary_manager
+    restart_policy:
+      condition: on-failure
+      delay: 10s
+      max_attempts: 5
+      window: 2m

--- a/ansible/roles/docker_services/templates/configs/homepage/services.yaml.j2
+++ b/ansible/roles/docker_services/templates/configs/homepage/services.yaml.j2
@@ -247,6 +247,10 @@
         icon: syncthing.svg
         href: https://syncthing.int.{{ cloudflare_zone }}:8443
         description: Save/state/device sync
+    - Dozzle:
+        icon: dozzle.svg
+        href: https://dozzle.int.{{ cloudflare_zone }}:8443
+        description: Real-time Docker log viewer
     - Vaultwarden:
         icon: vaultwarden.png
         href: https://vaultwarden.{{ cloudflare_zone }}

--- a/terraform/technitium/internal-dns/main.tf
+++ b/terraform/technitium/internal-dns/main.tf
@@ -6,6 +6,7 @@ locals {
     "autobrr",
     "bazarr",
     "czkawka",
+    "dozzle",
     "gitea",
     "gotify",
     "grafana",

--- a/terraform/uptime-kuma/locals.tf
+++ b/terraform/uptime-kuma/locals.tf
@@ -53,6 +53,7 @@ locals {
     znc       = { group = "media", tag_keys = ["media"] }
 
     # Monitoring
+    dozzle      = { group = "monitoring", tag_keys = ["monitoring"] }
     gotify      = { group = "monitoring", tag_keys = ["monitoring"] }
     grafana     = { group = "monitoring", tag_keys = ["monitoring"] }
     homepage    = { group = "monitoring", tag_keys = ["monitoring"] }
@@ -200,6 +201,8 @@ locals {
       path                  = "/-/ready"
       accepted_status_codes = ["200-299"]
     }
+
+    dozzle = { category = "monitoring", port = 8080 }
 
     gotify = { category = "monitoring", port = 80 }
 


### PR DESCRIPTION
### Motivation

- Provide Dozzle as a first-class docker service so logs can be viewed centrally via the existing `docker_services` role. 
- Ensure internal DNS resolution for Dozzle so private Traefik routes and direct checks work via Technitium. 
- Add Uptime Kuma monitors so Dozzle is included in private/direct health checks. 
- Expose Dozzle on the homepage utilities card for quick access.

### Description

- Added a new service vars file `ansible/group_vars/all/services/dozzle.yml` which defines the Dozzle stack image, swarm deployment, Traefik private exposure, and a read-only Docker socket mount. 
- Registered `dozzle` in the global service list at `ansible/group_vars/all/docker_services.yml` so the service can be managed by the `docker_services` role. 
- Inserted a Dozzle entry into the Homepage template at `ansible/roles/docker_services/templates/configs/homepage/services.yaml.j2` under the `utilities` section. 
- Added `dozzle` to the Technitium internal DNS A-record generation list in `terraform/technitium/internal-dns/main.tf`. 
- Added Dozzle entries to the Uptime Kuma Terraform locals in `terraform/uptime-kuma/locals.tf` for both private (Traefik) and direct HTTP monitor maps and for direct monitor port configuration.

### Testing

- Attempted to run `terraform fmt` for `terraform/technitium/internal-dns` and `terraform/uptime-kuma`, but formatting/validation could not be executed because the Terraform CLI is not available in the environment (`terraform: command not found`). 
- No automated Uptime Kuma/terraform applies or other CI checks were run in this environment due to missing CLI/tools. 
- Verified the new/modified files are present in the working tree and ready for downstream validation in CI or a local environment with Terraform available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f9d922b708323ae791213f354bf81)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dozzle service integrated into the platform dashboard with DNS routing, web access, and health monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lebowski89/homelab/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->