### PR TITLE
Add Prometheus/Alertmanager configs, rules, validation script, and CI workflow

### DIFF
--- a/.github/workflows/alerting-config-validation.yml
+++ b/.github/workflows/alerting-config-validation.yml
@@ -1,0 +1,35 @@
+---
+name: Alerting config validation
+
+on:
+  pull_request:
+    paths:
+      - ansible/group_vars/all/services/alertmanager.yml
+      - ansible/group_vars/all/services/prometheus.yml
+      - ansible/roles/docker_services/templates/configs/alertmanager/**
+      - ansible/roles/docker_services/templates/configs/prometheus.yml.j2
+      - ansible/roles/docker_services/templates/configs/prometheus/rules/**
+      - scripts/validate-alerting-configs.sh
+      - .github/workflows/alerting-config-validation.yml
+  push:
+    paths:
+      - ansible/group_vars/all/services/alertmanager.yml
+      - ansible/group_vars/all/services/prometheus.yml
+      - ansible/roles/docker_services/templates/configs/alertmanager/**
+      - ansible/roles/docker_services/templates/configs/prometheus.yml.j2
+      - ansible/roles/docker_services/templates/configs/prometheus/rules/**
+      - scripts/validate-alerting-configs.sh
+      - .github/workflows/alerting-config-validation.yml
+
+jobs:
+  validate-alerting-configs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Python render dependencies
+        run: python3 -m pip install jinja2 pyyaml
+
+      - name: Validate rendered Prometheus and Alertmanager configs
+        run: scripts/validate-alerting-configs.sh

--- a/ansible/group_vars/all/services/alertmanager.yml
+++ b/ansible/group_vars/all/services/alertmanager.yml
@@ -1,0 +1,106 @@
+---
+
+alertmanager:
+  enabled: true
+  tags: [apps, monitoring, alertmanager]
+  name: alertmanager
+  stack: alertmanager
+  image: prom/alertmanager:v0.28.1
+  named_networks:
+    overlay:
+      external: true
+  command:
+    - "--config.file=/etc/alertmanager/alertmanager.yml"
+    - "--storage.path=/alertmanager"
+  user: >-
+    {{ hostvars[docker_services_primary_manager].docker_host_puid }}:{{ hostvars[docker_services_primary_manager].docker_host_pgid }}
+  environment:
+    TZ: "{{ timezone }}"
+  paths:
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/alertmanager"
+      state: directory
+      mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/alertmanager/data"
+      state: directory
+      mode: "0755"
+  templates:
+    - src: configs/alertmanager/alertmanager.yml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/alertmanager/alertmanager.yml"
+      mode: "0644"
+      force: true
+  volumes:
+    config:
+      type: bind
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/alertmanager"
+      target: /etc/alertmanager
+      read_only: true
+    data:
+      type: bind
+      source: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/alertmanager/data"
+      target: /alertmanager
+      read_only: false
+  traefik:
+    enable: true
+    exposure: private
+    port: 9093
+  deploy:
+    type: swarm
+    mode: replicated
+    replicas: 1
+    host: "{{ docker_services_primary_manager }}"
+    constraints:
+      - node.labels.docker_services_host == docker_services_primary_manager
+    restart_policy:
+      condition: on-failure
+      delay: 10s
+      max_attempts: 5
+      window: 2m
+
+alertmanager_gotify_bridge:
+  enabled: true
+  tags: [apps, monitoring, alertmanager, gotify]
+  name: alertmanager-gotify-bridge
+  stack: alertmanager
+  image: ghcr.io/druggeri/alertmanager_gotify_bridge:v2.3.2
+  named_networks:
+    overlay:
+      external: true
+  environment:
+    TZ: "{{ timezone }}"
+    GOTIFY_ENDPOINT: http://gotify:80/message
+    BIND_ADDRESS: 0.0.0.0
+    PORT: "8080"
+    WEBHOOK_PATH: /gotify_webhook
+    DEFAULT_PRIORITY: "5"
+    EXTENDED_DETAILS: "true"
+    DISPATCH_ERRORS: "true"
+  env_file:
+    - "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/alertmanager-gotify-bridge/.env"
+  infisical:
+    fail_on_empty: true
+    secrets_map:
+      - var: gotify_alertmanager_token
+        path: "/Gotify"
+        name: ALERTMANAGER_TOKEN
+  paths:
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/alertmanager-gotify-bridge"
+      state: directory
+      mode: "0755"
+  templates:
+    - src: configs/alertmanager/gotify-bridge.env.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/alertmanager-gotify-bridge/.env"
+      mode: "0660"
+      force: true
+      no_log: true
+  deploy:
+    type: swarm
+    mode: replicated
+    replicas: 1
+    host: "{{ docker_services_primary_manager }}"
+    constraints:
+      - node.labels.docker_services_host == docker_services_primary_manager
+    restart_policy:
+      condition: on-failure
+      delay: 10s
+      max_attempts: 5
+      window: 2m

--- a/ansible/group_vars/all/services/prometheus.yml
+++ b/ansible/group_vars/all/services/prometheus.yml
@@ -24,9 +24,20 @@ prometheus:
     - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/prometheus/data"
       state: directory
       mode: "0755"
+    - path: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/prometheus/rules"
+      state: directory
+      mode: "0755"
   templates:
     - src: configs/prometheus.yml.j2
       dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/prometheus/prometheus.yml"
+      mode: "0644"
+      force: true
+    - src: configs/prometheus/rules/infrastructure.yml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/prometheus/rules/infrastructure.yml"
+      mode: "0644"
+      force: true
+    - src: configs/prometheus/rules/applications.yml.j2
+      dest: "{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}/prometheus/rules/applications.yml"
       mode: "0644"
       force: true
   volumes:

--- a/ansible/roles/docker_services/templates/configs/alertmanager/README.md
+++ b/ansible/roles/docker_services/templates/configs/alertmanager/README.md
@@ -1,0 +1,78 @@
+# Alertmanager alert flow
+
+Alert flow is intentionally small and boring for the first rollout:
+
+```text
+Prometheus -> Alertmanager -> alertmanager-gotify-bridge -> Gotify
+```
+
+## Secrets
+
+`alertmanager-gotify-bridge` reads the Gotify application token from its env file. The env file is rendered by Ansible from the Infisical secret:
+
+- path: `/Gotify`
+- name: `ALERTMANAGER_TOKEN`
+- rendered variable: `GOTIFY_TOKEN`
+
+No Gotify token value should be committed to this repository.
+
+## Enabled rule files
+
+Prometheus currently renders and loads only these rule files:
+
+- `infrastructure.yml`
+- `applications.yml`
+
+The enabled rules only use metrics from scrape jobs defined in `prometheus.yml.j2`:
+
+- `up` for Prometheus, Alertmanager, and alertmanager-gotify-bridge target health
+- `alertmanager_gotify_bridge_gotify_up` from alertmanager-gotify-bridge `/metrics`
+- `traefik_service_requests_total` from the Traefik scrape target
+- `haproxy_server_up` from the HAProxy scrape target
+
+The Gotify bridge `/metrics` endpoint is documented by the upstream project and exports bridge request counters plus Gotify health metrics.
+
+## Future rules intentionally not enabled yet
+
+The following alert ideas should stay disabled until the matching exporter and exact metric names/semantics are confirmed in this repo's Prometheus setup:
+
+- Docker Swarm desired/running replica mismatch
+- container restart loops
+- certificate expiry
+- backup freshness and absent backup metrics
+- Postgres/Patroni leader and replica lag
+- ZFS pool health
+- SMART disk health/errors
+- Uptime Kuma monitor state
+- node filesystem disk usage via node_exporter
+
+When enabling backup freshness, include both stale and absent-metric alerts. When enabling SMART/ZFS alerts, prefer current failing state or explicit counters over `increase()` on health/status gauges.
+
+## Test alert
+
+After deployment, send a temporary test alert through Alertmanager from a machine that can reach the private Alertmanager endpoint:
+
+```bash
+curl -XPOST http://alertmanager:9093/api/v2/alerts \
+  -H 'Content-Type: application/json' \
+  -d '[{"labels":{"alertname":"TestGotifyNotification","severity":"warning"},"annotations":{"summary":"Test alert from Alertmanager","description":"This verifies Prometheus -> Alertmanager -> Gotify bridge -> Gotify delivery."}}]'
+```
+
+## Config validation
+
+Render and validate the alerting templates with:
+
+```bash
+scripts/validate-alerting-configs.sh
+```
+
+The script first YAML-parses the Alertmanager and Prometheus service definition files, renders the Jinja templates to a temporary directory, then runs:
+
+```bash
+promtool check config prometheus.local-validation.yml
+promtool check rules rules/infrastructure.yml
+promtool check rules rules/applications.yml
+amtool check-config alertmanager.yml
+```
+
+The Prometheus config check uses a validation-only rendered config whose `rule_files` entry points at the rendered rule directory. Rule files are also validated one at a time so Docker-based validation does not rely on shell glob expansion inside the container.

--- a/ansible/roles/docker_services/templates/configs/alertmanager/alertmanager.yml.j2
+++ b/ansible/roles/docker_services/templates/configs/alertmanager/alertmanager.yml.j2
@@ -1,0 +1,36 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: gotify
+  group_by: [alertname, cluster, service, job, instance, severity]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - receiver: gotify
+      matchers:
+        - severity="critical"
+      repeat_interval: 1h
+    - receiver: gotify
+      matchers:
+        - severity="warning"
+      repeat_interval: 6h
+
+inhibit_rules:
+  - source_matchers:
+      - severity="critical"
+    target_matchers:
+      - severity="warning"
+    equal: [alertname, instance]
+  - source_matchers:
+      - alertname="PrometheusTargetDown"
+    target_matchers:
+      - severity=~"warning|critical"
+    equal: [job, instance]
+
+receivers:
+  - name: gotify
+    webhook_configs:
+      - url: http://alertmanager-gotify-bridge:8080/gotify_webhook
+        send_resolved: true

--- a/ansible/roles/docker_services/templates/configs/alertmanager/gotify-bridge.env.j2
+++ b/ansible/roles/docker_services/templates/configs/alertmanager/gotify-bridge.env.j2
@@ -1,0 +1,1 @@
+GOTIFY_TOKEN={{ gotify_alertmanager_token }}

--- a/ansible/roles/docker_services/templates/configs/prometheus.yml.j2
+++ b/ansible/roles/docker_services/templates/configs/prometheus.yml.j2
@@ -2,6 +2,14 @@ global:
   scrape_interval: 15s
   scrape_timeout: 10s
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
 scrape_configs:
   - job_name: "prometheus"
     scrape_interval: 5s
@@ -25,3 +33,14 @@ scrape_configs:
     scrape_timeout: 10s
     static_configs:
       - targets: ["traefik:8082"]
+
+  - job_name: "alertmanager"
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["alertmanager:9093"]
+
+  - job_name: "alertmanager-gotify-bridge"
+    scrape_interval: 30s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["alertmanager-gotify-bridge:8080"]

--- a/ansible/roles/docker_services/templates/configs/prometheus/rules/applications.yml.j2
+++ b/ansible/roles/docker_services/templates/configs/prometheus/rules/applications.yml.j2
@@ -1,0 +1,22 @@
+groups:
+  - name: applications.rules
+    rules:
+      - alert: Traefik5xxSpike
+        expr: sum by (service) (rate(traefik_service_requests_total{code=~"5.."}[5m])) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Traefik 5xx spike for {{ '{{' }} $labels.service {{ '}}' }}"
+          description: "Traefik is serving more than 0.1 5xx responses/sec for {{ '{{' }} $labels.service {{ '}}' }} over 5 minutes."
+          priority: "7"
+
+      - alert: HAProxyBackendDown
+        expr: haproxy_server_up == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "HAProxy backend down: {{ '{{' }} $labels.proxy {{ '}}' }}/{{ '{{' }} $labels.server {{ '}}' }}"
+          description: "HAProxy backend server {{ '{{' }} $labels.server {{ '}}' }} in {{ '{{' }} $labels.proxy {{ '}}' }} has been down for 5 minutes."
+          priority: "9"

--- a/ansible/roles/docker_services/templates/configs/prometheus/rules/infrastructure.yml.j2
+++ b/ansible/roles/docker_services/templates/configs/prometheus/rules/infrastructure.yml.j2
@@ -1,0 +1,42 @@
+groups:
+  - name: infrastructure.rules
+    rules:
+      - alert: PrometheusTargetDown
+        expr: up{job!~"alertmanager|alertmanager-gotify-bridge"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Prometheus target down: {{ '{{' }} $labels.job {{ '}}' }}/{{ '{{' }} $labels.instance {{ '}}' }}"
+          description: "Prometheus has been unable to scrape {{ '{{' }} $labels.job {{ '}}' }} on {{ '{{' }} $labels.instance {{ '}}' }} for 5 minutes."
+          priority: "8"
+
+      - alert: AlertmanagerDown
+        expr: up{job="alertmanager"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Alertmanager is down"
+          description: "Prometheus has been unable to scrape Alertmanager on {{ '{{' }} $labels.instance {{ '}}' }} for 5 minutes."
+          priority: "9"
+
+      - alert: GotifyBridgeDown
+        expr: up{job="alertmanager-gotify-bridge"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Alertmanager Gotify bridge is down"
+          description: "Prometheus has been unable to scrape alertmanager-gotify-bridge on {{ '{{' }} $labels.instance {{ '}}' }} for 5 minutes."
+          priority: "9"
+
+      - alert: GotifyBackendUnhealthy
+        expr: alertmanager_gotify_bridge_gotify_up == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Gotify backend is unhealthy from the bridge"
+          description: "alertmanager-gotify-bridge cannot reach Gotify's health endpoint."
+          priority: "9"

--- a/scripts/validate-alerting-configs.sh
+++ b/scripts/validate-alerting-configs.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${OUT_DIR:-$(mktemp -d)}"
+PROM_IMAGE="${PROM_IMAGE:-prom/prometheus:v3.12.0}"
+ALERTMANAGER_IMAGE="${ALERTMANAGER_IMAGE:-prom/alertmanager:v0.28.1}"
+
+cleanup() {
+  if [[ "${KEEP_RENDERED:-0}" != "1" ]]; then
+    rm -rf "${OUT_DIR}"
+  else
+    echo "Rendered configs kept at ${OUT_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "${OUT_DIR}/rules"
+export ROOT_DIR OUT_DIR
+
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+from jinja2 import Environment
+import yaml
+
+root = Path(os.environ["ROOT_DIR"])
+out = Path(os.environ["OUT_DIR"])
+env = Environment()
+
+def render(src: Path, dest: Path) -> None:
+    rendered = env.from_string(src.read_text()).render()
+    yaml.safe_load(rendered)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(rendered)
+
+# Basic YAML validation for service definitions that affect the alerting stack.
+# The Jinja expressions in these files are YAML scalar values, so raw parsing is
+# sufficient here. This is a syntax check, not full schema validation.
+for service_yaml in [
+    root / "ansible/group_vars/all/services/alertmanager.yml",
+    root / "ansible/group_vars/all/services/prometheus.yml",
+]:
+    yaml.safe_load(service_yaml.read_text())
+
+render(root / "ansible/roles/docker_services/templates/configs/prometheus.yml.j2", out / "prometheus.yml")
+render(root / "ansible/roles/docker_services/templates/configs/alertmanager/alertmanager.yml.j2", out / "alertmanager.yml")
+
+rules_dir = root / "ansible/roles/docker_services/templates/configs/prometheus/rules"
+for src in sorted(rules_dir.glob("*.yml.j2")):
+    render(src, out / "rules" / src.name.removesuffix(".j2"))
+
+# The deployed Prometheus config intentionally points at /etc/prometheus/rules/*.yml.
+# For validation, write local/Docker variants whose rule_files path points at the
+# rendered rule files in OUT_DIR so promtool check config validates the rendered
+# rules instead of a non-existent host /etc/prometheus path.
+prometheus_config = yaml.safe_load((out / "prometheus.yml").read_text())
+prometheus_config["rule_files"] = [str(out / "rules" / "*.yml")]
+(out / "prometheus.local-validation.yml").write_text(yaml.safe_dump(prometheus_config, sort_keys=False))
+prometheus_config["rule_files"] = ["/rendered/rules/*.yml"]
+(out / "prometheus.docker-validation.yml").write_text(yaml.safe_dump(prometheus_config, sort_keys=False))
+PY
+
+run_tool() {
+  local image="$1"
+  local binary="$2"
+  local docker_args="$3"
+  shift 3
+
+  if command -v "${binary}" >/dev/null 2>&1; then
+    "${binary}" "$@"
+  elif command -v docker >/dev/null 2>&1; then
+    # shellcheck disable=SC2086
+    docker run --rm -v "${OUT_DIR}:/rendered:ro" "${image}" "${binary}" ${docker_args}
+  else
+    echo "ERROR: neither ${binary} nor docker is available" >&2
+    return 127
+  fi
+}
+
+run_tool "${PROM_IMAGE}" promtool "check config /rendered/prometheus.docker-validation.yml" check config "${OUT_DIR}/prometheus.local-validation.yml"
+
+shopt -s nullglob
+rule_files=("${OUT_DIR}"/rules/*.yml)
+shopt -u nullglob
+
+if (( ${#rule_files[@]} == 0 )); then
+  echo "ERROR: no rendered Prometheus rule files found in ${OUT_DIR}/rules" >&2
+  exit 1
+fi
+
+for rule_file in "${rule_files[@]}"; do
+  rule_name="$(basename "${rule_file}")"
+  run_tool "${PROM_IMAGE}" promtool "check rules /rendered/rules/${rule_name}" check rules "${rule_file}"
+done
+
+run_tool "${ALERTMANAGER_IMAGE}" amtool "check-config /rendered/alertmanager.yml" check-config "${OUT_DIR}/alertmanager.yml"


### PR DESCRIPTION
### Motivation

- Introduce a minimal Prometheus + Alertmanager alerting stack with a Gotify bridge for notifications to enable basic alerting in the deployment.
- Provide out-of-tree Prometheus rule files and Alertmanager routing to separate infrastructure and application alerts.
- Add automated validation to catch template/rendering and Prometheus/Alertmanager config errors before deployment.

### Description

- Add Alertmanager service definition at `ansible/group_vars/all/services/alertmanager.yml` including an `alertmanager_gotify_bridge` service and templates/volumes for Alertmanager and the Gotify bridge.
- Update `ansible/group_vars/all/services/prometheus.yml` to add rules directory, and to render `infrastructure.yml` and `applications.yml` rules into the service appdata path.
- Add Jinja templates for runtime configs at `ansible/roles/docker_services/templates/configs/` including `prometheus.yml.j2`, `alertmanager/alertmanager.yml.j2`, `alertmanager/gotify-bridge.env.j2`, and Prometheus rule templates under `prometheus/rules/` plus a README describing flow and validation.
- Add `scripts/validate-alerting-configs.sh` which renders Jinja templates to a temporary directory, performs YAML parse checks, and runs `promtool check config`, `promtool check rules`, and `amtool check-config` using local binaries or Docker fallbacks.
- Add a GitHub Actions workflow `/.github/workflows/alerting-config-validation.yml` to run the validation script on PRs and pushes that touch alerting-related files.

### Testing

- No automated tests were executed as part of this change itself, but CI coverage was added: the new workflow will run `scripts/validate-alerting-configs.sh` on relevant PRs and pushes.
- The validation script invokes `promtool` and `amtool` (or Docker images `prom/prometheus` and `prom/alertmanager` as fallback) to run `promtool check config`, `promtool check rules`, and `amtool check-config` against the rendered configs. 
- The script also renders templates and performs YAML parsing with `jinja2`/`pyyaml` to ensure templates render and produce valid YAML before tool checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3486ca5bc88323960163947e30ea08)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented alert routing and management with severity-based grouping
  * Added alert notifications integration with Gotify
  * Defined infrastructure monitoring rules for target and service health
  * Defined application monitoring rules for traffic anomalies and backend availability

* **Documentation**
  * Added alerting system documentation with configuration and testing procedures

* **Tests**
  * Added automated validation for alerting configurations on code changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->