### PR TITLE
Feat/GitHub repo governance

### DIFF
--- a/.github/workflows/ansible-docs.yml
+++ b/.github/workflows/ansible-docs.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ansible-docs-${{ github.ref }}
-  cancel-in-progress: true
+  group: generated-docs-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -95,17 +95,40 @@ jobs:
             exit 1
           fi
 
-      - name: Commit generated docs to branch
+      - name: Commit generated docs
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
 
-          git add -A ansible/roles
-
-          if git diff --cached --quiet; then
-            echo "No documentation changes to commit"
+          if git diff --quiet; then
+            echo "No generated doc changes."
             exit 0
           fi
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add ansible/roles
           git commit -m "docs(ansible): regenerate role docs"
-          git push origin HEAD:${{ github.event.pull_request.head.ref || github.ref_name }}
+
+      - name: Push generated docs
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          set -euo pipefail
+
+          BRANCH="${{ github.event.pull_request.head.ref || github.ref_name }}"
+
+          for attempt in 1 2 3; do
+            echo "Push attempt ${attempt} to ${BRANCH}"
+
+            if git push origin HEAD:"${BRANCH}"; then
+              exit 0
+            fi
+
+            echo "Push rejected; rebasing on latest ${BRANCH}..."
+            git fetch origin "${BRANCH}"
+            git rebase "origin/${BRANCH}"
+          done
+
+          echo "Failed to push generated docs after retries."
+          exit 1

--- a/.github/workflows/ansible-docs.yml
+++ b/.github/workflows/ansible-docs.yml
@@ -10,12 +10,12 @@ on:
       - '.github/workflows/ansible-docs.yml'
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 concurrency:
   group: ansible-docs-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: write
 
 jobs:
   generate_docs:

--- a/.github/workflows/ansible-docs.yml
+++ b/.github/workflows/ansible-docs.yml
@@ -3,9 +3,7 @@
 name: Generate Ansible Docs
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
     paths:
       - 'ansible/roles/**'
       - 'ansible/test/**'
@@ -21,7 +19,9 @@ concurrency:
 
 jobs:
   generate_docs:
-    if: github.actor != 'github-actions[bot]'
+    if: >-
+      github.actor != 'github-actions[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
 
     steps:
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v6.3.0
@@ -94,7 +95,7 @@ jobs:
             exit 1
           fi
 
-      - name: Commit updated docs
+      - name: Commit generated docs to branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -107,6 +108,4 @@ jobs:
           fi
 
           git commit -m "docs(ansible): regenerate role docs"
-
-          git pull --rebase origin main
-          git push origin HEAD:main
+          git push origin HEAD:${{ github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/tofu-check.yml
+++ b/.github/workflows/tofu-check.yml
@@ -35,6 +35,7 @@ jobs:
           - terraform/cloudflare/homelab
           - terraform/cloudflare/hugo
           - terraform/github/hugo
+          - terraform/github/homelab
           - terraform/netbox
           - terraform/proxmox/mappings/resources
           - terraform/proxmox/settings/pve1

--- a/.github/workflows/tofu-docs.yml
+++ b/.github/workflows/tofu-docs.yml
@@ -13,8 +13,8 @@ permissions:
   contents: write
 
 concurrency:
-  group: tofu-docs-${{ github.ref }}
-  cancel-in-progress: true
+  group: generated-docs-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/tofu-docs.yml
+++ b/.github/workflows/tofu-docs.yml
@@ -7,12 +7,7 @@ on:
     paths:
       - "terraform/**/*.tf"
       - ".github/workflows/tofu-docs.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "terraform/**/*.tf"
-      - ".github/workflows/tofu-docs.yml"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -23,6 +18,9 @@ concurrency:
 
 jobs:
   docs:
+    if: >-
+      github.actor != 'github-actions[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
 
     steps:
@@ -30,9 +28,9 @@ jobs:
         uses: actions/checkout@v7.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
-      - name: Render OpenTofu docs
+      - name: Render and commit OpenTofu docs
         uses: terraform-docs/gh-actions@v1.4.1
         with:
           working-dir: .

--- a/.github/workflows/tofu-docs.yml
+++ b/.github/workflows/tofu-docs.yml
@@ -16,6 +16,9 @@ concurrency:
   group: tofu-docs-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   docs:
     if: >-

--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/05/25 |
+| Readme update        | 2026/07/09 |
 
 
 
@@ -27,49 +27,49 @@
 
 | Var          | Type         | Value       |
 |--------------|--------------|-------------|
-| [docker_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L3)   | list | `[]` |    
-| [docker_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L4)   | str | `docker-ce` |    
-| [docker_packages.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L5)   | str | `docker-ce-cli` |    
-| [docker_packages.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L6)   | str | `containerd.io` |    
-| [docker_packages.**3**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L7)   | str | `docker-buildx-plugin` |    
-| [docker_packages.**4**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L8)   | str | `docker-compose-plugin` |    
-| [docker_prereq_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L10)   | list | `[]` |    
-| [docker_prereq_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L11)   | str | `ca-certificates` |    
-| [docker_prereq_packages.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L12)   | str | `curl` |    
-| [docker_apt_arch_map](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L14)   | dict | `{}` |    
-| [docker_apt_arch_map.**x86_64**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L15)   | str | `amd64` |    
-| [docker_apt_arch_map.**aarch64**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L16)   | str | `arm64` |    
-| [docker_apt_arch](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L18)   | str | `{{ docker_apt_arch_map[ansible_architecture] ¦ default(ansible_architecture) }}` |    
-| [docker_repo_url](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L20)   | str | `https://download.docker.com/linux/ubuntu` |    
-| [docker_repo_channel](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L21)   | str | `stable` |    
-| [docker_keyring_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L22)   | str | `/etc/apt/keyrings` |    
-| [docker_keyring_file](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L23)   | str | `/etc/apt/keyrings/docker.asc` |    
-| [docker_repo_filename](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L24)   | str | `docker` |    
-| [docker_install_compose_plugin](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L26)   | bool | `True` |    
-| [docker_manage_user](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L27)   | bool | `False` |    
-| [docker_user](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L28)   | str |  |    
-| [docker_network](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L30)   | str | `overlay` |    
-| [docker_network_driver](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L31)   | str | `overlay` |    
-| [docker_network_subnet](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L32)   | str | `172.98.0.0/24` |    
-| [docker_prune_threshold_percent](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L34)   | int | `80` |    
-| [docker_prune_filesystem_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L35)   | str | `/` |    
-| [docker_prune_until](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L36)   | str | `168h` |    
-| [docker_prune_images](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L38)   | bool | `True` |    
-| [docker_prune_containers](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L39)   | bool | `True` |    
-| [docker_prune_builder_cache](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L40)   | bool | `True` |    
-| [docker_prune_networks](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L41)   | bool | `False` |    
-| [docker_prune_volumes](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L42)   | bool | `False` |    
-| [docker_prune_manage_timer](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L44)   | bool | `True` |    
-| [docker_prune_timer_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L45)   | str | `docker-prune-safe` |    
-| [docker_prune_timer_on_calendar](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L46)   | str | `Sun *-*-* 04:30:00` |    
-| [docker_prune_timer_randomized_delay_sec](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L47)   | str | `1h` |    
-| [docker_prune_script_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L48)   | str | `/usr/local/sbin/docker-prune-safe` |    
-| [docker_prune_timer_min_usage_percent](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L52)   | int | `0` |    
-| [docker_prune_unraid_user_script_manage](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L54)   | bool | `True` |    
-| [docker_prune_unraid_user_script_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L55)   | str | `docker-prune-safe` |    
-| [docker_prune_unraid_user_scripts_root](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L56)   | str | `/boot/config/plugins/user.scripts/scripts` |    
-| [docker_prune_unraid_user_script_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L57)   | str | `{{ docker_prune_unraid_user_scripts_root }}/{{ docker_prune_unraid_user_script_name }}` |    
-| [docker_prune_unraid_user_script_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L58)   | str | `{{ docker_prune_unraid_user_script_dir }}/script` |    
+| [docker_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L3)   | list | `[]` |    
+| [docker_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L4)   | str | `docker-ce` |    
+| [docker_packages.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L5)   | str | `docker-ce-cli` |    
+| [docker_packages.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L6)   | str | `containerd.io` |    
+| [docker_packages.**3**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L7)   | str | `docker-buildx-plugin` |    
+| [docker_packages.**4**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L8)   | str | `docker-compose-plugin` |    
+| [docker_prereq_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L10)   | list | `[]` |    
+| [docker_prereq_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L11)   | str | `ca-certificates` |    
+| [docker_prereq_packages.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L12)   | str | `curl` |    
+| [docker_apt_arch_map](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L14)   | dict | `{}` |    
+| [docker_apt_arch_map.**x86_64**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L15)   | str | `amd64` |    
+| [docker_apt_arch_map.**aarch64**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L16)   | str | `arm64` |    
+| [docker_apt_arch](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L18)   | str | `{{ docker_apt_arch_map[ansible_architecture] ¦ default(ansible_architecture) }}` |    
+| [docker_repo_url](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L20)   | str | `https://download.docker.com/linux/ubuntu` |    
+| [docker_repo_channel](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L21)   | str | `stable` |    
+| [docker_keyring_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L22)   | str | `/etc/apt/keyrings` |    
+| [docker_keyring_file](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L23)   | str | `/etc/apt/keyrings/docker.asc` |    
+| [docker_repo_filename](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L24)   | str | `docker` |    
+| [docker_install_compose_plugin](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L26)   | bool | `True` |    
+| [docker_manage_user](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L27)   | bool | `False` |    
+| [docker_user](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L28)   | str |  |    
+| [docker_network](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L30)   | str | `overlay` |    
+| [docker_network_driver](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L31)   | str | `overlay` |    
+| [docker_network_subnet](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L32)   | str | `172.98.0.0/24` |    
+| [docker_prune_threshold_percent](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L34)   | int | `80` |    
+| [docker_prune_filesystem_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L35)   | str | `/` |    
+| [docker_prune_until](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L36)   | str | `168h` |    
+| [docker_prune_images](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L38)   | bool | `True` |    
+| [docker_prune_containers](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L39)   | bool | `True` |    
+| [docker_prune_builder_cache](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L40)   | bool | `True` |    
+| [docker_prune_networks](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L41)   | bool | `False` |    
+| [docker_prune_volumes](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L42)   | bool | `False` |    
+| [docker_prune_manage_timer](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L44)   | bool | `True` |    
+| [docker_prune_timer_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L45)   | str | `docker-prune-safe` |    
+| [docker_prune_timer_on_calendar](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L46)   | str | `Sun *-*-* 04:30:00` |    
+| [docker_prune_timer_randomized_delay_sec](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L47)   | str | `1h` |    
+| [docker_prune_script_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L48)   | str | `/usr/local/sbin/docker-prune-safe` |    
+| [docker_prune_timer_min_usage_percent](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L52)   | int | `0` |    
+| [docker_prune_unraid_user_script_manage](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L54)   | bool | `True` |    
+| [docker_prune_unraid_user_script_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L55)   | str | `docker-prune-safe` |    
+| [docker_prune_unraid_user_scripts_root](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L56)   | str | `/boot/config/plugins/user.scripts/scripts` |    
+| [docker_prune_unraid_user_script_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L57)   | str | `{{ docker_prune_unraid_user_scripts_root }}/{{ docker_prune_unraid_user_script_name }}` |    
+| [docker_prune_unraid_user_script_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L58)   | str | `{{ docker_prune_unraid_user_script_dir }}/script` |    
 
 
 

--- a/ansible/roles/docker_services/README.md
+++ b/ansible/roles/docker_services/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/06/30 |
+| Readme update        | 2026/07/09 |
 
 
 
@@ -27,54 +27,54 @@
 
 | Var          | Type         | Value       |
 |--------------|--------------|-------------|
-| [docker_services_default_deploy_profile](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L3)   | str | `none` |    
-| [docker_services_deploy_profiles](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L5)   | dict | `{}` |    
-| [docker_services_deploy_profiles.**none**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L6)   | dict | `{}` |    
-| [docker_services_deploy_profiles.**standard**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L8)   | dict | `{}` |    
-| [docker_services_deploy_profiles.standard.**restart_policy**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L9)   | dict | `{}` |    
-| [docker_services_deploy_profiles.standard.restart_policy.**condition**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L10)   | str | `on-failure` |    
-| [docker_services_deploy_profiles.standard.restart_policy.**delay**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L11)   | str | `10s` |    
-| [docker_services_deploy_profiles.standard.restart_policy.**max_attempts**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L12)   | int | `5` |    
-| [docker_services_deploy_profiles.standard.restart_policy.**window**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L13)   | str | `2m` |    
-| [docker_services_deploy_profiles.standard.**update_config**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L14)   | dict | `{}` |    
-| [docker_services_deploy_profiles.standard.update_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L15)   | int | `1` |    
-| [docker_services_deploy_profiles.standard.update_config.**delay**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L16)   | str | `10s` |    
-| [docker_services_deploy_profiles.standard.update_config.**failure_action**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L17)   | str | `rollback` |    
-| [docker_services_deploy_profiles.standard.update_config.**order**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L18)   | str | `stop-first` |    
-| [docker_services_deploy_profiles.standard.**rollback_config**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L19)   | dict | `{}` |    
-| [docker_services_deploy_profiles.standard.rollback_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L20)   | int | `1` |    
-| [docker_services_deploy_profiles.standard.rollback_config.**delay**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L21)   | str | `10s` |    
-| [docker_services_deploy_profiles.standard.rollback_config.**order**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L22)   | str | `stop-first` |    
-| [docker_services_deploy_profiles.**careful**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L24)   | dict | `{}` |    
-| [docker_services_deploy_profiles.careful.**restart_policy**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L25)   | dict | `{}` |    
-| [docker_services_deploy_profiles.careful.restart_policy.**condition**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L26)   | str | `on-failure` |    
-| [docker_services_deploy_profiles.careful.restart_policy.**delay**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L27)   | str | `10s` |    
-| [docker_services_deploy_profiles.careful.restart_policy.**max_attempts**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L28)   | int | `5` |    
-| [docker_services_deploy_profiles.careful.restart_policy.**window**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L29)   | str | `2m` |    
-| [docker_services_deploy_profiles.careful.**update_config**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L30)   | dict | `{}` |    
-| [docker_services_deploy_profiles.careful.update_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L31)   | int | `1` |    
-| [docker_services_deploy_profiles.careful.update_config.**delay**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L32)   | str | `30s` |    
-| [docker_services_deploy_profiles.careful.update_config.**failure_action**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L33)   | str | `rollback` |    
-| [docker_services_deploy_profiles.careful.update_config.**order**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L34)   | str | `stop-first` |    
-| [docker_services_deploy_profiles.careful.**rollback_config**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L35)   | dict | `{}` |    
-| [docker_services_deploy_profiles.careful.rollback_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L36)   | int | `1` |    
-| [docker_services_deploy_profiles.careful.rollback_config.**delay**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L37)   | str | `30s` |    
-| [docker_services_deploy_profiles.careful.rollback_config.**order**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L38)   | str | `stop-first` |    
-| [docker_services_deploy_profiles.**stateless_ha**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L40)   | dict | `{}` |    
-| [docker_services_deploy_profiles.stateless_ha.**restart_policy**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L41)   | dict | `{}` |    
-| [docker_services_deploy_profiles.stateless_ha.restart_policy.**condition**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L42)   | str | `on-failure` |    
-| [docker_services_deploy_profiles.stateless_ha.restart_policy.**delay**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L43)   | str | `5s` |    
-| [docker_services_deploy_profiles.stateless_ha.restart_policy.**max_attempts**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L44)   | int | `5` |    
-| [docker_services_deploy_profiles.stateless_ha.restart_policy.**window**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L45)   | str | `2m` |    
-| [docker_services_deploy_profiles.stateless_ha.**update_config**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L46)   | dict | `{}` |    
-| [docker_services_deploy_profiles.stateless_ha.update_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L47)   | int | `1` |    
-| [docker_services_deploy_profiles.stateless_ha.update_config.**delay**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L48)   | str | `5s` |    
-| [docker_services_deploy_profiles.stateless_ha.update_config.**failure_action**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L49)   | str | `rollback` |    
-| [docker_services_deploy_profiles.stateless_ha.update_config.**order**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L50)   | str | `start-first` |    
-| [docker_services_deploy_profiles.stateless_ha.**rollback_config**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L51)   | dict | `{}` |    
-| [docker_services_deploy_profiles.stateless_ha.rollback_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L52)   | int | `1` |    
-| [docker_services_deploy_profiles.stateless_ha.rollback_config.**delay**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L53)   | str | `5s` |    
-| [docker_services_deploy_profiles.stateless_ha.rollback_config.**order**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L54)   | str | `start-first` |    
+| [docker_services_default_deploy_profile](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L3)   | str | `none` |    
+| [docker_services_deploy_profiles](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L5)   | dict | `{}` |    
+| [docker_services_deploy_profiles.**none**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L6)   | dict | `{}` |    
+| [docker_services_deploy_profiles.**standard**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L8)   | dict | `{}` |    
+| [docker_services_deploy_profiles.standard.**restart_policy**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L9)   | dict | `{}` |    
+| [docker_services_deploy_profiles.standard.restart_policy.**condition**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L10)   | str | `on-failure` |    
+| [docker_services_deploy_profiles.standard.restart_policy.**delay**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L11)   | str | `10s` |    
+| [docker_services_deploy_profiles.standard.restart_policy.**max_attempts**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L12)   | int | `5` |    
+| [docker_services_deploy_profiles.standard.restart_policy.**window**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L13)   | str | `2m` |    
+| [docker_services_deploy_profiles.standard.**update_config**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L14)   | dict | `{}` |    
+| [docker_services_deploy_profiles.standard.update_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L15)   | int | `1` |    
+| [docker_services_deploy_profiles.standard.update_config.**delay**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L16)   | str | `10s` |    
+| [docker_services_deploy_profiles.standard.update_config.**failure_action**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L17)   | str | `rollback` |    
+| [docker_services_deploy_profiles.standard.update_config.**order**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L18)   | str | `stop-first` |    
+| [docker_services_deploy_profiles.standard.**rollback_config**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L19)   | dict | `{}` |    
+| [docker_services_deploy_profiles.standard.rollback_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L20)   | int | `1` |    
+| [docker_services_deploy_profiles.standard.rollback_config.**delay**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L21)   | str | `10s` |    
+| [docker_services_deploy_profiles.standard.rollback_config.**order**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L22)   | str | `stop-first` |    
+| [docker_services_deploy_profiles.**careful**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L24)   | dict | `{}` |    
+| [docker_services_deploy_profiles.careful.**restart_policy**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L25)   | dict | `{}` |    
+| [docker_services_deploy_profiles.careful.restart_policy.**condition**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L26)   | str | `on-failure` |    
+| [docker_services_deploy_profiles.careful.restart_policy.**delay**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L27)   | str | `10s` |    
+| [docker_services_deploy_profiles.careful.restart_policy.**max_attempts**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L28)   | int | `5` |    
+| [docker_services_deploy_profiles.careful.restart_policy.**window**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L29)   | str | `2m` |    
+| [docker_services_deploy_profiles.careful.**update_config**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L30)   | dict | `{}` |    
+| [docker_services_deploy_profiles.careful.update_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L31)   | int | `1` |    
+| [docker_services_deploy_profiles.careful.update_config.**delay**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L32)   | str | `30s` |    
+| [docker_services_deploy_profiles.careful.update_config.**failure_action**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L33)   | str | `rollback` |    
+| [docker_services_deploy_profiles.careful.update_config.**order**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L34)   | str | `stop-first` |    
+| [docker_services_deploy_profiles.careful.**rollback_config**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L35)   | dict | `{}` |    
+| [docker_services_deploy_profiles.careful.rollback_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L36)   | int | `1` |    
+| [docker_services_deploy_profiles.careful.rollback_config.**delay**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L37)   | str | `30s` |    
+| [docker_services_deploy_profiles.careful.rollback_config.**order**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L38)   | str | `stop-first` |    
+| [docker_services_deploy_profiles.**stateless_ha**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L40)   | dict | `{}` |    
+| [docker_services_deploy_profiles.stateless_ha.**restart_policy**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L41)   | dict | `{}` |    
+| [docker_services_deploy_profiles.stateless_ha.restart_policy.**condition**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L42)   | str | `on-failure` |    
+| [docker_services_deploy_profiles.stateless_ha.restart_policy.**delay**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L43)   | str | `5s` |    
+| [docker_services_deploy_profiles.stateless_ha.restart_policy.**max_attempts**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L44)   | int | `5` |    
+| [docker_services_deploy_profiles.stateless_ha.restart_policy.**window**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L45)   | str | `2m` |    
+| [docker_services_deploy_profiles.stateless_ha.**update_config**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L46)   | dict | `{}` |    
+| [docker_services_deploy_profiles.stateless_ha.update_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L47)   | int | `1` |    
+| [docker_services_deploy_profiles.stateless_ha.update_config.**delay**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L48)   | str | `5s` |    
+| [docker_services_deploy_profiles.stateless_ha.update_config.**failure_action**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L49)   | str | `rollback` |    
+| [docker_services_deploy_profiles.stateless_ha.update_config.**order**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L50)   | str | `start-first` |    
+| [docker_services_deploy_profiles.stateless_ha.**rollback_config**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L51)   | dict | `{}` |    
+| [docker_services_deploy_profiles.stateless_ha.rollback_config.**parallelism**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L52)   | int | `1` |    
+| [docker_services_deploy_profiles.stateless_ha.rollback_config.**delay**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L53)   | str | `5s` |    
+| [docker_services_deploy_profiles.stateless_ha.rollback_config.**order**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L54)   | str | `start-first` |    
 
 
 

--- a/ansible/roles/hugo/README.md
+++ b/ansible/roles/hugo/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/06/29 |
+| Readme update        | 2026/07/09 |
 
 
 
@@ -27,60 +27,60 @@
 
 | Var          | Type         | Value       |
 |--------------|--------------|-------------|
-| [hugo_fs_host](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L3)   | str | `{{ docker_services_primary_manager }}` |    
-| [hugo_root_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L4)   | str | `{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}` |    
-| [hugo_site_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L5)   | str | `{{ hugo_root_path }}/blog` |    
-| [hugo_theme_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L6)   | str | `{{ hugo_site_path }}/themes/terminal` |    
-| [hugo_image](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L7)   | str | `ghcr.io/gohugoio/hugo:v0.163.3` |    
-| [hugo_directory_paths](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L9)   | list | `[]` |    
-| [hugo_directory_paths.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L10)   | dict | `{}` |    
-| [hugo_directory_paths.0.**path**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L10)   | str | `{{ hugo_site_path }}` |    
-| [hugo_directory_paths.0.**state**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L11)   | str | `directory` |    
-| [hugo_directory_paths.0.**mode**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L12)   | str | `0755` |    
-| [hugo_directory_paths.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L13)   | dict | `{}` |    
-| [hugo_directory_paths.1.**path**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L13)   | str | `{{ hugo_site_path }}/.github` |    
-| [hugo_directory_paths.1.**state**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L14)   | str | `directory` |    
-| [hugo_directory_paths.1.**mode**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L15)   | str | `0755` |    
-| [hugo_directory_paths.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L16)   | dict | `{}` |    
-| [hugo_directory_paths.2.**path**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L16)   | str | `{{ hugo_site_path }}/.github/workflows` |    
-| [hugo_directory_paths.2.**state**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L17)   | str | `directory` |    
-| [hugo_directory_paths.2.**mode**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L18)   | str | `0755` |    
-| [hugo_copy_items](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L20)   | list | `[]` |    
-| [hugo_copy_items.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L21)   | dict | `{}` |    
-| [hugo_copy_items.0.**src**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L21)   | str | `files/favicon.png` |    
-| [hugo_copy_items.0.**dest**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L22)   | str | `{{ hugo_site_path }}/static/favicon.png` |    
-| [hugo_copy_items.0.**mode**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L23)   | str | `0664` |    
-| [hugo_copy_items.0.**force**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L24)   | bool | `False` |    
-| [hugo_copy_items.0.**wait**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L25)   | bool | `True` |    
-| [hugo_copy_items.0.**wait_timeout**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L26)   | int | `30` |    
-| [hugo_copy_items.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L27)   | dict | `{}` |    
-| [hugo_copy_items.1.**src**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L27)   | str | `files/og-image.png` |    
-| [hugo_copy_items.1.**dest**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L28)   | str | `{{ hugo_site_path }}/static/og-image.png` |    
-| [hugo_copy_items.1.**mode**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L29)   | str | `0664` |    
-| [hugo_copy_items.1.**force**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L30)   | bool | `False` |    
-| [hugo_copy_items.1.**wait**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L31)   | bool | `True` |    
-| [hugo_copy_items.1.**wait_timeout**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L32)   | int | `30` |    
-| [hugo_copy_items.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L33)   | dict | `{}` |    
-| [hugo_copy_items.2.**src**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L33)   | str | `files/terminal.css` |    
-| [hugo_copy_items.2.**dest**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L34)   | str | `{{ hugo_site_path }}/static/terminal.css` |    
-| [hugo_copy_items.2.**mode**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L35)   | str | `0664` |    
-| [hugo_copy_items.2.**force**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L36)   | bool | `False` |    
-| [hugo_copy_items.2.**wait**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L37)   | bool | `True` |    
-| [hugo_copy_items.2.**wait_timeout**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L38)   | int | `30` |    
-| [hugo_copy_items.**3**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L39)   | dict | `{}` |    
-| [hugo_copy_items.3.**src**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L39)   | str | `files/pages.yaml` |    
-| [hugo_copy_items.3.**dest**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L40)   | str | `{{ hugo_site_path }}/.github/workflows/hugo.yaml` |    
-| [hugo_copy_items.3.**mode**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L41)   | str | `0664` |    
-| [hugo_copy_items.3.**force**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L42)   | bool | `False` |    
-| [hugo_copy_items.3.**wait**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L43)   | bool | `True` |    
-| [hugo_copy_items.3.**wait_timeout**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L44)   | int | `30` |    
-| [hugo_templates](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L46)   | list | `[]` |    
-| [hugo_templates.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L47)   | dict | `{}` |    
-| [hugo_templates.0.**src**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L47)   | str | `hugo.yaml.j2` |    
-| [hugo_templates.0.**dest**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L48)   | str | `{{ hugo_site_path }}/hugo.yaml` |    
-| [hugo_templates.0.**mode**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L49)   | str | `0664` |    
-| [hugo_templates.0.**force**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L50)   | bool | `True` |    
-| [hugo_cloudflare_zone](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L52)   | str |  |    
+| [hugo_fs_host](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L3)   | str | `{{ docker_services_primary_manager }}` |    
+| [hugo_root_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L4)   | str | `{{ hostvars[docker_services_primary_manager].docker_host_appdata_root }}` |    
+| [hugo_site_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L5)   | str | `{{ hugo_root_path }}/blog` |    
+| [hugo_theme_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L6)   | str | `{{ hugo_site_path }}/themes/terminal` |    
+| [hugo_image](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L7)   | str | `ghcr.io/gohugoio/hugo:v0.163.3` |    
+| [hugo_directory_paths](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L9)   | list | `[]` |    
+| [hugo_directory_paths.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L10)   | dict | `{}` |    
+| [hugo_directory_paths.0.**path**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L10)   | str | `{{ hugo_site_path }}` |    
+| [hugo_directory_paths.0.**state**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L11)   | str | `directory` |    
+| [hugo_directory_paths.0.**mode**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L12)   | str | `0755` |    
+| [hugo_directory_paths.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L13)   | dict | `{}` |    
+| [hugo_directory_paths.1.**path**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L13)   | str | `{{ hugo_site_path }}/.github` |    
+| [hugo_directory_paths.1.**state**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L14)   | str | `directory` |    
+| [hugo_directory_paths.1.**mode**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L15)   | str | `0755` |    
+| [hugo_directory_paths.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L16)   | dict | `{}` |    
+| [hugo_directory_paths.2.**path**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L16)   | str | `{{ hugo_site_path }}/.github/workflows` |    
+| [hugo_directory_paths.2.**state**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L17)   | str | `directory` |    
+| [hugo_directory_paths.2.**mode**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L18)   | str | `0755` |    
+| [hugo_copy_items](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L20)   | list | `[]` |    
+| [hugo_copy_items.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L21)   | dict | `{}` |    
+| [hugo_copy_items.0.**src**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L21)   | str | `files/favicon.png` |    
+| [hugo_copy_items.0.**dest**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L22)   | str | `{{ hugo_site_path }}/static/favicon.png` |    
+| [hugo_copy_items.0.**mode**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L23)   | str | `0664` |    
+| [hugo_copy_items.0.**force**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L24)   | bool | `False` |    
+| [hugo_copy_items.0.**wait**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L25)   | bool | `True` |    
+| [hugo_copy_items.0.**wait_timeout**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L26)   | int | `30` |    
+| [hugo_copy_items.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L27)   | dict | `{}` |    
+| [hugo_copy_items.1.**src**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L27)   | str | `files/og-image.png` |    
+| [hugo_copy_items.1.**dest**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L28)   | str | `{{ hugo_site_path }}/static/og-image.png` |    
+| [hugo_copy_items.1.**mode**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L29)   | str | `0664` |    
+| [hugo_copy_items.1.**force**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L30)   | bool | `False` |    
+| [hugo_copy_items.1.**wait**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L31)   | bool | `True` |    
+| [hugo_copy_items.1.**wait_timeout**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L32)   | int | `30` |    
+| [hugo_copy_items.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L33)   | dict | `{}` |    
+| [hugo_copy_items.2.**src**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L33)   | str | `files/terminal.css` |    
+| [hugo_copy_items.2.**dest**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L34)   | str | `{{ hugo_site_path }}/static/terminal.css` |    
+| [hugo_copy_items.2.**mode**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L35)   | str | `0664` |    
+| [hugo_copy_items.2.**force**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L36)   | bool | `False` |    
+| [hugo_copy_items.2.**wait**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L37)   | bool | `True` |    
+| [hugo_copy_items.2.**wait_timeout**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L38)   | int | `30` |    
+| [hugo_copy_items.**3**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L39)   | dict | `{}` |    
+| [hugo_copy_items.3.**src**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L39)   | str | `files/pages.yaml` |    
+| [hugo_copy_items.3.**dest**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L40)   | str | `{{ hugo_site_path }}/.github/workflows/hugo.yaml` |    
+| [hugo_copy_items.3.**mode**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L41)   | str | `0664` |    
+| [hugo_copy_items.3.**force**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L42)   | bool | `False` |    
+| [hugo_copy_items.3.**wait**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L43)   | bool | `True` |    
+| [hugo_copy_items.3.**wait_timeout**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L44)   | int | `30` |    
+| [hugo_templates](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L46)   | list | `[]` |    
+| [hugo_templates.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L47)   | dict | `{}` |    
+| [hugo_templates.0.**src**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L47)   | str | `hugo.yaml.j2` |    
+| [hugo_templates.0.**dest**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L48)   | str | `{{ hugo_site_path }}/hugo.yaml` |    
+| [hugo_templates.0.**mode**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L49)   | str | `0664` |    
+| [hugo_templates.0.**force**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L50)   | bool | `True` |    
+| [hugo_cloudflare_zone](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L52)   | str |  |    
 
 
 

--- a/ansible/roles/infisical/README.md
+++ b/ansible/roles/infisical/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/06/26 |
+| Readme update        | 2026/07/09 |
 
 
 
@@ -27,63 +27,63 @@
 
 | Var          | Type         | Value       |
 |--------------|--------------|-------------|
-| [infisical_enc_key](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L9)   | str |  |    
-| [infisical_jwt_key](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L10)   | str |  |    
-| [infisical_postgres_user](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L11)   | str |  |    
-| [infisical_postgres_pass](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L12)   | str |  |    
-| [infisical_redis_password](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L13)   | str |  |    
-| [infisical_domain](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L14)   | str |  |    
-| [infisical_smtp_email](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L15)   | str |  |    
-| [infisical_smtp_user](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L16)   | str |  |    
-| [infisical_smtp_pass](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L17)   | str |  |    
-| [infisical_smtp_sender](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L18)   | str |  |    
-| [infisical_redis_required_docker_secrets](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L20)   | dict | `{}` |    
-| [infisical_redis_required_docker_secrets.**infisical_redis_password_secret**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L21)   | str | `{{ infisical_redis_password }}` |    
-| [infisical_redis_docker_secrets](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L23)   | str | `{{ infisical_redis_required_docker_secrets }}` |    
-| [infisical_redis_secrets_files_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L25)   | str | `{{ infisical_base_path }}/secrets` |    
-| [infisical_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L31)   | str | `infisical` |    
-| [infisical_stack](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L32)   | str | `infisical` |    
-| [infisical_compose_file](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L33)   | str | `infisical-compose.yml` |    
-| [infisical_compose_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L34)   | str | `{{ infisical_base_path }}/{{ infisical_compose_file }}` |    
-| [infisical_image](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L36)   | str | `docker.io/infisical/infisical:v0.161.8` |    
-| [infisical_timezone](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L37)   | str | `{{ timezone ¦ default('Australia/Melbourne') }}` |    
-| [infisical_puid](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L38)   | str | `{{ docker_host_puid ¦ default('1000') }}` |    
-| [infisical_pgid](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L39)   | str | `{{ docker_host_pgid ¦ default('1000') }}` |    
-| [infisical_port](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L40)   | int | `8066` |    
-| [infisical_base_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L41)   | str | `{{ docker_host_appdata_root ¦ default('/opt') }}/infisical` |    
-| [infisical_env_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L42)   | str | `{{ infisical_base_path }}/.env` |    
-| [infisical_smtp_host](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L44)   | str | `smtp.porkbun.com` |    
-| [infisical_smtp_port](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L45)   | int | `587` |    
-| [infisical_frontend_fqdn](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L47)   | str | `{{ infisical_name }}.int.{{ infisical_domain }}` |    
-| [infisical_frontend_address](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L48)   | str | `https://{{ infisical_frontend_fqdn }}:8443` |    
-| [infisical_backend_address](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L49)   | str | `http://{{ infisical_name }}:8080` |    
-| [infisical_docker_network](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L51)   | str | `overlay` |    
-| [infisical_logging](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L53)   | dict | `{}` |    
-| [infisical_logging.**driver**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L54)   | str | `json-file` |    
-| [infisical_logging.**options**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L55)   | dict | `{}` |    
-| [infisical_logging.options.**max-size**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L56)   | str | `50m` |    
-| [infisical_logging.options.**max-file**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L57)   | str | `5` |    
-| [infisical_logging.options.**compress**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L58)   | str | `true` |    
-| [infisical_restart_policy](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L60)   | str | `unless-stopped` |    
-| [infisical_redis_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L66)   | str | `infisical-redis` |    
-| [infisical_redis_image](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L67)   | str | `valkey/valkey:9.1-alpine` |    
-| [infisical_redis_puid](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L68)   | str | `{{ docker_host_puid ¦ default('1000') }}` |    
-| [infisical_redis_pgid](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L69)   | str | `{{ docker_host_pgid ¦ default('1000') }}` |    
-| [infisical_redis_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L70)   | str | `{{ infisical_base_path }}/redis` |    
-| [infisical_postgres_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L78)   | str | `haproxy` |    
-| [infisical_postgres_port](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L79)   | int | `5432` |    
-| [infisical_postgres_db_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L80)   | str | `infisical` |    
-| [infisical_traefik_enable](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L86)   | bool | `True` |    
-| [infisical_traefik_dynamic_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L87)   | str | `/opt/traefik/dynamic` |    
-| [infisical_traefik_entrypoint](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L88)   | str | `https_private` |    
-| [infisical_traefik_authelia_enable](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L89)   | bool | `False` |    
-| [infisical_traefik_crowdsec_enable](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L90)   | bool | `False` |    
-| [infisical_traefik_headers_middleware](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L91)   | str | `secure-headers@file` |    
-| [infisical_traefik_middleware_chain](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L92)   | str | `{{ infisical_name }}-ui-chain` |    
-| [infisical_traefik_certresolver](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L93)   | str | `dns-cloudflare` |    
-| [infisical_traefik_tls_options](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L94)   | str | `securetls@file` |    
-| [infisical_traefik_dynamic_owner](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L95)   | int | `1000` |    
-| [infisical_traefik_dynamic_group](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L96)   | int | `1000` |    
+| [infisical_enc_key](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L9)   | str |  |    
+| [infisical_jwt_key](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L10)   | str |  |    
+| [infisical_postgres_user](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L11)   | str |  |    
+| [infisical_postgres_pass](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L12)   | str |  |    
+| [infisical_redis_password](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L13)   | str |  |    
+| [infisical_domain](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L14)   | str |  |    
+| [infisical_smtp_email](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L15)   | str |  |    
+| [infisical_smtp_user](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L16)   | str |  |    
+| [infisical_smtp_pass](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L17)   | str |  |    
+| [infisical_smtp_sender](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L18)   | str |  |    
+| [infisical_redis_required_docker_secrets](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L20)   | dict | `{}` |    
+| [infisical_redis_required_docker_secrets.**infisical_redis_password_secret**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L21)   | str | `{{ infisical_redis_password }}` |    
+| [infisical_redis_docker_secrets](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L23)   | str | `{{ infisical_redis_required_docker_secrets }}` |    
+| [infisical_redis_secrets_files_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L25)   | str | `{{ infisical_base_path }}/secrets` |    
+| [infisical_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L31)   | str | `infisical` |    
+| [infisical_stack](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L32)   | str | `infisical` |    
+| [infisical_compose_file](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L33)   | str | `infisical-compose.yml` |    
+| [infisical_compose_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L34)   | str | `{{ infisical_base_path }}/{{ infisical_compose_file }}` |    
+| [infisical_image](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L36)   | str | `docker.io/infisical/infisical:v0.161.8` |    
+| [infisical_timezone](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L37)   | str | `{{ timezone ¦ default('Australia/Melbourne') }}` |    
+| [infisical_puid](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L38)   | str | `{{ docker_host_puid ¦ default('1000') }}` |    
+| [infisical_pgid](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L39)   | str | `{{ docker_host_pgid ¦ default('1000') }}` |    
+| [infisical_port](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L40)   | int | `8066` |    
+| [infisical_base_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L41)   | str | `{{ docker_host_appdata_root ¦ default('/opt') }}/infisical` |    
+| [infisical_env_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L42)   | str | `{{ infisical_base_path }}/.env` |    
+| [infisical_smtp_host](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L44)   | str | `smtp.porkbun.com` |    
+| [infisical_smtp_port](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L45)   | int | `587` |    
+| [infisical_frontend_fqdn](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L47)   | str | `{{ infisical_name }}.int.{{ infisical_domain }}` |    
+| [infisical_frontend_address](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L48)   | str | `https://{{ infisical_frontend_fqdn }}:8443` |    
+| [infisical_backend_address](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L49)   | str | `http://{{ infisical_name }}:8080` |    
+| [infisical_docker_network](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L51)   | str | `overlay` |    
+| [infisical_logging](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L53)   | dict | `{}` |    
+| [infisical_logging.**driver**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L54)   | str | `json-file` |    
+| [infisical_logging.**options**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L55)   | dict | `{}` |    
+| [infisical_logging.options.**max-size**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L56)   | str | `50m` |    
+| [infisical_logging.options.**max-file**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L57)   | str | `5` |    
+| [infisical_logging.options.**compress**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L58)   | str | `true` |    
+| [infisical_restart_policy](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L60)   | str | `unless-stopped` |    
+| [infisical_redis_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L66)   | str | `infisical-redis` |    
+| [infisical_redis_image](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L67)   | str | `valkey/valkey:9.1-alpine` |    
+| [infisical_redis_puid](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L68)   | str | `{{ docker_host_puid ¦ default('1000') }}` |    
+| [infisical_redis_pgid](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L69)   | str | `{{ docker_host_pgid ¦ default('1000') }}` |    
+| [infisical_redis_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L70)   | str | `{{ infisical_base_path }}/redis` |    
+| [infisical_postgres_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L78)   | str | `haproxy` |    
+| [infisical_postgres_port](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L79)   | int | `5432` |    
+| [infisical_postgres_db_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L80)   | str | `infisical` |    
+| [infisical_traefik_enable](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L86)   | bool | `True` |    
+| [infisical_traefik_dynamic_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L87)   | str | `/opt/traefik/dynamic` |    
+| [infisical_traefik_entrypoint](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L88)   | str | `https_private` |    
+| [infisical_traefik_authelia_enable](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L89)   | bool | `False` |    
+| [infisical_traefik_crowdsec_enable](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L90)   | bool | `False` |    
+| [infisical_traefik_headers_middleware](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L91)   | str | `secure-headers@file` |    
+| [infisical_traefik_middleware_chain](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L92)   | str | `{{ infisical_name }}-ui-chain` |    
+| [infisical_traefik_certresolver](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L93)   | str | `dns-cloudflare` |    
+| [infisical_traefik_tls_options](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L94)   | str | `securetls@file` |    
+| [infisical_traefik_dynamic_owner](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L95)   | int | `1000` |    
+| [infisical_traefik_dynamic_group](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L96)   | int | `1000` |    
 
 
 

--- a/ansible/roles/netbox/README.md
+++ b/ansible/roles/netbox/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/05/25 |
+| Readme update        | 2026/07/09 |
 
 
 
@@ -27,66 +27,66 @@
 
 | Var          | Type         | Value       |
 |--------------|--------------|-------------|
-| [netbox_superuser_email](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L9)   | str |  |    
-| [netbox_superuser_password](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L10)   | str |  |    
-| [netbox_postgres_user](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L11)   | str |  |    
-| [netbox_postgres_pass](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L12)   | str |  |    
-| [netbox_redis_password](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L13)   | str |  |    
-| [netbox_domain](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L14)   | str |  |    
-| [netbox_required_docker_secrets](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L16)   | dict | `{}` |    
-| [netbox_required_docker_secrets.**netbox_superuser_email_secret**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L17)   | str | `{{ netbox_superuser_email }}` |    
-| [netbox_required_docker_secrets.**netbox_superuser_password_secret**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L18)   | str | `{{ netbox_superuser_password }}` |    
-| [netbox_required_docker_secrets.**netbox_db_user_secret**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L19)   | str | `{{ netbox_postgres_user }}` |    
-| [netbox_required_docker_secrets.**netbox_db_password_secret**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L20)   | str | `{{ netbox_postgres_pass }}` |    
-| [netbox_required_docker_secrets.**netbox_redis_password_secret**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L21)   | str | `{{ netbox_redis_password }}` |    
-| [netbox_docker_secrets](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L23)   | str | `{{ netbox_required_docker_secrets }}` |    
-| [netbox_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L29)   | str | `netbox` |    
-| [netbox_stack](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L30)   | str | `netbox` |    
-| [netbox_compose_file](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L31)   | str | `netbox-compose.yml` |    
-| [netbox_compose_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L32)   | str | `{{ netbox_base_path }}/{{ netbox_compose_file }}` |    
-| [netbox_image](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L34)   | str | `lscr.io/linuxserver/netbox:v4.6.0-ls351` |    
-| [netbox_timezone](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L35)   | str | `{{ timezone ¦ default('Australia/Melbourne') }}` |    
-| [netbox_puid](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L36)   | str | `{{ docker_host_puid ¦ default('1000') }}` |    
-| [netbox_pgid](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L37)   | str | `{{ docker_host_pgid ¦ default('1000') }}` |    
-| [netbox_base_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L38)   | str | `{{ docker_host_appdata_root ¦ default('/opt') }}/netbox` |    
-| [netbox_frontend_fqdn](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L40)   | str | `{{ netbox_name }}.int.{{ netbox_domain }}` |    
-| [netbox_frontend_address](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L41)   | str | `https://{{ netbox_frontend_fqdn }}:8443` |    
-| [netbox_backend_address](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L42)   | str | `http://{{ netbox_name }}:8000` |    
-| [netbox_swarm_node_hostname](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L44)   | str | `{{ inventory_hostname }}` |    
-| [netbox_docker_network](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L45)   | str | `overlay` |    
-| [netbox_logging](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L47)   | dict | `{}` |    
-| [netbox_logging.**driver**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L48)   | str | `json-file` |    
-| [netbox_logging.**options**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L49)   | dict | `{}` |    
-| [netbox_logging.options.**max-size**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L50)   | str | `50m` |    
-| [netbox_logging.options.**max-file**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L51)   | str | `5` |    
-| [netbox_logging.options.**compress**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L52)   | str | `true` |    
-| [netbox_restart_policy](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L54)   | dict | `{}` |    
-| [netbox_restart_policy.**condition**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L55)   | str | `on-failure` |    
-| [netbox_restart_policy.**delay**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L56)   | str | `10s` |    
-| [netbox_restart_policy.**max_attempts**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L57)   | int | `5` |    
-| [netbox_restart_policy.**window**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L58)   | str | `2m` |    
-| [netbox_redis_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L64)   | str | `netbox-redis` |    
-| [netbox_redis_image](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L65)   | str | `valkey/valkey:9.1-alpine` |    
-| [netbox_redis_puid](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L66)   | str | `{{ docker_host_puid ¦ default('1000') }}` |    
-| [netbox_redis_pgid](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L67)   | str | `{{ docker_host_pgid ¦ default('1000') }}` |    
-| [netbox_redis_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L68)   | str | `{{ netbox_base_path }}/redis` |    
-| [netbox_postgres_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L74)   | str | `netbox-postgres` |    
-| [netbox_postgres_image](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L75)   | str | `docker.io/library/postgres:18.4` |    
-| [netbox_postgres_puid](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L76)   | str | `999` |    
-| [netbox_postgres_pgid](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L77)   | str | `999` |    
-| [netbox_postgres_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L78)   | str | `{{ netbox_base_path }}/postgres` |    
-| [netbox_postgres_db_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L79)   | str | `netbox` |    
-| [netbox_traefik_enable](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L85)   | bool | `True` |    
-| [netbox_traefik_dynamic_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L86)   | str | `/opt/traefik/dynamic` |    
-| [netbox_traefik_entrypoint](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L87)   | str | `https_private` |    
-| [netbox_traefik_authelia_enable](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L88)   | bool | `False` |    
-| [netbox_traefik_crowdsec_enable](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L89)   | bool | `False` |    
-| [netbox_traefik_headers_middleware](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L90)   | str | `netbox-headers@file` |    
-| [netbox_traefik_middleware_chain](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L91)   | str | `{{ netbox_name }}-ui-chain` |    
-| [netbox_traefik_certresolver](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L92)   | str | `dns-cloudflare` |    
-| [netbox_traefik_tls_options](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L93)   | str | `securetls@file` |    
-| [netbox_traefik_dynamic_owner](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L94)   | str | `1000` |    
-| [netbox_traefik_dynamic_group](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L95)   | str | `1000` |    
+| [netbox_superuser_email](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L9)   | str |  |    
+| [netbox_superuser_password](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L10)   | str |  |    
+| [netbox_postgres_user](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L11)   | str |  |    
+| [netbox_postgres_pass](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L12)   | str |  |    
+| [netbox_redis_password](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L13)   | str |  |    
+| [netbox_domain](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L14)   | str |  |    
+| [netbox_required_docker_secrets](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L16)   | dict | `{}` |    
+| [netbox_required_docker_secrets.**netbox_superuser_email_secret**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L17)   | str | `{{ netbox_superuser_email }}` |    
+| [netbox_required_docker_secrets.**netbox_superuser_password_secret**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L18)   | str | `{{ netbox_superuser_password }}` |    
+| [netbox_required_docker_secrets.**netbox_db_user_secret**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L19)   | str | `{{ netbox_postgres_user }}` |    
+| [netbox_required_docker_secrets.**netbox_db_password_secret**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L20)   | str | `{{ netbox_postgres_pass }}` |    
+| [netbox_required_docker_secrets.**netbox_redis_password_secret**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L21)   | str | `{{ netbox_redis_password }}` |    
+| [netbox_docker_secrets](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L23)   | str | `{{ netbox_required_docker_secrets }}` |    
+| [netbox_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L29)   | str | `netbox` |    
+| [netbox_stack](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L30)   | str | `netbox` |    
+| [netbox_compose_file](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L31)   | str | `netbox-compose.yml` |    
+| [netbox_compose_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L32)   | str | `{{ netbox_base_path }}/{{ netbox_compose_file }}` |    
+| [netbox_image](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L34)   | str | `lscr.io/linuxserver/netbox:v4.6.0-ls351` |    
+| [netbox_timezone](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L35)   | str | `{{ timezone ¦ default('Australia/Melbourne') }}` |    
+| [netbox_puid](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L36)   | str | `{{ docker_host_puid ¦ default('1000') }}` |    
+| [netbox_pgid](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L37)   | str | `{{ docker_host_pgid ¦ default('1000') }}` |    
+| [netbox_base_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L38)   | str | `{{ docker_host_appdata_root ¦ default('/opt') }}/netbox` |    
+| [netbox_frontend_fqdn](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L40)   | str | `{{ netbox_name }}.int.{{ netbox_domain }}` |    
+| [netbox_frontend_address](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L41)   | str | `https://{{ netbox_frontend_fqdn }}:8443` |    
+| [netbox_backend_address](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L42)   | str | `http://{{ netbox_name }}:8000` |    
+| [netbox_swarm_node_hostname](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L44)   | str | `{{ inventory_hostname }}` |    
+| [netbox_docker_network](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L45)   | str | `overlay` |    
+| [netbox_logging](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L47)   | dict | `{}` |    
+| [netbox_logging.**driver**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L48)   | str | `json-file` |    
+| [netbox_logging.**options**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L49)   | dict | `{}` |    
+| [netbox_logging.options.**max-size**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L50)   | str | `50m` |    
+| [netbox_logging.options.**max-file**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L51)   | str | `5` |    
+| [netbox_logging.options.**compress**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L52)   | str | `true` |    
+| [netbox_restart_policy](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L54)   | dict | `{}` |    
+| [netbox_restart_policy.**condition**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L55)   | str | `on-failure` |    
+| [netbox_restart_policy.**delay**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L56)   | str | `10s` |    
+| [netbox_restart_policy.**max_attempts**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L57)   | int | `5` |    
+| [netbox_restart_policy.**window**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L58)   | str | `2m` |    
+| [netbox_redis_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L64)   | str | `netbox-redis` |    
+| [netbox_redis_image](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L65)   | str | `valkey/valkey:9.1-alpine` |    
+| [netbox_redis_puid](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L66)   | str | `{{ docker_host_puid ¦ default('1000') }}` |    
+| [netbox_redis_pgid](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L67)   | str | `{{ docker_host_pgid ¦ default('1000') }}` |    
+| [netbox_redis_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L68)   | str | `{{ netbox_base_path }}/redis` |    
+| [netbox_postgres_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L74)   | str | `netbox-postgres` |    
+| [netbox_postgres_image](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L75)   | str | `docker.io/library/postgres:18.4` |    
+| [netbox_postgres_puid](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L76)   | str | `999` |    
+| [netbox_postgres_pgid](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L77)   | str | `999` |    
+| [netbox_postgres_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L78)   | str | `{{ netbox_base_path }}/postgres` |    
+| [netbox_postgres_db_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L79)   | str | `netbox` |    
+| [netbox_traefik_enable](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L85)   | bool | `True` |    
+| [netbox_traefik_dynamic_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L86)   | str | `/opt/traefik/dynamic` |    
+| [netbox_traefik_entrypoint](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L87)   | str | `https_private` |    
+| [netbox_traefik_authelia_enable](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L88)   | bool | `False` |    
+| [netbox_traefik_crowdsec_enable](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L89)   | bool | `False` |    
+| [netbox_traefik_headers_middleware](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L90)   | str | `netbox-headers@file` |    
+| [netbox_traefik_middleware_chain](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L91)   | str | `{{ netbox_name }}-ui-chain` |    
+| [netbox_traefik_certresolver](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L92)   | str | `dns-cloudflare` |    
+| [netbox_traefik_tls_options](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L93)   | str | `securetls@file` |    
+| [netbox_traefik_dynamic_owner](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L94)   | str | `1000` |    
+| [netbox_traefik_dynamic_group](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L95)   | str | `1000` |    
 
 
 

--- a/ansible/roles/node_exporter/README.md
+++ b/ansible/roles/node_exporter/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/06/30 |
+| Readme update        | 2026/07/09 |
 
 
 
@@ -27,19 +27,19 @@
 
 | Var          | Type         | Value       |
 |--------------|--------------|-------------|
-| [node_exporter_version](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L3)   | str | `1.10.1` |    
-| [node_exporter_arch](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L4)   | str | `amd64` |    
-| [node_exporter_user](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L5)   | str | `node_exporter` |    
-| [node_exporter_group](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L6)   | str | `node_exporter` |    
-| [node_exporter_install_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L8)   | str | `/usr/local/bin` |    
-| [node_exporter_textfile_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L9)   | str | `/var/lib/node_exporter/textfile_collector` |    
-| [node_exporter_listen_address](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L11)   | str | `0.0.0.0:9100` |    
-| [node_exporter_enabled_collectors](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L13)   | list | `[]` |    
-| [node_exporter_enabled_collectors.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L14)   | str | `systemd` |    
-| [node_exporter_enabled_collectors.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L15)   | str | `processes` |    
-| [node_exporter_enabled_collectors.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L16)   | str | `textfile` |    
-| [node_exporter_disabled_collectors](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L18)   | list | `[]` |    
-| [node_exporter_extra_args](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L20)   | list | `[]` |    
+| [node_exporter_version](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L3)   | str | `1.10.1` |    
+| [node_exporter_arch](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L4)   | str | `amd64` |    
+| [node_exporter_user](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L5)   | str | `node_exporter` |    
+| [node_exporter_group](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L6)   | str | `node_exporter` |    
+| [node_exporter_install_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L8)   | str | `/usr/local/bin` |    
+| [node_exporter_textfile_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L9)   | str | `/var/lib/node_exporter/textfile_collector` |    
+| [node_exporter_listen_address](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L11)   | str | `0.0.0.0:9100` |    
+| [node_exporter_enabled_collectors](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L13)   | list | `[]` |    
+| [node_exporter_enabled_collectors.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L14)   | str | `systemd` |    
+| [node_exporter_enabled_collectors.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L15)   | str | `processes` |    
+| [node_exporter_enabled_collectors.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L16)   | str | `textfile` |    
+| [node_exporter_disabled_collectors](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L18)   | list | `[]` |    
+| [node_exporter_extra_args](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L20)   | list | `[]` |    
 
 
 

--- a/ansible/roles/opentofu/README.md
+++ b/ansible/roles/opentofu/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/06/05 |
+| Readme update        | 2026/07/09 |
 
 
 
@@ -27,20 +27,20 @@
 
 | Var          | Type         | Value       |
 |--------------|--------------|-------------|
-| [opentofu_prereq_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L3)   | list | `[]` |    
-| [opentofu_prereq_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L4)   | str | `apt-transport-https` |    
-| [opentofu_prereq_packages.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L5)   | str | `ca-certificates` |    
-| [opentofu_prereq_packages.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L6)   | str | `curl` |    
-| [opentofu_prereq_packages.**3**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L7)   | str | `gnupg` |    
-| [opentofu_prereq_packages.**4**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L8)   | str | `software-properties-common` |    
-| [opentofu_source_url](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L10)   | str | `https://packages.opentofu.org/opentofu/tofu/any/` |    
-| [opentofu_source_suite](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L11)   | str | `any` |    
-| [opentofu_keyring_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L12)   | str | `/etc/apt/keyrings` |    
-| [opentofu_keyring_file](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L13)   | str | `/etc/apt/keyrings/opentofu.gpg` |    
-| [opentofu_keyring_file_repo](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L14)   | str | `/etc/apt/keyrings/opentofu-repo.gpg` |    
-| [opentofu_repo_filename](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L15)   | str | `opentofu` |    
-| [opentofu_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L17)   | list | `[]` |    
-| [opentofu_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L17)   | str | `tofu` |    
+| [opentofu_prereq_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L3)   | list | `[]` |    
+| [opentofu_prereq_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L4)   | str | `apt-transport-https` |    
+| [opentofu_prereq_packages.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L5)   | str | `ca-certificates` |    
+| [opentofu_prereq_packages.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L6)   | str | `curl` |    
+| [opentofu_prereq_packages.**3**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L7)   | str | `gnupg` |    
+| [opentofu_prereq_packages.**4**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L8)   | str | `software-properties-common` |    
+| [opentofu_source_url](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L10)   | str | `https://packages.opentofu.org/opentofu/tofu/any/` |    
+| [opentofu_source_suite](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L11)   | str | `any` |    
+| [opentofu_keyring_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L12)   | str | `/etc/apt/keyrings` |    
+| [opentofu_keyring_file](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L13)   | str | `/etc/apt/keyrings/opentofu.gpg` |    
+| [opentofu_keyring_file_repo](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L14)   | str | `/etc/apt/keyrings/opentofu-repo.gpg` |    
+| [opentofu_repo_filename](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L15)   | str | `opentofu` |    
+| [opentofu_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L17)   | list | `[]` |    
+| [opentofu_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L17)   | str | `tofu` |    
 
 
 

--- a/ansible/roles/postgres/README.md
+++ b/ansible/roles/postgres/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/05/25 |
+| Readme update        | 2026/07/09 |
 
 
 
@@ -27,43 +27,43 @@
 
 | Var          | Type         | Value       |
 |--------------|--------------|-------------|
-| [postgres_version](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L7)   | int | `18` |    
-| [postgres_etcd_data_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L13)   | str | `/var/lib/etcd` |    
-| [postgres_etcd_client_port](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L14)   | int | `2379` |    
-| [postgres_etcd_peer_port](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L15)   | int | `2380` |    
-| [postgres_etcd_cluster_token](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L16)   | str | `pg-ha-1` |    
-| [postgres_etcd_initial_cluster](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L18)   | list | `[]` |    
-| [postgres_patroni_scope](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L24)   | str | `pg-cluster` |    
-| [postgres_patroni_namespace](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L25)   | str | `/service` |    
-| [postgres_patroni_node_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L26)   | str | `{{ inventory_hostname }}` |    
-| [postgres_patroni_config_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L28)   | str | `/etc/patroni` |    
-| [postgres_patroni_config_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L29)   | str | `{{ postgres_patroni_config_dir }}/config.yml` |    
-| [postgres_patroni_data_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L30)   | str | `/var/lib/postgresql/{{ postgres_version }}/main` |    
-| [postgres_patroni_bin_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L31)   | str | `/usr/lib/postgresql/{{ postgres_version }}/bin` |    
-| [postgres_patroni_restapi_port](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L32)   | int | `8008` |    
-| [postgres_patroni_postgres_port](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L33)   | int | `5432` |    
-| [postgres_patroni_superuser_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L39)   | str | `postgres` |    
-| [postgres_patroni_superuser_pass](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L40)   | str |  |    
-| [postgres_patroni_replication_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L42)   | str | `replicator` |    
-| [postgres_patroni_replication_pass](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L43)   | str |  |    
-| [postgres_patroni_admin_role_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L45)   | str | `admin` |    
-| [postgres_patroni_admin_role_pass](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L46)   | str |  |    
-| [postgres_patroni_admin_role_login](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L47)   | bool | `True` |    
-| [postgres_patroni_admin_role_createdb](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L48)   | bool | `True` |    
-| [postgres_patroni_admin_role_createrole](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L49)   | bool | `False` |    
-| [postgres_patroni_etcd_hosts](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L51)   | list | `[]` |    
-| [postgres_patroni_pg_hba_extra](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L52)   | list | `[]` |    
-| [postgres_uptime_kuma_monitor_role_name](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L58)   | str | `uptime_kuma_monitor` |    
-| [postgres_uptime_kuma_monitor_role_pass](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L59)   | str |  |    
-| [postgres_uptime_kuma_monitor_database](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L60)   | str | `postgres` |    
-| [postgres_backup_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L72)   | str | `/tmp` |    
-| [postgres_backup_dbs](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L73)   | list | `[]` |    
-| [postgres_backup_dbs_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L74)   | str | `{{ postgres_backup_dir }}` |    
-| [postgres_backup_dbs_format](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L75)   | str | `custom` |    
-| [postgres_restore_dbs_dir](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L81)   | str | `/tmp` |    
-| [postgres_restore_dbs_drop_existing](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L82)   | bool | `True` |    
-| [postgres_restore_dbs_map](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L87)   | list | `[]` |    
-| [postgres_fix_owner_map](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L102)   | list | `[]` |    
+| [postgres_version](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L7)   | int | `18` |    
+| [postgres_etcd_data_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L13)   | str | `/var/lib/etcd` |    
+| [postgres_etcd_client_port](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L14)   | int | `2379` |    
+| [postgres_etcd_peer_port](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L15)   | int | `2380` |    
+| [postgres_etcd_cluster_token](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L16)   | str | `pg-ha-1` |    
+| [postgres_etcd_initial_cluster](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L18)   | list | `[]` |    
+| [postgres_patroni_scope](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L24)   | str | `pg-cluster` |    
+| [postgres_patroni_namespace](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L25)   | str | `/service` |    
+| [postgres_patroni_node_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L26)   | str | `{{ inventory_hostname }}` |    
+| [postgres_patroni_config_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L28)   | str | `/etc/patroni` |    
+| [postgres_patroni_config_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L29)   | str | `{{ postgres_patroni_config_dir }}/config.yml` |    
+| [postgres_patroni_data_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L30)   | str | `/var/lib/postgresql/{{ postgres_version }}/main` |    
+| [postgres_patroni_bin_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L31)   | str | `/usr/lib/postgresql/{{ postgres_version }}/bin` |    
+| [postgres_patroni_restapi_port](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L32)   | int | `8008` |    
+| [postgres_patroni_postgres_port](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L33)   | int | `5432` |    
+| [postgres_patroni_superuser_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L39)   | str | `postgres` |    
+| [postgres_patroni_superuser_pass](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L40)   | str |  |    
+| [postgres_patroni_replication_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L42)   | str | `replicator` |    
+| [postgres_patroni_replication_pass](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L43)   | str |  |    
+| [postgres_patroni_admin_role_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L45)   | str | `admin` |    
+| [postgres_patroni_admin_role_pass](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L46)   | str |  |    
+| [postgres_patroni_admin_role_login](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L47)   | bool | `True` |    
+| [postgres_patroni_admin_role_createdb](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L48)   | bool | `True` |    
+| [postgres_patroni_admin_role_createrole](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L49)   | bool | `False` |    
+| [postgres_patroni_etcd_hosts](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L51)   | list | `[]` |    
+| [postgres_patroni_pg_hba_extra](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L52)   | list | `[]` |    
+| [postgres_uptime_kuma_monitor_role_name](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L58)   | str | `uptime_kuma_monitor` |    
+| [postgres_uptime_kuma_monitor_role_pass](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L59)   | str |  |    
+| [postgres_uptime_kuma_monitor_database](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L60)   | str | `postgres` |    
+| [postgres_backup_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L72)   | str | `/tmp` |    
+| [postgres_backup_dbs](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L73)   | list | `[]` |    
+| [postgres_backup_dbs_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L74)   | str | `{{ postgres_backup_dir }}` |    
+| [postgres_backup_dbs_format](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L75)   | str | `custom` |    
+| [postgres_restore_dbs_dir](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L81)   | str | `/tmp` |    
+| [postgres_restore_dbs_drop_existing](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L82)   | bool | `True` |    
+| [postgres_restore_dbs_map](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L87)   | list | `[]` |    
+| [postgres_fix_owner_map](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L102)   | list | `[]` |    
 
 
 

--- a/ansible/roles/postgres/tasks/sub_tasks/admin/fix_owner.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/admin/fix_owner.yml
@@ -28,7 +28,7 @@
     label: "{{ item.db | default('undefined-db') }}"
 
 - name: Fix DB owner | Query Patroni cluster state from first postgres node
-  #checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
+  # checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
   ansible.builtin.uri:
     url: "http://{{ hostvars[groups['tags_postgres'][0]].local_ip }}:{{ postgres_patroni_restapi_port }}/cluster"
     method: GET

--- a/ansible/roles/postgres/tasks/sub_tasks/admin/pg_admin.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/admin/pg_admin.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Query Patroni cluster state from first postgres node
-  #checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
+  # checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
   ansible.builtin.uri:
     url: "http://{{ hostvars[groups['tags_postgres'][0]].local_ip }}:{{ postgres_patroni_restapi_port }}/cluster"
     method: GET

--- a/ansible/roles/postgres/tasks/sub_tasks/admin/pg_hba.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/admin/pg_hba.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Patroni dynamic pg_hba | Query Patroni cluster state from first postgres node
-  #checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
+  # checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
   ansible.builtin.uri:
     url: "http://{{ hostvars[groups['tags_postgres'][0]].local_ip }}:{{ postgres_patroni_restapi_port }}/cluster"
     method: GET
@@ -76,7 +76,7 @@
   delegate_to: "{{ docker_services_primary_manager }}"
 
 - name: Patroni dynamic pg_hba | Read current dynamic config from leader
-  #checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
+  # checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
   ansible.builtin.uri:
     url: "http://{{ postgres_patroni_leader_member.host }}:{{ postgres_patroni_restapi_port }}/config"
     method: GET
@@ -99,7 +99,7 @@
   delegate_to: "{{ docker_services_primary_manager }}"
 
 - name: Patroni dynamic pg_hba | Patch DCS config with desired pg_hba
-  #checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
+  # checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
   ansible.builtin.uri:
     url: "http://{{ postgres_patroni_leader_member.host }}:{{ postgres_patroni_restapi_port }}/config"
     method: PATCH

--- a/ansible/roles/postgres/tasks/sub_tasks/backup.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/backup.yml
@@ -10,7 +10,7 @@
       You must provide postgres_backup_dbs as a non-empty list.
 
 - name: Backup DBs | Query Patroni cluster state from first postgres node
-  #checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
+  # checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
   ansible.builtin.uri:
     url: "http://{{ hostvars[groups['tags_postgres'][0]].local_ip }}:{{ postgres_patroni_restapi_port }}/cluster"
     method: GET

--- a/ansible/roles/postgres/tasks/sub_tasks/restore.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/restore.yml
@@ -28,7 +28,7 @@
     label: "{{ item.db | default('undefined-db') }}"
 
 - name: Restore DBs | Query Patroni cluster state from first postgres node
-  #checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
+  # checkov:skip=CKV2_ANSIBLE_1:Internal homelab service endpoint over trusted management network
   ansible.builtin.uri:
     url: "http://{{ hostvars[groups['tags_postgres'][0]].local_ip }}:{{ postgres_patroni_restapi_port }}/cluster"
     method: GET

--- a/ansible/roles/ubuntu/README.md
+++ b/ansible/roles/ubuntu/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/06/17 |
+| Readme update        | 2026/07/09 |
 
 
 
@@ -27,134 +27,134 @@
 
 | Var          | Type         | Value       |
 |--------------|--------------|-------------|
-| [ubuntu_apt_base_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L3)   | list | `[]` |    
-| [ubuntu_apt_base_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L4)   | str | `python3` |    
-| [ubuntu_apt_base_packages.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L5)   | str | `python3-apt` |    
-| [ubuntu_apt_base_packages.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L6)   | str | `ca-certificates` |    
-| [ubuntu_apt_base_packages.**3**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L7)   | str | `apt-utils` |    
-| [ubuntu_apt_common_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L9)   | list | `[]` |    
-| [ubuntu_apt_common_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L10)   | str | `curl` |    
-| [ubuntu_apt_common_packages.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L11)   | str | `wget` |    
-| [ubuntu_apt_common_packages.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L12)   | str | `git` |    
-| [ubuntu_apt_common_packages.**3**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L13)   | str | `jq` |    
-| [ubuntu_apt_common_packages.**4**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L14)   | str | `rsync` |    
-| [ubuntu_apt_common_packages.**5**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L15)   | str | `logrotate` |    
-| [ubuntu_apt_common_packages.**6**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L16)   | str | `nano` |    
-| [ubuntu_apt_common_packages.**7**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L17)   | str | `unzip` |    
-| [ubuntu_apt_common_packages.**8**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L18)   | str | `tree` |    
-| [ubuntu_apt_common_packages.**9**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L19)   | str | `lsof` |    
-| [ubuntu_apt_python_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L21)   | list | `[]` |    
-| [ubuntu_apt_python_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L22)   | str | `python3-pip` |    
-| [ubuntu_apt_python_packages.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L23)   | str | `python3-venv` |    
-| [ubuntu_apt_build_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L25)   | list | `[]` |    
-| [ubuntu_apt_build_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L26)   | str | `build-essential` |    
-| [ubuntu_apt_build_packages.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L27)   | str | `python3-dev` |    
-| [ubuntu_apt_build_packages.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L28)   | str | `gcc` |    
-| [ubuntu_apt_build_packages.**3**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L29)   | str | `g++` |    
-| [ubuntu_apt_build_packages.**4**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L30)   | str | `make` |    
-| [ubuntu_apt_admin_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L32)   | list | `[]` |    
-| [ubuntu_apt_admin_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L33)   | str | `zip` |    
-| [ubuntu_apt_admin_packages.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L34)   | str | `p7zip-full` |    
-| [ubuntu_apt_admin_packages.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L35)   | str | `argon2` |    
-| [ubuntu_apt_admin_packages.**3**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L36)   | str | `pwgen` |    
-| [ubuntu_apt_admin_packages.**4**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L37)   | str | `htop` |    
-| [ubuntu_apt_admin_packages.**5**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L38)   | str | `iotop` |    
-| [ubuntu_apt_admin_packages.**6**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L39)   | str | `nload` |    
-| [ubuntu_apt_admin_packages.**7**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L40)   | str | `ncdu` |    
-| [ubuntu_apt_admin_packages.**8**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L41)   | str | `mc` |    
-| [ubuntu_apt_admin_packages.**9**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L42)   | str | `dnsutils` |    
-| [ubuntu_apt_admin_packages.**10**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L43)   | str | `screen` |    
-| [ubuntu_apt_admin_packages.**11**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L44)   | str | `tmux` |    
-| [ubuntu_apt_admin_packages.**12**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L45)   | str | `apache2-utils` |    
-| [ubuntu_apt_admin_packages.**13**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L46)   | str | `moreutils` |    
-| [ubuntu_apt_admin_packages.**14**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L47)   | str | `man-db` |    
-| [ubuntu_apt_admin_packages.**15**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L48)   | str | `unrar-free` |    
-| [ubuntu_apt_network_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L50)   | list | `[]` |    
-| [ubuntu_apt_network_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L51)   | str | `vnstat` |    
-| [ubuntu_apt_network_packages.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L52)   | str | `pciutils` |    
-| [ubuntu_apt_network_packages.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L53)   | str | `ethtool` |    
-| [ubuntu_apt_firewall_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L55)   | list | `[]` |    
-| [ubuntu_apt_firewall_packages.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L56)   | str | `ufw` |    
-| [ubuntu_apt_docker_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L58)   | list | `[]` |    
-| [ubuntu_apt_swarm_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L59)   | list | `[]` |    
-| [ubuntu_apt_haproxy_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L60)   | list | `[]` |    
-| [ubuntu_apt_opentofu_packages](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L61)   | list | `[]` |    
-| [ubuntu_apt_env_vars](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L63)   | dict | `{}` |    
-| [ubuntu_apt_env_vars.**DEBIAN_FRONTEND**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L64)   | str | `noninteractive` |    
-| [ubuntu_apt_env_vars.**DEBIAN_PRIORITY**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L65)   | str | `critical` |    
-| [ubuntu_ansible_repo_root](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L67)   | str | `/opt` |    
-| [ubuntu_ansible_repo_dirname](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L68)   | str | `homelab` |    
-| [ubuntu_ansible_repo_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L69)   | str | `{{ ubuntu_ansible_repo_root }}/{{ ubuntu_ansible_repo_dirname }}` |    
-| [ubuntu_ansible_dirname](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L70)   | str | `ansible` |    
-| [ubuntu_ansible_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L71)   | str | `{{ ubuntu_ansible_repo_path }}/{{ ubuntu_ansible_dirname }}` |    
-| [ubuntu_manage_repo_clone](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L73)   | bool | `True` |    
-| [ubuntu_repo_url](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L74)   | str | `https://github.com/Lebowski89/homelab.git` |    
-| [ubuntu_repo_version](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L75)   | str | `main` |    
-| [ubuntu_ansible_opt_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L77)   | str | `/opt/ansible` |    
-| [ubuntu_ansible_venv_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L78)   | str | `{{ ubuntu_ansible_opt_path }}/ansible-venv` |    
-| [ubuntu_ansible_secrets_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L79)   | str | `{{ ubuntu_ansible_opt_path }}/.secrets` |    
-| [ubuntu_ansible_become_pass_file](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L80)   | str | `{{ ubuntu_ansible_secrets_path }}/.ansible_become_pass` |    
-| [ubuntu_ansible_vault_pass_file](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L81)   | str | `{{ ubuntu_ansible_secrets_path }}/.ansible_vault_pass` |    
-| [ubuntu_skynet_install](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L83)   | bool | `True` |    
-| [ubuntu_skynet_install_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L84)   | str | `/usr/local/bin/skynet` |    
-| [ubuntu_skynet_doctor_ping_target](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L85)   | str | `tags_skynet` |    
-| [ubuntu_skynet_docker_services_vars](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L86)   | str | `{{ ubuntu_ansible_path }}/group_vars/all/docker_services.yml` |    
-| [ubuntu_sysctl_file](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L88)   | str | `/etc/sysctl.d/99-ubuntu-tuning.conf` |    
-| [ubuntu_sysctl_settings](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L90)   | dict | `{}` |    
-| [ubuntu_sysctl_settings.fs.inotify.**max_user_watches**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L91)   | int | `524288` |    
-| [ubuntu_sysctl_settings.net.core.**default_qdisc**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L92)   | str | `fq` |    
-| [ubuntu_sysctl_settings.net.core.**netdev_budget**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L93)   | int | `50000` |    
-| [ubuntu_sysctl_settings.net.core.**netdev_max_backlog**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L94)   | int | `100000` |    
-| [ubuntu_sysctl_settings.net.core.**rmem_max**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L95)   | int | `67108864` |    
-| [ubuntu_sysctl_settings.net.core.**somaxconn**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L96)   | int | `4096` |    
-| [ubuntu_sysctl_settings.net.core.**wmem_max**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L97)   | int | `67108864` |    
-| [ubuntu_sysctl_settings.net.ipv4.conf.all.**accept_redirects**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L98)   | int | `0` |    
-| [ubuntu_sysctl_settings.net.ipv4.conf.all.**accept_source_route**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L99)   | int | `0` |    
-| [ubuntu_sysctl_settings.net.ipv4.conf.all.**secure_redirects**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L100)   | int | `0` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_adv_win_scale**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L101)   | int | `2` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_congestion_control**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L102)   | str | `bbr` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_fin_timeout**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L103)   | int | `10` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_max_syn_backlog**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L104)   | int | `30000` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_max_tw_buckets**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L105)   | int | `2000000` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_mtu_probing**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L106)   | int | `1` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_rfc1337**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L107)   | int | `1` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_rmem**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L108)   | str | `4096 87380 33554432` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_sack**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L109)   | int | `1` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_slow_start_after_idle**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L110)   | int | `0` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_tw_reuse**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L111)   | int | `2` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_window_scaling**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L112)   | int | `1` |    
-| [ubuntu_sysctl_settings.net.ipv4.**tcp_wmem**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L113)   | str | `4096 87380 33554432` |    
-| [ubuntu_sysctl_settings.net.ipv4.**udp_rmem_min**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L114)   | int | `8192` |    
-| [ubuntu_sysctl_settings.net.ipv4.**udp_wmem_min**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L115)   | int | `8192` |    
-| [ubuntu_sysctl_settings.vm.**dirty_background_ratio**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L116)   | int | `10` |    
-| [ubuntu_sysctl_settings.vm.**dirty_ratio**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L117)   | int | `15` |    
-| [ubuntu_sysctl_settings.vm.**swappiness**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L118)   | int | `10` |    
-| [ubuntu_sysctl_settings.net.ipv4.neigh.default.**gc_thresh1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L119)   | int | `1024` |    
-| [ubuntu_sysctl_settings.net.ipv4.neigh.default.**gc_thresh2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L120)   | int | `2048` |    
-| [ubuntu_sysctl_settings.net.ipv4.neigh.default.**gc_thresh3**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L121)   | int | `4096` |    
-| [ubuntu_pam_limits](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L123)   | list | `[]` |    
-| [ubuntu_pam_limits.**0**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L124)   | dict | `{}` |    
-| [ubuntu_pam_limits.0.**domain**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L124)   | str | `*` |    
-| [ubuntu_pam_limits.0.**limit_type**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L125)   | str | `-` |    
-| [ubuntu_pam_limits.0.**limit_item**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L126)   | str | `nofile` |    
-| [ubuntu_pam_limits.0.**value**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L127)   | str | `100000` |    
-| [ubuntu_pam_limits.**1**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L128)   | dict | `{}` |    
-| [ubuntu_pam_limits.1.**domain**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L128)   | str | `*` |    
-| [ubuntu_pam_limits.1.**limit_type**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L129)   | str | `soft` |    
-| [ubuntu_pam_limits.1.**limit_item**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L130)   | str | `memlock` |    
-| [ubuntu_pam_limits.1.**value**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L131)   | str | `unlimited` |    
-| [ubuntu_pam_limits.**2**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L132)   | dict | `{}` |    
-| [ubuntu_pam_limits.2.**domain**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L132)   | str | `*` |    
-| [ubuntu_pam_limits.2.**limit_type**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L133)   | str | `hard` |    
-| [ubuntu_pam_limits.2.**limit_item**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L134)   | str | `memlock` |    
-| [ubuntu_pam_limits.2.**value**](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L135)   | str | `unlimited` |    
-| [ubuntu_defaults_netplan_config](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L137)   | str | `netplan-config.yaml` |    
-| [ubuntu_netplan_config_path](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L138)   | str | `/etc/netplan/{{ ubuntu_defaults_netplan_config }}` |    
-| [ubuntu_defaults_netplan_gateway](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L140)   | str | `<multiline value: folded_strip>` |    
-| [ubuntu_defaults_netplan_nameservers](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L147)   | str | `<multiline value: folded_strip>` |    
-| [ubuntu_netplan_prefix](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L157)   | int | `24` |    
-| [ubuntu_nic_tuning_enabled](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L159)   | bool | `True` |    
-| [ubuntu_vnstat_enabled](https://github.com/Lebowski89/homelab/blob/main/defaults/main.yml#L160)   | bool | `True` |    
+| [ubuntu_apt_base_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L3)   | list | `[]` |    
+| [ubuntu_apt_base_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L4)   | str | `python3` |    
+| [ubuntu_apt_base_packages.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L5)   | str | `python3-apt` |    
+| [ubuntu_apt_base_packages.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L6)   | str | `ca-certificates` |    
+| [ubuntu_apt_base_packages.**3**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L7)   | str | `apt-utils` |    
+| [ubuntu_apt_common_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L9)   | list | `[]` |    
+| [ubuntu_apt_common_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L10)   | str | `curl` |    
+| [ubuntu_apt_common_packages.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L11)   | str | `wget` |    
+| [ubuntu_apt_common_packages.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L12)   | str | `git` |    
+| [ubuntu_apt_common_packages.**3**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L13)   | str | `jq` |    
+| [ubuntu_apt_common_packages.**4**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L14)   | str | `rsync` |    
+| [ubuntu_apt_common_packages.**5**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L15)   | str | `logrotate` |    
+| [ubuntu_apt_common_packages.**6**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L16)   | str | `nano` |    
+| [ubuntu_apt_common_packages.**7**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L17)   | str | `unzip` |    
+| [ubuntu_apt_common_packages.**8**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L18)   | str | `tree` |    
+| [ubuntu_apt_common_packages.**9**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L19)   | str | `lsof` |    
+| [ubuntu_apt_python_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L21)   | list | `[]` |    
+| [ubuntu_apt_python_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L22)   | str | `python3-pip` |    
+| [ubuntu_apt_python_packages.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L23)   | str | `python3-venv` |    
+| [ubuntu_apt_build_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L25)   | list | `[]` |    
+| [ubuntu_apt_build_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L26)   | str | `build-essential` |    
+| [ubuntu_apt_build_packages.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L27)   | str | `python3-dev` |    
+| [ubuntu_apt_build_packages.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L28)   | str | `gcc` |    
+| [ubuntu_apt_build_packages.**3**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L29)   | str | `g++` |    
+| [ubuntu_apt_build_packages.**4**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L30)   | str | `make` |    
+| [ubuntu_apt_admin_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L32)   | list | `[]` |    
+| [ubuntu_apt_admin_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L33)   | str | `zip` |    
+| [ubuntu_apt_admin_packages.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L34)   | str | `p7zip-full` |    
+| [ubuntu_apt_admin_packages.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L35)   | str | `argon2` |    
+| [ubuntu_apt_admin_packages.**3**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L36)   | str | `pwgen` |    
+| [ubuntu_apt_admin_packages.**4**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L37)   | str | `htop` |    
+| [ubuntu_apt_admin_packages.**5**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L38)   | str | `iotop` |    
+| [ubuntu_apt_admin_packages.**6**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L39)   | str | `nload` |    
+| [ubuntu_apt_admin_packages.**7**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L40)   | str | `ncdu` |    
+| [ubuntu_apt_admin_packages.**8**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L41)   | str | `mc` |    
+| [ubuntu_apt_admin_packages.**9**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L42)   | str | `dnsutils` |    
+| [ubuntu_apt_admin_packages.**10**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L43)   | str | `screen` |    
+| [ubuntu_apt_admin_packages.**11**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L44)   | str | `tmux` |    
+| [ubuntu_apt_admin_packages.**12**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L45)   | str | `apache2-utils` |    
+| [ubuntu_apt_admin_packages.**13**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L46)   | str | `moreutils` |    
+| [ubuntu_apt_admin_packages.**14**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L47)   | str | `man-db` |    
+| [ubuntu_apt_admin_packages.**15**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L48)   | str | `unrar-free` |    
+| [ubuntu_apt_network_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L50)   | list | `[]` |    
+| [ubuntu_apt_network_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L51)   | str | `vnstat` |    
+| [ubuntu_apt_network_packages.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L52)   | str | `pciutils` |    
+| [ubuntu_apt_network_packages.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L53)   | str | `ethtool` |    
+| [ubuntu_apt_firewall_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L55)   | list | `[]` |    
+| [ubuntu_apt_firewall_packages.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L56)   | str | `ufw` |    
+| [ubuntu_apt_docker_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L58)   | list | `[]` |    
+| [ubuntu_apt_swarm_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L59)   | list | `[]` |    
+| [ubuntu_apt_haproxy_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L60)   | list | `[]` |    
+| [ubuntu_apt_opentofu_packages](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L61)   | list | `[]` |    
+| [ubuntu_apt_env_vars](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L63)   | dict | `{}` |    
+| [ubuntu_apt_env_vars.**DEBIAN_FRONTEND**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L64)   | str | `noninteractive` |    
+| [ubuntu_apt_env_vars.**DEBIAN_PRIORITY**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L65)   | str | `critical` |    
+| [ubuntu_ansible_repo_root](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L67)   | str | `/opt` |    
+| [ubuntu_ansible_repo_dirname](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L68)   | str | `homelab` |    
+| [ubuntu_ansible_repo_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L69)   | str | `{{ ubuntu_ansible_repo_root }}/{{ ubuntu_ansible_repo_dirname }}` |    
+| [ubuntu_ansible_dirname](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L70)   | str | `ansible` |    
+| [ubuntu_ansible_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L71)   | str | `{{ ubuntu_ansible_repo_path }}/{{ ubuntu_ansible_dirname }}` |    
+| [ubuntu_manage_repo_clone](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L73)   | bool | `True` |    
+| [ubuntu_repo_url](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L74)   | str | `https://github.com/Lebowski89/homelab.git` |    
+| [ubuntu_repo_version](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L75)   | str | `main` |    
+| [ubuntu_ansible_opt_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L77)   | str | `/opt/ansible` |    
+| [ubuntu_ansible_venv_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L78)   | str | `{{ ubuntu_ansible_opt_path }}/ansible-venv` |    
+| [ubuntu_ansible_secrets_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L79)   | str | `{{ ubuntu_ansible_opt_path }}/.secrets` |    
+| [ubuntu_ansible_become_pass_file](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L80)   | str | `{{ ubuntu_ansible_secrets_path }}/.ansible_become_pass` |    
+| [ubuntu_ansible_vault_pass_file](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L81)   | str | `{{ ubuntu_ansible_secrets_path }}/.ansible_vault_pass` |    
+| [ubuntu_skynet_install](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L83)   | bool | `True` |    
+| [ubuntu_skynet_install_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L84)   | str | `/usr/local/bin/skynet` |    
+| [ubuntu_skynet_doctor_ping_target](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L85)   | str | `tags_skynet` |    
+| [ubuntu_skynet_docker_services_vars](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L86)   | str | `{{ ubuntu_ansible_path }}/group_vars/all/docker_services.yml` |    
+| [ubuntu_sysctl_file](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L88)   | str | `/etc/sysctl.d/99-ubuntu-tuning.conf` |    
+| [ubuntu_sysctl_settings](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L90)   | dict | `{}` |    
+| [ubuntu_sysctl_settings.fs.inotify.**max_user_watches**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L91)   | int | `524288` |    
+| [ubuntu_sysctl_settings.net.core.**default_qdisc**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L92)   | str | `fq` |    
+| [ubuntu_sysctl_settings.net.core.**netdev_budget**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L93)   | int | `50000` |    
+| [ubuntu_sysctl_settings.net.core.**netdev_max_backlog**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L94)   | int | `100000` |    
+| [ubuntu_sysctl_settings.net.core.**rmem_max**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L95)   | int | `67108864` |    
+| [ubuntu_sysctl_settings.net.core.**somaxconn**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L96)   | int | `4096` |    
+| [ubuntu_sysctl_settings.net.core.**wmem_max**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L97)   | int | `67108864` |    
+| [ubuntu_sysctl_settings.net.ipv4.conf.all.**accept_redirects**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L98)   | int | `0` |    
+| [ubuntu_sysctl_settings.net.ipv4.conf.all.**accept_source_route**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L99)   | int | `0` |    
+| [ubuntu_sysctl_settings.net.ipv4.conf.all.**secure_redirects**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L100)   | int | `0` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_adv_win_scale**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L101)   | int | `2` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_congestion_control**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L102)   | str | `bbr` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_fin_timeout**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L103)   | int | `10` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_max_syn_backlog**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L104)   | int | `30000` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_max_tw_buckets**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L105)   | int | `2000000` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_mtu_probing**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L106)   | int | `1` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_rfc1337**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L107)   | int | `1` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_rmem**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L108)   | str | `4096 87380 33554432` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_sack**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L109)   | int | `1` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_slow_start_after_idle**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L110)   | int | `0` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_tw_reuse**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L111)   | int | `2` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_window_scaling**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L112)   | int | `1` |    
+| [ubuntu_sysctl_settings.net.ipv4.**tcp_wmem**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L113)   | str | `4096 87380 33554432` |    
+| [ubuntu_sysctl_settings.net.ipv4.**udp_rmem_min**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L114)   | int | `8192` |    
+| [ubuntu_sysctl_settings.net.ipv4.**udp_wmem_min**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L115)   | int | `8192` |    
+| [ubuntu_sysctl_settings.vm.**dirty_background_ratio**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L116)   | int | `10` |    
+| [ubuntu_sysctl_settings.vm.**dirty_ratio**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L117)   | int | `15` |    
+| [ubuntu_sysctl_settings.vm.**swappiness**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L118)   | int | `10` |    
+| [ubuntu_sysctl_settings.net.ipv4.neigh.default.**gc_thresh1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L119)   | int | `1024` |    
+| [ubuntu_sysctl_settings.net.ipv4.neigh.default.**gc_thresh2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L120)   | int | `2048` |    
+| [ubuntu_sysctl_settings.net.ipv4.neigh.default.**gc_thresh3**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L121)   | int | `4096` |    
+| [ubuntu_pam_limits](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L123)   | list | `[]` |    
+| [ubuntu_pam_limits.**0**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L124)   | dict | `{}` |    
+| [ubuntu_pam_limits.0.**domain**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L124)   | str | `*` |    
+| [ubuntu_pam_limits.0.**limit_type**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L125)   | str | `-` |    
+| [ubuntu_pam_limits.0.**limit_item**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L126)   | str | `nofile` |    
+| [ubuntu_pam_limits.0.**value**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L127)   | str | `100000` |    
+| [ubuntu_pam_limits.**1**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L128)   | dict | `{}` |    
+| [ubuntu_pam_limits.1.**domain**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L128)   | str | `*` |    
+| [ubuntu_pam_limits.1.**limit_type**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L129)   | str | `soft` |    
+| [ubuntu_pam_limits.1.**limit_item**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L130)   | str | `memlock` |    
+| [ubuntu_pam_limits.1.**value**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L131)   | str | `unlimited` |    
+| [ubuntu_pam_limits.**2**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L132)   | dict | `{}` |    
+| [ubuntu_pam_limits.2.**domain**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L132)   | str | `*` |    
+| [ubuntu_pam_limits.2.**limit_type**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L133)   | str | `hard` |    
+| [ubuntu_pam_limits.2.**limit_item**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L134)   | str | `memlock` |    
+| [ubuntu_pam_limits.2.**value**](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L135)   | str | `unlimited` |    
+| [ubuntu_defaults_netplan_config](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L137)   | str | `netplan-config.yaml` |    
+| [ubuntu_netplan_config_path](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L138)   | str | `/etc/netplan/{{ ubuntu_defaults_netplan_config }}` |    
+| [ubuntu_defaults_netplan_gateway](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L140)   | str | `<multiline value: folded_strip>` |    
+| [ubuntu_defaults_netplan_nameservers](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L147)   | str | `<multiline value: folded_strip>` |    
+| [ubuntu_netplan_prefix](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L157)   | int | `24` |    
+| [ubuntu_nic_tuning_enabled](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L159)   | bool | `True` |    
+| [ubuntu_vnstat_enabled](https://github.com/Lebowski89/homelab/blob/feat/github-repo-governance/defaults/main.yml#L160)   | bool | `True` |    
 
 
 

--- a/docs/cheat_sheets/git-history-cheatsheet.md
+++ b/docs/cheat_sheets/git-history-cheatsheet.md
@@ -1,0 +1,597 @@
+# Git History Cleanup Cheat Sheet
+
+A practical checklist for cleaning up a noisy Git history with interactive rebases, batching, backup branches, and force-push verification.
+
+> Assumption: you are the solo maintainer or you have coordinated with collaborators. This rewrites `main` history.
+
+---
+
+## Golden Rules
+
+- Do not run `git pull` during a history rewrite.
+- Use `git push --force-with-lease origin main`, not plain `--force`.
+- Create a `backup/before-batch-N` branch before each batch.
+- Verify the final file tree is unchanged before pushing.
+- During conflicts, do **not** use `git add .`; add only the specific resolved files.
+- Ignore untracked generated folders such as `.ansible/`, `ansible/`, or `terraform/` unless you intentionally created them and know they belong in Git.
+- The actual `git-rebase-todo` can differ from a generated `git log --reverse` list. Edit the real todo Git opens.
+- In an interactive rebase, `ours` means the already-rebased current state; `theirs` means the commit currently being replayed.
+
+---
+
+## One-Time Editor Setup
+
+Use Nano for reliability:
+
+```bash
+git config --global core.editor "nano"
+```
+
+Or override per command:
+
+```bash
+GIT_EDITOR=nano git rebase -i <range>
+```
+
+For VS Code:
+
+```bash
+git config --global core.editor "code --wait"
+```
+
+---
+
+## Verify Current State Before Starting a Batch
+
+```bash
+git fetch origin
+
+git rev-parse HEAD
+git rev-parse origin/main
+
+git status --short
+```
+
+`HEAD` and `origin/main` should match before starting the next batch.
+
+If you just completed a batch, verify the final tree matches the backup:
+
+```bash
+git diff backup/before-batch-N..HEAD --stat
+
+git rev-parse backup/before-batch-N^{tree}
+git rev-parse HEAD^{tree}
+```
+
+The diff should be empty. The tree hashes should match.
+
+---
+
+## Create the Next Batch Boundary
+
+After batch `N` is complete, use its backup branch to find the oldest cleaned commit from that batch:
+
+```bash
+BOUNDARY="$(git log --reverse --format='%H' backup/before-batch-N..HEAD | head -n 1)"
+echo "$BOUNDARY"
+git show -s --oneline "$BOUNDARY"
+```
+
+Then create the next backup branch:
+
+```bash
+git branch backup/before-batch-$((N + 1))
+```
+
+If the branch may already exist:
+
+```bash
+git show-ref --verify --quiet refs/heads/backup/before-batch-$((N + 1)) || git branch backup/before-batch-$((N + 1))
+```
+
+---
+
+## Generate Prep Files for Review
+
+Normal batch:
+
+```bash
+BATCH_SIZE=120
+
+git log --reverse --no-merges --format='pick %h %s' "$BOUNDARY"~$BATCH_SIZE.."$BOUNDARY" > /tmp/batchNEXT-picks.txt
+
+git log --reverse --no-merges --name-status --oneline "$BOUNDARY"~$BATCH_SIZE.."$BOUNDARY" > /tmp/batchNEXT-files.txt
+
+cat /tmp/batchNEXT-picks.txt
+```
+
+Upload or inspect both files:
+
+```text
+/tmp/batchNEXT-picks.txt
+/tmp/batchNEXT-files.txt
+```
+
+The `picks` file shows commit order. The `files` file shows what each commit actually changed, which makes grouping much safer.
+
+---
+
+## When You Are Near the Root Commit
+
+If this fails:
+
+```bash
+git log --reverse --no-merges --format='pick %h %s' "$BOUNDARY"~120.."$BOUNDARY"
+```
+
+with:
+
+```text
+fatal: ambiguous argument '<hash>~120..<hash>'
+```
+
+then there are not 120 parents behind that commit. Use a root batch.
+
+Generate root prep files:
+
+```bash
+git log --reverse --no-merges --format='pick %h %s' "$BOUNDARY" > /tmp/batchNEXT-picks.txt
+
+git log --reverse --no-merges --name-status --oneline "$BOUNDARY" > /tmp/batchNEXT-files.txt
+
+cat /tmp/batchNEXT-picks.txt
+```
+
+Start root rebase:
+
+```bash
+git rebase -i --root
+```
+
+In the actual todo, edit only the old/root section and leave the already-cleaned commits unchanged.
+
+---
+
+## Start the Actual Interactive Rebase
+
+Normal batch:
+
+```bash
+git rebase -i "$BOUNDARY"~$BATCH_SIZE
+```
+
+Root batch:
+
+```bash
+git rebase -i --root
+```
+
+When Git opens the todo, save the actual todo somewhere if needed:
+
+```bash
+cat .git/rebase-merge/git-rebase-todo > /tmp/actual-git-rebase-todo.txt
+```
+
+View progress:
+
+```bash
+git status
+cat .git/rebase-merge/done
+cat .git/rebase-merge/git-rebase-todo
+```
+
+Edit the todo during an active rebase:
+
+```bash
+git rebase --edit-todo
+```
+
+---
+
+## Todo Editing Pattern
+
+Typical squash group:
+
+```text
+reword abc1234 meaningful first commit in group
+fixup def5678 small follow-up
+fixup 1112223 linting
+fixup 3334445 fixes
+```
+
+Use:
+
+- `reword` for the first commit in a logical group, so you can write a clean final message.
+- `fixup` for noisy follow-ups, linting, formatting, dependency pin noise, and repair commits.
+- `pick` for commits that should remain separate or for already-cleaned history.
+- Avoid changing order unless necessary; grouping contiguous commits is safer.
+
+---
+
+## Reword Message Style
+
+Examples:
+
+```text
+feat(ansible): add Docker and Ubuntu roles
+refactor(docker_services): restructure service helper tasks
+fix(docker_services): stabilize swarm config templating
+chore(maintenance): update service and runtime pins
+docs(ansible): regenerate role documentation
+ci(ansible): tighten linting and workflow paths
+```
+
+Good prefixes:
+
+```text
+feat
+fix
+refactor
+chore
+docs
+ci
+```
+
+---
+
+## Continue Through Reword Prompts
+
+After saving the todo, Git will stop at each `reword` commit. Replace the commit message with the prepared message, save, and continue.
+
+If you need to amend manually:
+
+```bash
+git commit --amend
+```
+
+Then:
+
+```bash
+git rebase --continue
+```
+
+---
+
+## Conflict Triage
+
+When Git stops:
+
+```bash
+git status --short --untracked-files=no
+git show --stat --oneline REBASE_HEAD
+```
+
+This tells you which commit is being replayed and which tracked files are conflicted.
+
+After resolving a conflict:
+
+```bash
+git add path/to/resolved-file.yml
+git rebase --continue
+```
+
+Never use this during conflicts:
+
+```bash
+git add .
+```
+
+---
+
+## Ours vs Theirs During Rebase
+
+During a rebase:
+
+```bash
+# keep already-rebased current state
+git checkout --ours path/to/file
+
+# take the commit currently being replayed
+git checkout --theirs path/to/file
+```
+
+Then:
+
+```bash
+git add path/to/file
+git rebase --continue
+```
+
+Use this carefully. Do not blindly take one side for a large file unless you know that is correct.
+
+---
+
+## Skipping Duplicate Commits
+
+Sometimes a duplicate commit collides with changes already included in an earlier squash group.
+
+Inspect first:
+
+```bash
+git show --stat --oneline REBASE_HEAD
+git status --short --untracked-files=no
+```
+
+If it is clearly duplicate noise already represented in the squashed result:
+
+```bash
+git rebase --skip
+```
+
+After the whole batch finishes, verify with:
+
+```bash
+git diff backup/before-batch-N..HEAD --stat
+```
+
+If the diff is empty, the skip did not change the final tree.
+
+---
+
+## Empty Commit During Fixup
+
+You may see:
+
+```text
+You asked to amend the most recent commit, but doing so would make it empty.
+```
+
+This often happens with early README churn or add/remove/re-add sequences.
+
+If the next fixup will re-add or complete the logical commit, allow the temporary empty state:
+
+```bash
+git commit --amend --allow-empty --no-edit
+git rebase --continue
+```
+
+If the commit is truly redundant and should disappear:
+
+```bash
+git rebase --skip
+```
+
+---
+
+## Abort a Batch
+
+Abort the active rebase:
+
+```bash
+git rebase --abort
+```
+
+Check you are back to the pre-rebase state:
+
+```bash
+git status --short
+git diff backup/before-batch-N..HEAD --stat
+```
+
+---
+
+## Recover From a Bad Batch
+
+Reset to the backup branch:
+
+```bash
+git reset --hard backup/before-batch-N
+```
+
+Or inspect reflog:
+
+```bash
+git reflog --date=local --oneline | head -50
+```
+
+Reset to a known good reflog entry:
+
+```bash
+git reset --hard <hash>
+```
+
+---
+
+## Final Batch Verification
+
+After the rebase completes:
+
+```bash
+git status --short
+
+git diff backup/before-batch-N..HEAD --stat
+
+git rev-parse backup/before-batch-N^{tree}
+git rev-parse HEAD^{tree}
+```
+
+Expected:
+
+- `git diff ... --stat` is empty.
+- Tree hashes match.
+- No tracked changes in `git status --short`.
+
+Untracked generated folders can be ignored or removed if you are sure they are not needed:
+
+```bash
+rm -rf .ansible ansible terraform
+```
+
+Only do that if they are truly generated leftovers and not real project files in your current tree.
+
+---
+
+## Push Rewritten Main
+
+```bash
+git push --force-with-lease origin main
+```
+
+Verify:
+
+```bash
+git fetch origin
+
+git rev-parse HEAD
+git rev-parse origin/main
+```
+
+The two hashes should match.
+
+Count commits:
+
+```bash
+git rev-list --count HEAD
+```
+
+Show recent cleaned history:
+
+```bash
+git log --oneline --decorate -40
+```
+
+---
+
+## Useful Inspection Commands
+
+Show branch graph:
+
+```bash
+git log --oneline --decorate --graph --all -40
+```
+
+Show oldest commits:
+
+```bash
+git log --reverse --oneline | head -50
+```
+
+Show newest commits:
+
+```bash
+git log --oneline -50
+```
+
+Show changed files in a commit:
+
+```bash
+git show --stat --oneline <commit>
+```
+
+Show name-status changes in a range:
+
+```bash
+git log --reverse --no-merges --name-status --oneline <range>
+```
+
+Find root commit:
+
+```bash
+git rev-list --max-parents=0 --oneline HEAD
+```
+
+Count commits behind a boundary:
+
+```bash
+git rev-list --count "$BOUNDARY"
+```
+
+---
+
+## Standard Batch Template
+
+Replace `N` and `NEXT`.
+
+```bash
+# verify current state
+git fetch origin
+git rev-parse HEAD
+git rev-parse origin/main
+git status --short
+git diff backup/before-batch-N..HEAD --stat
+
+# find boundary from previous batch
+BOUNDARY="$(git log --reverse --format='%H' backup/before-batch-N..HEAD | head -n 1)"
+echo "$BOUNDARY"
+git show -s --oneline "$BOUNDARY"
+
+# backup before next rewrite
+git branch backup/before-batch-NEXT
+
+# prep files
+BATCH_SIZE=120
+
+git log --reverse --no-merges --format='pick %h %s' "$BOUNDARY"~$BATCH_SIZE.."$BOUNDARY" > /tmp/batchNEXT-picks.txt
+
+git log --reverse --no-merges --name-status --oneline "$BOUNDARY"~$BATCH_SIZE.."$BOUNDARY" > /tmp/batchNEXT-files.txt
+
+cat /tmp/batchNEXT-picks.txt
+
+# actual rebase
+git rebase -i "$BOUNDARY"~$BATCH_SIZE
+
+# after rebase
+git status --short
+git diff backup/before-batch-NEXT..HEAD --stat
+git rev-parse backup/before-batch-NEXT^{tree}
+git rev-parse HEAD^{tree}
+
+# push
+git push --force-with-lease origin main
+
+# verify remote
+git fetch origin
+git rev-parse HEAD
+git rev-parse origin/main
+git rev-list --count HEAD
+```
+
+---
+
+## Standard Root Batch Template
+
+Use when `BOUNDARY~BATCH_SIZE` does not exist.
+
+```bash
+# verify current state
+git fetch origin
+git rev-parse HEAD
+git rev-parse origin/main
+git status --short
+
+# find boundary from previous batch
+BOUNDARY="$(git log --reverse --format='%H' backup/before-batch-N..HEAD | head -n 1)"
+echo "$BOUNDARY"
+git show -s --oneline "$BOUNDARY"
+
+git rev-list --count "$BOUNDARY"
+git rev-list --max-parents=0 --oneline "$BOUNDARY"
+
+# backup
+git branch backup/before-batch-NEXT
+
+# prep root section
+git log --reverse --no-merges --format='pick %h %s' "$BOUNDARY" > /tmp/batchNEXT-picks.txt
+
+git log --reverse --no-merges --name-status --oneline "$BOUNDARY" > /tmp/batchNEXT-files.txt
+
+cat /tmp/batchNEXT-picks.txt
+
+# actual root rebase
+git rebase -i --root
+
+# after rebase
+git status --short
+git diff backup/before-batch-NEXT..HEAD --stat
+git rev-parse backup/before-batch-NEXT^{tree}
+git rev-parse HEAD^{tree}
+
+# push
+git push --force-with-lease origin main
+
+# verify
+git fetch origin
+git rev-parse HEAD
+git rev-parse origin/main
+git rev-list --count HEAD
+```

--- a/docs/cheat_sheets/git-history-cheatsheet.md
+++ b/docs/cheat_sheets/git-history-cheatsheet.md
@@ -13,7 +13,7 @@ A practical checklist for cleaning up a noisy Git history with interactive rebas
 - Create a `backup/before-batch-N` branch before each batch.
 - Verify the final file tree is unchanged before pushing.
 - During conflicts, do **not** use `git add .`; add only the specific resolved files.
-- Ignore untracked generated folders such as `.ansible/`, `ansible/`, or `terraform/` unless you intentionally created them and know they belong in Git.
+- Ignore untracked generated folders, such as `.ansible/`, unless you intentionally created them and know they belong in Git.
 - The actual `git-rebase-todo` can differ from a generated `git log --reverse` list. Edit the real todo Git opens.
 - In an interactive rebase, `ours` means the already-rebased current state; `theirs` means the commit currently being replayed.
 
@@ -414,7 +414,7 @@ Expected:
 Untracked generated folders can be ignored or removed if you are sure they are not needed:
 
 ```bash
-rm -rf .ansible ansible terraform
+rm -rf .ansible
 ```
 
 Only do that if they are truly generated leftovers and not real project files in your current tree.
@@ -516,7 +516,7 @@ echo "$BOUNDARY"
 git show -s --oneline "$BOUNDARY"
 
 # backup before next rewrite
-git branch backup/before-batch-NEXT
+git show-ref --verify --quiet refs/heads/backup/before-batch-NEXT || git branch backup/before-batch-NEXT
 
 # prep files
 BATCH_SIZE=120
@@ -568,7 +568,7 @@ git rev-list --count "$BOUNDARY"
 git rev-list --max-parents=0 --oneline "$BOUNDARY"
 
 # backup
-git branch backup/before-batch-NEXT
+git show-ref --verify --quiet refs/heads/backup/before-batch-NEXT || git branch backup/before-batch-NEXT
 
 # prep root section
 git log --reverse --no-merges --format='pick %h %s' "$BOUNDARY" > /tmp/batchNEXT-picks.txt

--- a/renovate.json
+++ b/renovate.json
@@ -72,8 +72,7 @@
                 "module"
             ],
             "groupName": "terraform providers and modules",
-            "labels": [
-                "renovate",
+            "addLabels": [
                 "terraform"
             ]
         },
@@ -92,8 +91,7 @@
             "matchManagers": [
                 "terraform"
             ],
-            "labels": [
-                "renovate",
+            "addLabels": [
                 "terraform"
             ]
         },
@@ -113,12 +111,11 @@
                 "major"
             ],
             "dependencyDashboardApproval": true,
-            "labels": [
-                "renovate",
+            "prPriority": 20,
+            "addLabels": [
                 "docker",
                 "major"
-            ],
-            "prPriority": 20
+            ]
         },
         {
             "description": "Delay Docker minor updates a little longer",
@@ -129,12 +126,11 @@
                 "minor"
             ],
             "minimumReleaseAge": "7 days",
-            "labels": [
-                "renovate",
+            "prPriority": 0,
+            "addLabels": [
                 "docker",
                 "minor"
-            ],
-            "prPriority": 0
+            ]
         },
         {
             "description": "Label Docker patch updates",
@@ -145,12 +141,11 @@
                 "patch"
             ],
             "minimumReleaseAge": "3 days",
-            "labels": [
-                "renovate",
+            "prPriority": -1,
+            "addLabels": [
                 "docker",
                 "patch"
-            ],
-            "prPriority": -1
+            ]
         },
         {
             "description": "Weekly batch for non-critical Docker minor/patch updates",
@@ -168,12 +163,35 @@
             ],
             "minimumGroupSize": 2,
             "separateMinorPatch": false,
-            "labels": [
-                "renovate",
+            "prPriority": -5,
+            "addLabels": [
                 "docker",
                 "batch"
             ],
-            "prPriority": -5
+            "excludePackageNames": [
+                "postgres",
+                "docker.io/library/postgres",
+                "redis",
+                "docker.io/library/redis",
+                "valkey/valkey",
+                "traefik",
+                "docker.io/library/traefik",
+                "authelia/authelia",
+                "docker.io/infisical/infisical",
+                "infisical/infisical",
+                "netboxcommunity/netbox",
+                "lscr.io/linuxserver/netbox",
+                "lscr.io/linuxserver/plex",
+                "prom/prometheus",
+                "grafana/grafana",
+                "grafana/loki",
+                "grafana/alloy",
+                "haproxy",
+                "docker.io/library/haproxy",
+                "cloudflare/cloudflared",
+                "crowdsecurity/crowdsec",
+                "portainer/portainer-ce"
+            ]
         },
         {
             "description": "Keep critical infrastructure and database images separate",
@@ -205,12 +223,10 @@
                 "portainer/portainer-ce"
             ],
             "groupName": null,
-            "labels": [
-                "renovate",
+            "addLabels": [
                 "docker",
                 "critical"
-            ],
-            "prPriority": 5
+            ]
         },
         {
             "description": "Use target version in Traefik branch names",
@@ -224,13 +240,10 @@
             "branchTopic": "{{{depNameSanitized}}}-{{{newVersion}}}",
             "separateMinorPatch": false,
             "groupName": null,
-            "labels": [
-                "renovate",
-                "docker",
-                "critical",
+            "prPriority": 10,
+            "addLabels": [
                 "traefik"
-            ],
-            "prPriority": 10
+            ]
         },
         {
             "description": "Hotio release-v semver tags",
@@ -291,8 +304,7 @@
                 "lscr.io/linuxserver/plex"
             ],
             "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-            "labels": [
-                "renovate",
+            "addLabels": [
                 "docker",
                 "plex"
             ]
@@ -340,8 +352,7 @@
             ],
             "groupName": "python package patch updates",
             "groupSlug": "python-package-patch",
-            "labels": [
-                "renovate",
+            "addLabels": [
                 "python",
                 "patch"
             ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,373 +1,350 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "timezone": "Australia/Melbourne",
-  "dependencyDashboard": true,
-  "labels": [
-    "renovate"
-  ],
-  "prConcurrentLimit": 8,
-  "prHourlyLimit": 2,
-  "rangeStrategy": "pin",
-  "semanticCommits": "enabled",
-  "semanticCommitType": "chore",
-  "semanticCommitScope": "deps",
-  "commitBodyTable": true,
-  "minimumReleaseAge": "3 days",
-  "separateMajorMinor": true,
-  "separateMinorPatch": true,
-  "prBodyNotes": [
-    "Homelab note: review upstream release notes/changelog before merging."
-  ],
-  "lockFileMaintenance": {
-    "enabled": true,
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-      "schedule:monthly"
+        "config:recommended"
+    ],
+    "timezone": "Australia/Melbourne",
+    "dependencyDashboard": true,
+    "labels": [
+        "renovate"
+    ],
+    "ignorePaths": [
+        "**/node_modules/**",
+        "**/bower_components/**",
+        "**/vendor/**",
+        "**/examples/**",
+        "**/fixtures/**",
+        "**/collections/**",
+        "**/ansible/collections/**",
+        "**/.ansible/**"
+    ],
+    "prConcurrentLimit": 5,
+    "prHourlyLimit": 1,
+    "branchConcurrentLimit": 5,
+    "rangeStrategy": "pin",
+    "semanticCommits": "enabled",
+    "semanticCommitType": "chore",
+    "semanticCommitScope": "deps",
+    "commitBodyTable": true,
+    "minimumReleaseAge": "3 days",
+    "separateMajorMinor": true,
+    "separateMinorPatch": true,
+    "prBodyNotes": [
+        "Homelab note: review upstream release notes/changelog before merging."
+    ],
+    "lockFileMaintenance": {
+        "enabled": true,
+        "extends": [
+            "schedule:monthly"
+        ]
+    },
+    "customManagers": [
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/\\.ya?ml$/"
+            ],
+            "matchStrings": [
+                "image:\\s*[\"']?(?<depName>[^\"'\\s:@]+(?:\\/[^\"'\\s:@]+)*)\\s*:(?<currentValue>[^\"'\\s@]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?[\"']?"
+            ],
+            "datasourceTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/ansible\\/roles\\/ubuntu\\/tasks\\/.*\\.ya?ml$/"
+            ],
+            "matchStrings": [
+                "-\\s*(?<depName>[A-Za-z0-9._-]+)==(?<currentValue>[^\\s\"']+)"
+            ],
+            "datasourceTemplate": "pypi",
+            "versioningTemplate": "pep440"
+        }
+    ],
+    "packageRules": [
+        {
+            "description": "Group Terraform/OpenTofu providers and modules",
+            "matchManagers": [
+                "terraform"
+            ],
+            "matchDepTypes": [
+                "required_provider",
+                "module"
+            ],
+            "groupName": "terraform providers and modules",
+            "labels": [
+                "renovate",
+                "terraform"
+            ]
+        },
+        {
+            "description": "Do not update Terraform/OpenTofu required_version constraints; managed manually as a range.",
+            "matchManagers": [
+                "terraform"
+            ],
+            "matchDepTypes": [
+                "required_version"
+            ],
+            "enabled": false
+        },
+        {
+            "description": "Label Terraform/OpenTofu updates",
+            "matchManagers": [
+                "terraform"
+            ],
+            "labels": [
+                "renovate",
+                "terraform"
+            ]
+        },
+        {
+            "description": "Do not automerge Docker updates",
+            "matchDatasources": [
+                "docker"
+            ],
+            "automerge": false
+        },
+        {
+            "description": "Require dependency dashboard approval for major Docker updates",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "dependencyDashboardApproval": true,
+            "labels": [
+                "renovate",
+                "docker",
+                "major"
+            ],
+            "prPriority": 20
+        },
+        {
+            "description": "Delay Docker minor updates a little longer",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchUpdateTypes": [
+                "minor"
+            ],
+            "minimumReleaseAge": "7 days",
+            "labels": [
+                "renovate",
+                "docker",
+                "minor"
+            ],
+            "prPriority": 0
+        },
+        {
+            "description": "Label Docker patch updates",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchUpdateTypes": [
+                "patch"
+            ],
+            "minimumReleaseAge": "3 days",
+            "labels": [
+                "renovate",
+                "docker",
+                "patch"
+            ],
+            "prPriority": -1
+        },
+        {
+            "description": "Weekly batch for non-critical Docker minor/patch updates",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch"
+            ],
+            "groupName": "weekly non-critical docker image updates",
+            "groupSlug": "weekly-docker-minor-patch",
+            "schedule": [
+                "* 3-7 * * 1"
+            ],
+            "minimumGroupSize": 2,
+            "separateMinorPatch": false,
+            "labels": [
+                "renovate",
+                "docker",
+                "batch"
+            ],
+            "prPriority": -5
+        },
+        {
+            "description": "Keep critical infrastructure and database images separate",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "postgres",
+                "docker.io/library/postgres",
+                "redis",
+                "docker.io/library/redis",
+                "valkey/valkey",
+                "traefik",
+                "docker.io/library/traefik",
+                "authelia/authelia",
+                "docker.io/infisical/infisical",
+                "infisical/infisical",
+                "netboxcommunity/netbox",
+                "lscr.io/linuxserver/netbox",
+                "lscr.io/linuxserver/plex",
+                "prom/prometheus",
+                "grafana/grafana",
+                "grafana/loki",
+                "grafana/alloy",
+                "haproxy",
+                "docker.io/library/haproxy",
+                "cloudflare/cloudflared",
+                "crowdsecurity/crowdsec",
+                "portainer/portainer-ce"
+            ],
+            "groupName": null,
+            "labels": [
+                "renovate",
+                "docker",
+                "critical"
+            ],
+            "prPriority": 5
+        },
+        {
+            "description": "Use target version in Traefik branch names",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "traefik",
+                "docker.io/library/traefik"
+            ],
+            "branchTopic": "{{{depNameSanitized}}}-{{{newVersion}}}",
+            "separateMinorPatch": false,
+            "groupName": null,
+            "labels": [
+                "renovate",
+                "docker",
+                "critical",
+                "traefik"
+            ],
+            "prPriority": 10
+        },
+        {
+            "description": "Hotio release-v semver tags",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "ghcr.io/hotio/bazarr",
+                "ghcr.io/hotio/nzbhydra2",
+                "ghcr.io/hotio/qbittorrent",
+                "ghcr.io/hotio/sabnzbd",
+                "ghcr.io/hotio/seerr",
+                "ghcr.io/hotio/stash",
+                "ghcr.io/hotio/tautulli",
+                "ghcr.io/hotio/unpackerr"
+            ],
+            "versioning": "regex:^release-v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+        },
+        {
+            "description": "Hotio arr release tags with build number",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "ghcr.io/hotio/lidarr",
+                "ghcr.io/hotio/prowlarr",
+                "ghcr.io/hotio/radarr",
+                "ghcr.io/hotio/sonarr"
+            ],
+            "versioning": "regex:^release-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)$"
+        },
+        {
+            "description": "Hotio Whisparr v-prefixed release tags",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "ghcr.io/hotio/whisparr"
+            ],
+            "versioning": "regex:^(?<compatibility>v\\d+)-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-release\\.(?<build>\\d+)$"
+        },
+        {
+            "description": "Block LinuxServer development tags",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "/^lscr\\.io\\/linuxserver\\//"
+            ],
+            "allowedVersions": "!/^development-.*$/"
+        },
+        {
+            "description": "LinuxServer Plex semver tags",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "lscr.io/linuxserver/plex"
+            ],
+            "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+            "labels": [
+                "renovate",
+                "docker",
+                "plex"
+            ]
+        },
+        {
+            "description": "LinuxServer vX.Y.Z-lsN tags",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "lscr.io/linuxserver/obsidian",
+                "lscr.io/linuxserver/ombi",
+                "lscr.io/linuxserver/syncthing",
+                "lscr.io/linuxserver/thelounge"
+            ],
+            "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ls(?<build>\\d+)$"
+        },
+        {
+            "description": "LinuxServer ZNC tags",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "lscr.io/linuxserver/znc"
+            ],
+            "versioning": "regex:^znc-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ls(?<build>\\d+)$"
+        },
+        {
+            "description": "LinuxServer LibreWolf tags",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "lscr.io/linuxserver/librewolf"
+            ],
+            "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<patch>\\d+)-ls(?<build>\\d+)$"
+        },
+        {
+            "description": "Group Python package patch updates",
+            "matchDatasources": [
+                "pypi"
+            ],
+            "matchUpdateTypes": [
+                "patch"
+            ],
+            "groupName": "python package patch updates",
+            "groupSlug": "python-package-patch",
+            "labels": [
+                "renovate",
+                "python",
+                "patch"
+            ]
+        }
     ]
-  },
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "image:\\s*[\"']?(?<depName>[^\"'\\s:@]+(?:\\/[^\"'\\s:@]+)*)\\s*:(?<currentValue>[^\"'\\s@]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?[\"']?"
-      ],
-      "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/ansible\\/roles\\/ubuntu\\/tasks\\/.*\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "-\\s*(?<depName>[A-Za-z0-9._-]+)==(?<currentValue>[^\\s\"']+)"
-      ],
-      "datasourceTemplate": "pypi",
-      "versioningTemplate": "pep440"
-    }
-  ],
-  "packageRules": [
-    {
-      "description": "Group Terraform/OpenTofu providers and modules",
-      "matchManagers": [
-        "terraform"
-      ],
-      "matchDepTypes": [
-        "required_provider",
-        "module"
-      ],
-      "groupName": "terraform providers and modules",
-      "labels": [
-        "renovate",
-        "terraform"
-      ]
-    },
-    {
-      "description": "Do not update Terraform/OpenTofu required_version constraints; managed manually as a range.",
-      "matchManagers": [
-        "terraform"
-      ],
-      "matchDepTypes": [
-        "required_version"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Label Terraform/OpenTofu updates",
-      "matchManagers": [
-        "terraform"
-      ],
-      "labels": [
-        "renovate",
-        "terraform"
-      ]
-    },
-    {
-      "description": "Do not automerge Docker updates",
-      "matchDatasources": [
-        "docker"
-      ],
-      "automerge": false
-    },
-    {
-      "description": "Require dependency dashboard approval for major Docker updates",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "dependencyDashboardApproval": true,
-      "labels": [
-        "renovate",
-        "docker",
-        "major"
-      ],
-      "prPriority": 20
-    },
-    {
-      "description": "Delay Docker minor updates a little longer",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "minimumReleaseAge": "7 days",
-      "labels": [
-        "renovate",
-        "docker",
-        "minor"
-      ],
-      "prPriority": 0
-    },
-    {
-      "description": "Label Docker patch updates",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "minimumReleaseAge": "3 days",
-      "labels": [
-        "renovate",
-        "docker",
-        "patch"
-      ],
-      "prPriority": -1
-    },
-    {
-      "description": "Keep critical infrastructure and database images separate",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "postgres",
-        "docker.io/library/postgres",
-        "redis",
-        "docker.io/library/redis",
-        "valkey/valkey",
-        "traefik",
-        "docker.io/library/traefik",
-        "authelia/authelia",
-        "docker.io/infisical/infisical",
-        "infisical/infisical",
-        "netboxcommunity/netbox",
-        "lscr.io/linuxserver/netbox",
-        "lscr.io/linuxserver/plex",
-        "prom/prometheus",
-        "grafana/grafana",
-        "grafana/loki",
-        "grafana/alloy",
-        "haproxy",
-        "docker.io/library/haproxy",
-        "cloudflare/cloudflared",
-        "crowdsecurity/crowdsec",
-        "portainer/portainer-ce"
-      ],
-      "groupName": null,
-      "labels": [
-        "renovate",
-        "docker",
-        "critical"
-      ],
-      "prPriority": 5
-    },
-    {
-      "description": "Use target version in Traefik branch names",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "traefik",
-        "docker.io/library/traefik"
-      ],
-      "branchTopic": "{{{depNameSanitized}}}-{{{newVersion}}}",
-      "separateMinorPatch": false,
-      "groupName": null,
-      "labels": [
-        "renovate",
-        "docker",
-        "critical",
-        "traefik"
-      ],
-      "prPriority": 10
-    },
-    {
-      "description": "Group Hotio media patch updates",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "matchPackageNames": [
-        "ghcr.io/hotio/bazarr",
-        "ghcr.io/hotio/lidarr",
-        "ghcr.io/hotio/nzbhydra2",
-        "ghcr.io/hotio/prowlarr",
-        "ghcr.io/hotio/qbittorrent",
-        "ghcr.io/hotio/radarr",
-        "ghcr.io/hotio/sabnzbd",
-        "ghcr.io/hotio/seerr",
-        "ghcr.io/hotio/sonarr",
-        "ghcr.io/hotio/stash",
-        "ghcr.io/hotio/tautulli",
-        "ghcr.io/hotio/unpackerr",
-        "ghcr.io/hotio/whisparr"
-      ],
-      "groupName": "hotio media patch updates",
-      "groupSlug": "hotio-media-patch",
-      "labels": [
-        "renovate",
-        "docker",
-        "patch",
-        "media"
-      ]
-    },
-    {
-      "description": "Group LinuxServer patch updates for non-critical apps",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "matchPackageNames": [
-        "lscr.io/linuxserver/librewolf",
-        "lscr.io/linuxserver/obsidian",
-        "lscr.io/linuxserver/ombi",
-        "lscr.io/linuxserver/syncthing",
-        "lscr.io/linuxserver/thelounge",
-        "lscr.io/linuxserver/znc"
-      ],
-      "groupName": "linuxserver app patch updates",
-      "groupSlug": "linuxserver-app-patch",
-      "labels": [
-        "renovate",
-        "docker",
-        "patch",
-        "linuxserver"
-      ]
-    },
-    {
-      "description": "Hotio release-v semver tags",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "ghcr.io/hotio/bazarr",
-        "ghcr.io/hotio/nzbhydra2",
-        "ghcr.io/hotio/qbittorrent",
-        "ghcr.io/hotio/sabnzbd",
-        "ghcr.io/hotio/seerr",
-        "ghcr.io/hotio/stash",
-        "ghcr.io/hotio/tautulli",
-        "ghcr.io/hotio/unpackerr"
-      ],
-      "versioning": "regex:^release-v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
-    },
-    {
-      "description": "Hotio arr release tags with build number",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "ghcr.io/hotio/lidarr",
-        "ghcr.io/hotio/prowlarr",
-        "ghcr.io/hotio/radarr",
-        "ghcr.io/hotio/sonarr"
-      ],
-      "versioning": "regex:^release-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)$"
-    },
-    {
-      "description": "Hotio Whisparr v-prefixed release tags",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "ghcr.io/hotio/whisparr"
-      ],
-      "versioning": "regex:^(?<compatibility>v\\d+)-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-release\\.(?<build>\\d+)$"
-    },
-    {
-      "description": "Block LinuxServer development tags",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "/^lscr\\.io\\/linuxserver\\//"
-      ],
-      "allowedVersions": "!/^development-.*$/"
-    },
-    {
-      "description": "LinuxServer Plex semver tags",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "lscr.io/linuxserver/plex"
-      ],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "labels": [
-        "renovate",
-        "docker",
-        "plex"
-      ]
-    },
-    {
-      "description": "LinuxServer vX.Y.Z-lsN tags",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "lscr.io/linuxserver/obsidian",
-        "lscr.io/linuxserver/ombi",
-        "lscr.io/linuxserver/syncthing",
-        "lscr.io/linuxserver/thelounge"
-      ],
-      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ls(?<build>\\d+)$"
-    },
-    {
-      "description": "LinuxServer ZNC tags",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "lscr.io/linuxserver/znc"
-      ],
-      "versioning": "regex:^znc-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ls(?<build>\\d+)$"
-    },
-    {
-      "description": "LinuxServer LibreWolf tags",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "lscr.io/linuxserver/librewolf"
-      ],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<patch>\\d+)-ls(?<build>\\d+)$"
-    },
-    {
-      "description": "Group Python package patch updates",
-      "matchDatasources": [
-        "pypi"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "groupName": "python package patch updates",
-      "groupSlug": "python-package-patch",
-      "labels": [
-        "renovate",
-        "python",
-        "patch"
-      ]
-    }
-  ]
 }

--- a/terraform/github/homelab/.terraform.lock.hcl
+++ b/terraform/github/homelab/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.12.1"
+  constraints = "6.12.1"
+  hashes = [
+    "h1:/JLvYf7fCYeSoKc89py9WV94WnTgT71A3U4VaTPegpI=",
+    "h1:8bdqUshpu+zpfdHQVZ1Rg1rSaW9nSv1gzHt4HRPaZUk=",
+    "h1:9BfXk4BJJWZkaa/d/8i+U3u7Nr3tlGIHJ+7LBvc12gw=",
+    "h1:AkdRKjzShTel609CiVGyv3vWU7Qo8mwcUE6VJV/Gres=",
+    "h1:CmFsDWVQMUHitg2Lyqv/qI+lLXPv7J157Rv8YvQoPLY=",
+    "h1:Ekz3/V2jj7Tvw4WgDLmjTK+BWg9Eq/AIo1QcihXZqOU=",
+    "h1:HXXTIvXPBVJ4mBs01fcJk7wG8N3jGvR/4HqjnRGp4Wo=",
+    "h1:IVEhTwWpf1T+NXuY6J+KVY4mSjqyp5OdC5RI7MZQnNc=",
+    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
+    "h1:ghFGRYa6LdR4BjW0Fe8HXKI0ZmA1bTrwjhXDeZG7+3E=",
+    "h1:hHOwf554tYL9pQS2uRPbaAGSXRbbBJ/+HtQAoT9mtuA=",
+    "h1:udibqwcJrxhB4bIvNfRcFNClzgRCMWRmQ9CGwXrOVL4=",
+    "h1:w0nsMBpbxXyt2qzN7+3cHjGmJC73ROGBSJTcexcHuyA=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}

--- a/terraform/github/homelab/README.md
+++ b/terraform/github/homelab/README.md
@@ -24,6 +24,7 @@ No modules.
 | [github_actions_repository_permissions.homelab](https://registry.terraform.io/providers/integrations/github/6.12.1/docs/resources/actions_repository_permissions) | resource |
 | [github_repository.homelab](https://registry.terraform.io/providers/integrations/github/6.12.1/docs/resources/repository) | resource |
 | [github_repository_ruleset.main_clean_history](https://registry.terraform.io/providers/integrations/github/6.12.1/docs/resources/repository_ruleset) | resource |
+| [github_repository_vulnerability_alerts.homelab](https://registry.terraform.io/providers/integrations/github/6.12.1/docs/resources/repository_vulnerability_alerts) | resource |
 | [terraform_data.workflow_token_permissions](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 
 ## Inputs
@@ -33,7 +34,7 @@ No modules.
 | <a name="input_allow_forking"></a> [allow\_forking](#input\_allow\_forking) | Public repos can be forked regardless; this mainly matters for private/org repos. | `bool` | `true` | no |
 | <a name="input_default_branch"></a> [default\_branch](#input\_default\_branch) | Default branch protected by the ruleset. | `string` | `"main"` | no |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | GitHub owner/user/org, e.g. Lebowski89. | `string` | `"Lebowski89"` | no |
-| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | n/a | `string` | n/a | yes |
+| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | GitHub token used by the provider and REST API calls. | `string` | n/a | yes |
 | <a name="input_has_discussions"></a> [has\_discussions](#input\_has\_discussions) | n/a | `bool` | `false` | no |
 | <a name="input_has_issues"></a> [has\_issues](#input\_has\_issues) | n/a | `bool` | `true` | no |
 | <a name="input_has_projects"></a> [has\_projects](#input\_has\_projects) | n/a | `bool` | `true` | no |

--- a/terraform/github/homelab/README.md
+++ b/terraform/github/homelab/README.md
@@ -1,0 +1,53 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.11.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | 6.12.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_github"></a> [github](#provider\_github) | 6.12.1 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [github_actions_repository_permissions.homelab](https://registry.terraform.io/providers/integrations/github/6.12.1/docs/resources/actions_repository_permissions) | resource |
+| [github_repository.homelab](https://registry.terraform.io/providers/integrations/github/6.12.1/docs/resources/repository) | resource |
+| [github_repository_ruleset.main_clean_history](https://registry.terraform.io/providers/integrations/github/6.12.1/docs/resources/repository_ruleset) | resource |
+| [terraform_data.workflow_token_permissions](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_forking"></a> [allow\_forking](#input\_allow\_forking) | Public repos can be forked regardless; this mainly matters for private/org repos. | `bool` | `true` | no |
+| <a name="input_default_branch"></a> [default\_branch](#input\_default\_branch) | Default branch protected by the ruleset. | `string` | `"main"` | no |
+| <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | GitHub owner/user/org, e.g. Lebowski89. | `string` | `"Lebowski89"` | no |
+| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | n/a | `string` | n/a | yes |
+| <a name="input_has_discussions"></a> [has\_discussions](#input\_has\_discussions) | n/a | `bool` | `false` | no |
+| <a name="input_has_issues"></a> [has\_issues](#input\_has\_issues) | n/a | `bool` | `true` | no |
+| <a name="input_has_projects"></a> [has\_projects](#input\_has\_projects) | n/a | `bool` | `true` | no |
+| <a name="input_has_wiki"></a> [has\_wiki](#input\_has\_wiki) | n/a | `bool` | `false` | no |
+| <a name="input_repository_description"></a> [repository\_description](#input\_repository\_description) | Repository description. Adjust before importing/applying if GitHub currently differs. | `string` | `"Homelab infrastructure as code"` | no |
+| <a name="input_repository_name"></a> [repository\_name](#input\_repository\_name) | Repository to manage. | `string` | `"homelab"` | no |
+| <a name="input_repository_visibility"></a> [repository\_visibility](#input\_repository\_visibility) | public or private. Must match your existing repo unless you intend to change it. | `string` | `"public"` | no |
+| <a name="input_set_workflow_token_permissions"></a> [set\_workflow\_token\_permissions](#input\_set\_workflow\_token\_permissions) | Use a Terraform local-exec REST call to set Actions GITHUB\_TOKEN defaults to read/write. Official provider support is limited here. | `bool` | `true` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_main_ruleset_id"></a> [main\_ruleset\_id](#output\_main\_ruleset\_id) | n/a |
+| <a name="output_repository_full_name"></a> [repository\_full\_name](#output\_repository\_full\_name) | n/a |
+| <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/github/homelab/locals.tf
+++ b/terraform/github/homelab/locals.tf
@@ -2,7 +2,12 @@ locals {
   workflow_token_permissions = {
     owner       = var.github_owner
     repository  = github_repository.homelab.name
-    permissions = "write"
+    permissions = var.workflow_token_default_permissions
     approve_prs = false
   }
+
+  workflow_token_permissions_payload = jsonencode({
+    default_workflow_permissions     = local.workflow_token_permissions.permissions
+    can_approve_pull_request_reviews = local.workflow_token_permissions.approve_prs
+  })
 }

--- a/terraform/github/homelab/locals.tf
+++ b/terraform/github/homelab/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  workflow_token_permissions = {
+    owner       = var.github_owner
+    repository  = github_repository.homelab.name
+    permissions = "write"
+    approve_prs = false
+  }
+}

--- a/terraform/github/homelab/main.tf
+++ b/terraform/github/homelab/main.tf
@@ -1,0 +1,119 @@
+resource "github_repository" "homelab" {
+  #checkov:skip=CKV_GIT_1:Homelab repo is intentionally public unless repository_visibility is changed.
+  #checkov:skip=CKV_GIT_5:Personal homelab repo; zero required approvals keeps solo-maintainer flow practical.
+  #checkov:skip=CKV_GIT_6:Signed commits are not currently enforced for this personal repo.
+
+  name        = var.repository_name
+  description = var.repository_description
+  visibility  = var.repository_visibility
+
+  has_issues      = var.has_issues
+  has_projects    = var.has_projects
+  has_wiki        = var.has_wiki
+  has_discussions = var.has_discussions
+
+  allow_merge_commit  = false
+  allow_rebase_merge  = false
+  allow_squash_merge  = true
+  allow_auto_merge    = false
+  allow_update_branch = true
+
+  delete_branch_on_merge = true
+
+  squash_merge_commit_title   = "PR_TITLE"
+  squash_merge_commit_message = "BLANK"
+
+  allow_forking = var.allow_forking
+  auto_init     = false
+
+  archive_on_destroy = true
+
+  lifecycle {
+    prevent_destroy = true
+
+    ignore_changes = [
+      homepage_url,
+      topics,
+      merge_commit_message,
+      merge_commit_title,
+    ]
+  }
+}
+
+resource "github_repository_ruleset" "main_clean_history" {
+  name        = "main clean history"
+  repository  = github_repository.homelab.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    deletion         = true
+    non_fast_forward = true
+
+    required_linear_history = true
+
+    pull_request {
+      allowed_merge_methods             = ["squash"]
+      required_approving_review_count   = 0
+      required_review_thread_resolution = true
+      dismiss_stale_reviews_on_push     = false
+      require_code_owner_review         = false
+      require_last_push_approval        = false
+    }
+  }
+}
+
+resource "github_actions_repository_permissions" "homelab" {
+  repository      = github_repository.homelab.name
+  enabled         = true
+  allowed_actions = "all"
+
+  sha_pinning_required = false
+}
+
+resource "terraform_data" "workflow_token_permissions" {
+  count = var.set_workflow_token_permissions ? 1 : 0
+
+  input = {
+    owner       = var.github_owner
+    repository  = github_repository.homelab.name
+    permissions = "write"
+    approve_prs = false
+  }
+
+  triggers_replace = {
+    owner       = var.github_owner
+    repository  = github_repository.homelab.name
+    permissions = "write"
+    approve_prs = "false"
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/usr/bin/env", "bash", "-c"]
+
+    environment = {
+      GITHUB_TOKEN = var.github_token
+      GITHUB_OWNER = var.github_owner
+      GITHUB_REPO  = github_repository.homelab.name
+    }
+
+    command = <<-EOT
+      set -euo pipefail
+
+      curl -fsSL \
+        -X PUT \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/$${GITHUB_OWNER}/$${GITHUB_REPO}/actions/permissions/workflow" \
+        -d '{"default_workflow_permissions":"write","can_approve_pull_request_reviews":false}'
+    EOT
+  }
+}

--- a/terraform/github/homelab/main.tf
+++ b/terraform/github/homelab/main.tf
@@ -40,6 +40,10 @@ resource "github_repository" "homelab" {
   }
 }
 
+resource "github_repository_vulnerability_alerts" "homelab" {
+  repository = github_repository.homelab.name
+}
+
 resource "github_repository_ruleset" "main_clean_history" {
   name        = "main clean history"
   repository  = github_repository.homelab.name
@@ -81,19 +85,12 @@ resource "github_actions_repository_permissions" "homelab" {
 resource "terraform_data" "workflow_token_permissions" {
   count = var.set_workflow_token_permissions ? 1 : 0
 
-  input = {
-    owner       = var.github_owner
-    repository  = github_repository.homelab.name
-    permissions = "write"
-    approve_prs = false
-  }
+  input            = local.workflow_token_permissions
+  triggers_replace = local.workflow_token_permissions
 
-  triggers_replace = {
-    owner       = var.github_owner
-    repository  = github_repository.homelab.name
-    permissions = "write"
-    approve_prs = "false"
-  }
+  depends_on = [
+    github_actions_repository_permissions.homelab,
+  ]
 
   provisioner "local-exec" {
     interpreter = ["/usr/bin/env", "bash", "-c"]
@@ -108,6 +105,8 @@ resource "terraform_data" "workflow_token_permissions" {
       set -euo pipefail
 
       curl -fsSL \
+        --connect-timeout 10 \
+        --max-time 60 \
         -X PUT \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer $${GITHUB_TOKEN}" \

--- a/terraform/github/homelab/main.tf
+++ b/terraform/github/homelab/main.tf
@@ -112,7 +112,7 @@ resource "terraform_data" "workflow_token_permissions" {
         -H "Authorization: Bearer $${GITHUB_TOKEN}" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         "https://api.github.com/repos/$${GITHUB_OWNER}/$${GITHUB_REPO}/actions/permissions/workflow" \
-        -d '{"default_workflow_permissions":"write","can_approve_pull_request_reviews":false}'
+        -d '${local.workflow_token_permissions_payload}'
     EOT
   }
 }

--- a/terraform/github/homelab/outputs.tf
+++ b/terraform/github/homelab/outputs.tf
@@ -1,0 +1,11 @@
+output "repository_name" {
+  value = github_repository.homelab.name
+}
+
+output "repository_full_name" {
+  value = github_repository.homelab.full_name
+}
+
+output "main_ruleset_id" {
+  value = github_repository_ruleset.main_clean_history.ruleset_id
+}

--- a/terraform/github/homelab/provider.tf
+++ b/terraform/github/homelab/provider.tf
@@ -1,0 +1,4 @@
+provider "github" {
+  token = var.github_token
+  owner = var.github_owner
+}

--- a/terraform/github/homelab/secrets.auto.tfvars.sample
+++ b/terraform/github/homelab/secrets.auto.tfvars.sample
@@ -1,0 +1,1 @@
+github_token = "github_pat_..."

--- a/terraform/github/homelab/terraform.tfvars
+++ b/terraform/github/homelab/terraform.tfvars
@@ -1,0 +1,14 @@
+github_owner           = "Lebowski89"
+repository_name        = "homelab"
+repository_description = "Homelab Repo"
+repository_visibility  = "public"
+default_branch         = "main"
+
+has_issues      = true
+has_projects    = true
+has_wiki        = false
+has_discussions = false
+allow_forking   = true
+
+# Needed for docs workflows that commit generated files back to same-repo PR branches.
+set_workflow_token_permissions = true

--- a/terraform/github/homelab/variables.tf
+++ b/terraform/github/homelab/variables.tf
@@ -75,3 +75,14 @@ variable "set_workflow_token_permissions" {
   description = "Use a Terraform local-exec REST call to set Actions GITHUB_TOKEN defaults to read/write. Official provider support is limited here."
   default     = true
 }
+
+variable "workflow_token_default_permissions" {
+  description = "Default permissions granted to GITHUB_TOKEN for workflows."
+  type        = string
+  default     = "read"
+
+  validation {
+    condition     = contains(["read", "write"], var.workflow_token_default_permissions)
+    error_message = "workflow_token_default_permissions must be either read or write."
+  }
+}

--- a/terraform/github/homelab/variables.tf
+++ b/terraform/github/homelab/variables.tf
@@ -1,0 +1,71 @@
+variable "github_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "github_owner" {
+  type        = string
+  description = "GitHub owner/user/org, e.g. Lebowski89."
+  default     = "Lebowski89"
+}
+
+variable "repository_name" {
+  type        = string
+  description = "Repository to manage."
+  default     = "homelab"
+}
+
+variable "repository_description" {
+  type        = string
+  description = "Repository description. Adjust before importing/applying if GitHub currently differs."
+  default     = "Homelab infrastructure as code"
+}
+
+variable "repository_visibility" {
+  type        = string
+  description = "public or private. Must match your existing repo unless you intend to change it."
+  default     = "public"
+
+  validation {
+    condition     = contains(["public", "private"], var.repository_visibility)
+    error_message = "repository_visibility must be public or private."
+  }
+}
+
+variable "default_branch" {
+  type        = string
+  description = "Default branch protected by the ruleset."
+  default     = "main"
+}
+
+variable "has_issues" {
+  type    = bool
+  default = true
+}
+
+variable "has_projects" {
+  type    = bool
+  default = true
+}
+
+variable "has_wiki" {
+  type    = bool
+  default = false
+}
+
+variable "has_discussions" {
+  type    = bool
+  default = false
+}
+
+variable "allow_forking" {
+  type        = bool
+  description = "Public repos can be forked regardless; this mainly matters for private/org repos."
+  default     = true
+}
+
+variable "set_workflow_token_permissions" {
+  type        = bool
+  description = "Use a Terraform local-exec REST call to set Actions GITHUB_TOKEN defaults to read/write. Official provider support is limited here."
+  default     = true
+}

--- a/terraform/github/homelab/variables.tf
+++ b/terraform/github/homelab/variables.tf
@@ -1,6 +1,12 @@
 variable "github_token" {
-  type      = string
-  sensitive = true
+  description = "GitHub token used by the provider and REST API calls."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.github_token)) > 0
+    error_message = "github_token must not be empty."
+  }
 }
 
 variable "github_owner" {

--- a/terraform/github/homelab/versions.tf
+++ b/terraform/github/homelab/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "6.12.1"
+    }
+  }
+}

--- a/terraform/github/hugo/README.md
+++ b/terraform/github/hugo/README.md
@@ -31,7 +31,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_default_branch"></a> [default\_branch](#input\_default\_branch) | n/a | `string` | `"main"` | no |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | n/a | `string` | n/a | yes |
-| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | n/a | `string` | n/a | yes |
+| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | GitHub token used by the provider and REST API calls. | `string` | n/a | yes |
 | <a name="input_repository_description"></a> [repository\_description](#input\_repository\_description) | n/a | `string` | `"Hugo blog"` | no |
 | <a name="input_repository_name"></a> [repository\_name](#input\_repository\_name) | n/a | `string` | `"blog"` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | n/a | `string` | `"public"` | no |

--- a/terraform/github/hugo/variables.tf
+++ b/terraform/github/hugo/variables.tf
@@ -1,6 +1,12 @@
 variable "github_token" {
-  type      = string
-  sensitive = true
+  description = "GitHub token used by the provider and REST API calls."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.github_token)) > 0
+    error_message = "github_token must not be empty."
+  }
 }
 
 variable "github_owner" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Terraform support for provisioning a GitHub repository with configurable features, branch protections, vulnerability alerts, and workflow permission settings (including published outputs).
  * Documentation workflows can now run on pull requests (with manual run support) and publish generated docs back to the PR branch.
  * Added a Git history cleanup cheat sheet with practical rebase workflows.

* **Documentation**
  * Expanded generated Terraform documentation for the new GitHub setup.
  * Improved documentation and validation for GitHub token inputs.

* **Maintenance**
  * Updated dependency automation to reduce PR volume and adjust update grouping behavior.
  * Added an OpenTofu/Terraform provider lockfile and expanded the check matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->