### PR TITLE
feat(n8n): add initial n8n VM and module

### DIFF
--- a/ansible/group_vars/all/tailscale_bootstrap.yml
+++ b/ansible/group_vars/all/tailscale_bootstrap.yml
@@ -1,0 +1,3 @@
+---
+
+tailscale_bootstrap_proxmox_host: pve1

--- a/ansible/host_vars/pve1.yml
+++ b/ansible/host_vars/pve1.yml
@@ -11,3 +11,22 @@ opentofu_api_user: terraform@pve
 opentofu_api_token_name: "terraform-token"
 
 proxmox_api_bootstrap_user: "root@pam"
+
+################################
+# TAILSCALE BOOTSTRAP
+################################
+
+tailscale_bootstrap_guest: ""
+tailscale_bootstrap_guests: {}
+
+# Populate the variables above before running the bootstrap role.
+#
+# Example:
+#
+# tailscale_bootstrap_guest: n8n
+#
+# tailscale_bootstrap_guests:
+#   n8n:
+#     vmid: 9010
+#     hostname: n8n
+#     enable_ssh: true

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -83,6 +83,22 @@
   tasks:
 
     ################################
+    # TAILSCALE BOOTSTRAP (QEMU AGENT)
+    ################################
+
+    - name: Include Tailscale bootstrap role
+      when: inventory_hostname == tailscale_bootstrap_proxmox_host
+      ansible.builtin.include_role:
+        name: tailscale_bootstrap
+        apply:
+          tags:
+            - never
+            - tailscale_bootstrap
+      tags:
+        - never
+        - tailscale_bootstrap
+
+    ################################
     # OS (CONFIG/SETTINGS)
     ################################
 

--- a/ansible/roles/infisical/README.md
+++ b/ansible/roles/infisical/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/07/15 |
+| Readme update        | 2026/07/21 |
 
 
 
@@ -45,7 +45,7 @@
 | [infisical_stack](defaults/main.yml#L32)   | str | `infisical` |    
 | [infisical_compose_file](defaults/main.yml#L33)   | str | `infisical-compose.yml` |    
 | [infisical_compose_path](defaults/main.yml#L34)   | str | `{{ infisical_base_path }}/{{ infisical_compose_file }}` |    
-| [infisical_image](defaults/main.yml#L36)   | str | `docker.io/infisical/infisical:v0.162.2` |    
+| [infisical_image](defaults/main.yml#L36)   | str | `docker.io/infisical/infisical:v0.162.6` |    
 | [infisical_timezone](defaults/main.yml#L37)   | str | `{{ timezone ¦ default('Australia/Melbourne') }}` |    
 | [infisical_puid](defaults/main.yml#L38)   | str | `{{ docker_host_puid ¦ default('1000') }}` |    
 | [infisical_pgid](defaults/main.yml#L39)   | str | `{{ docker_host_pgid ¦ default('1000') }}` |    

--- a/ansible/roles/tailscale_bootstrap/.docsible
+++ b/ansible/roles/tailscale_bootstrap/.docsible
@@ -1,0 +1,13 @@
+aap_hub: null
+automation_kind: null
+category: null
+critical: null
+description: null
+dt_dev: null
+dt_prod: null
+dt_update: 2026/07/21
+requester: null
+subCategory: null
+time_saving: null
+users: null
+version: null

--- a/ansible/roles/tailscale_bootstrap/README.md
+++ b/ansible/roles/tailscale_bootstrap/README.md
@@ -1,0 +1,95 @@
+<!-- DOCSIBLE START -->
+
+# 📃 Role overview
+
+## tailscale_bootstrap
+
+
+
+
+
+| Field                | Value           |
+|--------------------- |-----------------|
+| Readme update        | 2026/07/21 |
+
+
+
+
+
+
+
+
+### Defaults
+
+**These are static variables with lower priority**
+
+#### File: defaults/main.yml
+
+| Var          | Type         | Value       |
+|--------------|--------------|-------------|
+| [tailscale_bootstrap_guest](defaults/main.yml#L3)   | str |  |    
+| [tailscale_bootstrap_guests](defaults/main.yml#L4)   | dict | `{}` |    
+| [tailscale_bootstrap_guest_agent_retries](defaults/main.yml#L5)   | int | `30` |    
+| [tailscale_bootstrap_guest_agent_delay](defaults/main.yml#L6)   | int | `5` |    
+
+
+
+
+
+### Tasks
+
+
+#### File: tasks/main.yml
+
+| Name | Module | Has Conditions |
+| ---- | ------ | -------------- |
+| Tailscale Bootstrap ¦ Refuse check mode | ansible.builtin.assert | False |
+| Tailscale Bootstrap ¦ Validate guest selector | ansible.builtin.assert | False |
+| Tailscale Bootstrap ¦ Load selected guest configuration | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Validate selected guest configuration | ansible.builtin.assert | False |
+| Tailscale Bootstrap ¦ Build effective guest configuration | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Wait for QEMU Guest Agent | ansible.builtin.command | False |
+| Tailscale Bootstrap ¦ Check whether Tailscale is installed | ansible.builtin.command | False |
+| Tailscale Bootstrap ¦ Parse installation probe | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Validate installation probe | ansible.builtin.assert | False |
+| Tailscale Bootstrap ¦ Record installation state | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Install Tailscale | ansible.builtin.command | True |
+| Tailscale Bootstrap ¦ Parse installation result | ansible.builtin.set_fact | True |
+| Tailscale Bootstrap ¦ Validate installation result | ansible.builtin.assert | True |
+| Tailscale Bootstrap ¦ Enable and start tailscaled | ansible.builtin.command | False |
+| Tailscale Bootstrap ¦ Parse tailscaled result | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Validate tailscaled result | ansible.builtin.assert | False |
+| Tailscale Bootstrap ¦ Query current Tailscale status | ansible.builtin.command | False |
+| Tailscale Bootstrap ¦ Parse status envelope | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Validate status envelope | ansible.builtin.assert | False |
+| Tailscale Bootstrap ¦ Parse current Tailscale status | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Record current backend state | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Prompt for one-off authentication key | ansible.builtin.pause | True |
+| Tailscale Bootstrap ¦ Validate supplied authentication key | ansible.builtin.assert | True |
+| Tailscale Bootstrap ¦ Authenticate guest with Tailscale | ansible.builtin.command | True |
+| Tailscale Bootstrap ¦ Parse authentication result | ansible.builtin.set_fact | True |
+| Tailscale Bootstrap ¦ Record authentication result | ansible.builtin.set_fact | True |
+| Tailscale Bootstrap ¦ Validate authentication result | ansible.builtin.assert | True |
+| Tailscale Bootstrap ¦ Query final Tailscale status | ansible.builtin.command | False |
+| Tailscale Bootstrap ¦ Parse final status envelope | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Validate final status command | ansible.builtin.assert | False |
+| Tailscale Bootstrap ¦ Parse final Tailscale status | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Assert Tailscale is connected | ansible.builtin.assert | False |
+| Tailscale Bootstrap ¦ Query Tailscale IPv4 address | ansible.builtin.command | False |
+| Tailscale Bootstrap ¦ Parse Tailscale IP result | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Validate Tailscale IP result | ansible.builtin.assert | False |
+| Tailscale Bootstrap ¦ Record Tailscale IPv4 address | ansible.builtin.set_fact | False |
+| Tailscale Bootstrap ¦ Report result | ansible.builtin.debug | False |
+
+
+
+
+
+
+
+
+
+#### Dependencies
+
+No dependencies specified.
+<!-- DOCSIBLE END -->

--- a/ansible/roles/tailscale_bootstrap/defaults/main.yml
+++ b/ansible/roles/tailscale_bootstrap/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+tailscale_bootstrap_guest: ""
+tailscale_bootstrap_guests: {}
+tailscale_bootstrap_guest_agent_retries: 30
+tailscale_bootstrap_guest_agent_delay: 5

--- a/ansible/roles/tailscale_bootstrap/tasks/main.yml
+++ b/ansible/roles/tailscale_bootstrap/tasks/main.yml
@@ -1,0 +1,480 @@
+---
+
+################################
+# VALIDATION
+################################
+
+- name: Tailscale Bootstrap | Refuse check mode
+  ansible.builtin.assert:
+    that:
+      - not ansible_check_mode
+    fail_msg: >-
+      The Tailscale bootstrap role cannot run in check mode because it must
+      interrogate and potentially modify the guest through QEMU Guest Agent.
+
+- name: Tailscale Bootstrap | Validate guest selector
+  ansible.builtin.assert:
+    that:
+      - tailscale_bootstrap_guest | default("") | trim | length > 0
+      - tailscale_bootstrap_guests is mapping
+      - tailscale_bootstrap_guest in tailscale_bootstrap_guests
+    fail_msg: >-
+      Supply a guest defined in tailscale_bootstrap_guests.
+
+- name: Tailscale Bootstrap | Load selected guest configuration
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_guest_config: >-
+      {{ tailscale_bootstrap_guests[tailscale_bootstrap_guest] }}
+
+- name: Tailscale Bootstrap | Validate selected guest configuration
+  ansible.builtin.assert:
+    that:
+      - tailscale_bootstrap_guest_config is mapping
+      - tailscale_bootstrap_guest_config.vmid is defined
+      - tailscale_bootstrap_guest_config.vmid is number
+      - tailscale_bootstrap_guest_config.vmid | int >= 100
+      - tailscale_bootstrap_guest_config.hostname is defined
+      - tailscale_bootstrap_guest_config.hostname | string | trim | length > 0
+      - >-
+        tailscale_bootstrap_guest_config.hostname
+        is match('^[A-Za-z0-9][A-Za-z0-9.-]*$')
+      - >-
+        tailscale_bootstrap_guest_config.enable_ssh is not defined
+        or tailscale_bootstrap_guest_config.enable_ssh is boolean
+    fail_msg: >-
+      The selected guest requires a numeric vmid, a valid hostname, and an
+      optional boolean enable_ssh value.
+
+- name: Tailscale Bootstrap | Build effective guest configuration
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_vmid_effective: >-
+      {{ tailscale_bootstrap_guest_config.vmid | int }}
+    tailscale_bootstrap_hostname_effective: >-
+      {{ tailscale_bootstrap_guest_config.hostname | string | trim }}
+    tailscale_bootstrap_enable_ssh_effective: >-
+      {{ tailscale_bootstrap_guest_config.enable_ssh | default(true) | bool }}
+
+################################
+# QEMU GUEST AGENT
+################################
+
+- name: Tailscale Bootstrap | Wait for QEMU Guest Agent
+  ansible.builtin.command:
+    argv:
+      - qm
+      - guest
+      - cmd
+      - "{{ tailscale_bootstrap_vmid_effective | string }}"
+      - ping
+  register: tailscale_bootstrap_guest_ping
+  changed_when: false
+  failed_when: false
+  retries: "{{ tailscale_bootstrap_guest_agent_retries | default(60) | int }}"
+  delay: "{{ tailscale_bootstrap_guest_agent_delay | default(5) | int }}"
+  until: tailscale_bootstrap_guest_ping.rc == 0
+
+################################
+# TAILSCALE INSTALLATION
+################################
+
+- name: Tailscale Bootstrap | Check whether Tailscale is installed
+  ansible.builtin.command:
+    argv:
+      - qm
+      - guest
+      - exec
+      - "{{ tailscale_bootstrap_vmid_effective | string }}"
+      - --timeout
+      - "30"
+      - --
+      - /bin/sh
+      - -c
+      - >-
+        if command -v tailscale >/dev/null 2>&1;
+        then printf 'TAILSCALE_INSTALLED=1\n';
+        else printf 'TAILSCALE_INSTALLED=0\n';
+        fi
+  register: tailscale_bootstrap_install_probe_raw
+  changed_when: false
+
+- name: Tailscale Bootstrap | Parse installation probe
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_install_probe_envelope: >-
+      {{ tailscale_bootstrap_install_probe_raw.stdout | from_json }}
+
+- name: Tailscale Bootstrap | Validate installation probe
+  ansible.builtin.assert:
+    that:
+      - >-
+        tailscale_bootstrap_install_probe_envelope.get('exited', 0)
+        | int == 1
+      - >-
+        tailscale_bootstrap_install_probe_envelope.get('exitcode', 1)
+        | int == 0
+      - >-
+        'TAILSCALE_INSTALLED='
+        in tailscale_bootstrap_install_probe_envelope.get('out-data', '')
+    fail_msg: >-
+      Proxmox reached the guest, but the Tailscale installation probe did not
+      complete successfully.
+
+- name: Tailscale Bootstrap | Record installation state
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_installed: >-
+      {{
+        'TAILSCALE_INSTALLED=1'
+        in tailscale_bootstrap_install_probe_envelope.get('out-data', '')
+      }}
+
+- name: Tailscale Bootstrap | Install Tailscale
+  when: not tailscale_bootstrap_installed | bool
+  ansible.builtin.command:
+    argv:
+      - qm
+      - guest
+      - exec
+      - "{{ tailscale_bootstrap_vmid_effective | string }}"
+      - --timeout
+      - "600"
+      - --
+      - /bin/sh
+      - -c
+      - |-
+        set -eu
+        export DEBIAN_FRONTEND=noninteractive
+
+        apt-get update
+        apt-get install --yes ca-certificates curl
+
+        installer="$(mktemp /tmp/tailscale-install.XXXXXX)"
+        trap 'rm -f "$installer"' EXIT HUP INT TERM
+
+        curl -fsSL https://tailscale.com/install.sh -o "$installer"
+        /bin/sh "$installer"
+  register: tailscale_bootstrap_install_raw
+  changed_when: true
+
+- name: Tailscale Bootstrap | Parse installation result
+  when: not tailscale_bootstrap_installed | bool
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_install_envelope: >-
+      {{ tailscale_bootstrap_install_raw.stdout | from_json }}
+
+- name: Tailscale Bootstrap | Validate installation result
+  when: not tailscale_bootstrap_installed | bool
+  ansible.builtin.assert:
+    that:
+      - tailscale_bootstrap_install_envelope.get('exited', 0) | int == 1
+      - tailscale_bootstrap_install_envelope.get('exitcode', 1) | int == 0
+    fail_msg: >-
+      Tailscale installation inside the guest failed. Inspect the returned
+      guest-agent output and the guest's APT configuration.
+
+################################
+# TAILSCALED
+################################
+
+- name: Tailscale Bootstrap | Enable and start tailscaled
+  ansible.builtin.command:
+    argv:
+      - qm
+      - guest
+      - exec
+      - "{{ tailscale_bootstrap_vmid_effective | string }}"
+      - --timeout
+      - "60"
+      - --
+      - /bin/sh
+      - -c
+      - |-
+        set -eu
+
+        changed=0
+
+        systemctl is-enabled --quiet tailscaled || changed=1
+        systemctl is-active --quiet tailscaled || changed=1
+
+        systemctl enable --now tailscaled
+
+        printf 'TAILSCALED_CHANGED=%s\n' "$changed"
+  register: tailscale_bootstrap_daemon_raw
+  changed_when: >-
+    'TAILSCALED_CHANGED=1' in tailscale_bootstrap_daemon_raw.stdout
+
+- name: Tailscale Bootstrap | Parse tailscaled result
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_daemon_envelope: >-
+      {{ tailscale_bootstrap_daemon_raw.stdout | from_json }}
+
+- name: Tailscale Bootstrap | Validate tailscaled result
+  ansible.builtin.assert:
+    that:
+      - tailscale_bootstrap_daemon_envelope.get('exited', 0) | int == 1
+      - tailscale_bootstrap_daemon_envelope.get('exitcode', 1) | int == 0
+    fail_msg: >-
+      tailscaled could not be enabled or started inside the guest.
+
+################################
+# CURRENT AUTHENTICATION STATE
+################################
+
+- name: Tailscale Bootstrap | Query current Tailscale status
+  ansible.builtin.command:
+    argv:
+      - qm
+      - guest
+      - exec
+      - "{{ tailscale_bootstrap_vmid_effective | string }}"
+      - --timeout
+      - "30"
+      - --
+      - tailscale
+      - status
+      - --json
+  register: tailscale_bootstrap_status_raw
+  changed_when: false
+
+- name: Tailscale Bootstrap | Parse status envelope
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_status_envelope: >-
+      {{ tailscale_bootstrap_status_raw.stdout | from_json }}
+
+- name: Tailscale Bootstrap | Validate status envelope
+  ansible.builtin.assert:
+    that:
+      - tailscale_bootstrap_status_envelope.get('exited', 0) | int == 1
+      - tailscale_bootstrap_status_envelope.get('exitcode', 1) | int == 0
+      - >-
+        tailscale_bootstrap_status_envelope.get('out-data', '')
+        | trim
+        | length > 0
+    fail_msg: >-
+      The guest returned no usable output from tailscale status --json.
+
+- name: Tailscale Bootstrap | Parse current Tailscale status
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_status: >-
+      {{
+        (
+          tailscale_bootstrap_status_envelope.get('out-data', '{}')
+          | trim
+        )
+        | from_json
+      }}
+
+- name: Tailscale Bootstrap | Record current backend state
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_backend_state: >-
+      {{ tailscale_bootstrap_status.BackendState | default("Unknown") }}
+    tailscale_bootstrap_connected: >-
+      {{
+        tailscale_bootstrap_status.BackendState
+        | default("")
+        == "Running"
+      }}
+
+################################
+# AUTHENTICATION
+################################
+
+- name: Tailscale Bootstrap | Prompt for one-off authentication key
+  when: not tailscale_bootstrap_connected | bool
+  ansible.builtin.pause:
+    prompt: >-
+      Enter a one-off Tailscale authentication key for
+      {{ tailscale_bootstrap_hostname_effective }}
+    echo: false
+  register: tailscale_bootstrap_auth_prompt
+  no_log: true
+
+- name: Tailscale Bootstrap | Validate supplied authentication key
+  when: not tailscale_bootstrap_connected | bool
+  ansible.builtin.assert:
+    that:
+      - tailscale_bootstrap_auth_prompt.user_input is defined
+      - tailscale_bootstrap_auth_prompt.user_input | trim | length > 0
+    fail_msg: A non-empty one-off Tailscale authentication key is required.
+  no_log: true
+
+- name: Tailscale Bootstrap | Authenticate guest with Tailscale
+  when: not tailscale_bootstrap_connected | bool
+  ansible.builtin.command:
+    argv:
+      - qm
+      - guest
+      - exec
+      - "{{ tailscale_bootstrap_vmid_effective | string }}"
+      - --pass-stdin
+      - "1"
+      - --timeout
+      - "120"
+      - --
+      - /bin/sh
+      - -c
+      - |-
+        set -eu
+
+        hostname="$1"
+        enable_ssh="$2"
+
+        umask 077
+        key_file="$(mktemp /run/tailscale-auth.XXXXXX)"
+        trap 'rm -f "$key_file"' EXIT HUP INT TERM
+
+        cat > "$key_file"
+        test -s "$key_file"
+
+        set -- tailscale up \
+          "--auth-key=file:$key_file" \
+          "--hostname=$hostname"
+
+        if [ "$enable_ssh" = "1" ]; then
+          set -- "$@" --ssh
+        fi
+
+        "$@"
+      - tailscale-bootstrap
+      - "{{ tailscale_bootstrap_hostname_effective }}"
+      - "{{ '1' if tailscale_bootstrap_enable_ssh_effective else '0' }}"
+    stdin: "{{ tailscale_bootstrap_auth_prompt.user_input | trim }}"
+    stdin_add_newline: false
+  register: tailscale_bootstrap_auth_raw
+  changed_when: true
+  no_log: true
+
+- name: Tailscale Bootstrap | Parse authentication result
+  when: not tailscale_bootstrap_connected | bool
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_auth_envelope: >-
+      {{ tailscale_bootstrap_auth_raw.stdout | from_json }}
+  no_log: true
+
+- name: Tailscale Bootstrap | Record authentication result
+  when: not tailscale_bootstrap_connected | bool
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_auth_succeeded: >-
+      {{
+        tailscale_bootstrap_auth_envelope.get('exited', 0) | int == 1
+        and
+        tailscale_bootstrap_auth_envelope.get('exitcode', 1) | int == 0
+      }}
+  no_log: true
+
+- name: Tailscale Bootstrap | Validate authentication result
+  when: not tailscale_bootstrap_connected | bool
+  ansible.builtin.assert:
+    that:
+      - tailscale_bootstrap_auth_succeeded | bool
+    fail_msg: >-
+      Tailscale authentication failed inside the guest. The key was not
+      displayed or retained. Generate a fresh one-off key and retry.
+
+################################
+# FINAL VERIFICATION
+################################
+
+- name: Tailscale Bootstrap | Query final Tailscale status
+  ansible.builtin.command:
+    argv:
+      - qm
+      - guest
+      - exec
+      - "{{ tailscale_bootstrap_vmid_effective | string }}"
+      - --timeout
+      - "30"
+      - --
+      - tailscale
+      - status
+      - --json
+  register: tailscale_bootstrap_final_status_raw
+  changed_when: false
+
+- name: Tailscale Bootstrap | Parse final status envelope
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_final_status_envelope: >-
+      {{ tailscale_bootstrap_final_status_raw.stdout | from_json }}
+
+- name: Tailscale Bootstrap | Validate final status command
+  ansible.builtin.assert:
+    that:
+      - >-
+        tailscale_bootstrap_final_status_envelope.get('exited', 0)
+        | int == 1
+      - >-
+        tailscale_bootstrap_final_status_envelope.get('exitcode', 1)
+        | int == 0
+      - >-
+        tailscale_bootstrap_final_status_envelope.get('out-data', '')
+        | trim
+        | length > 0
+    fail_msg: The final Tailscale status command failed.
+
+- name: Tailscale Bootstrap | Parse final Tailscale status
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_final_status: >-
+      {{
+        (
+          tailscale_bootstrap_final_status_envelope.get('out-data', '{}')
+          | trim
+        )
+        | from_json
+      }}
+
+- name: Tailscale Bootstrap | Assert Tailscale is connected
+  ansible.builtin.assert:
+    that:
+      - >-
+        tailscale_bootstrap_final_status.BackendState
+        | default("")
+        == "Running"
+    fail_msg: >-
+      Tailscale was installed but its final BackendState is not Running.
+
+- name: Tailscale Bootstrap | Query Tailscale IPv4 address
+  ansible.builtin.command:
+    argv:
+      - qm
+      - guest
+      - exec
+      - "{{ tailscale_bootstrap_vmid_effective | string }}"
+      - --timeout
+      - "30"
+      - --
+      - tailscale
+      - ip
+      - -4
+  register: tailscale_bootstrap_ip_raw
+  changed_when: false
+
+- name: Tailscale Bootstrap | Parse Tailscale IP result
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_ip_envelope: >-
+      {{ tailscale_bootstrap_ip_raw.stdout | from_json }}
+
+- name: Tailscale Bootstrap | Validate Tailscale IP result
+  ansible.builtin.assert:
+    that:
+      - tailscale_bootstrap_ip_envelope.get('exited', 0) | int == 1
+      - tailscale_bootstrap_ip_envelope.get('exitcode', 1) | int == 0
+      - >-
+        tailscale_bootstrap_ip_envelope.get('out-data', '')
+        | trim
+        | length > 0
+    fail_msg: Tailscale is connected but no IPv4 address was returned.
+
+- name: Tailscale Bootstrap | Record Tailscale IPv4 address
+  ansible.builtin.set_fact:
+    tailscale_bootstrap_ipv4: >-
+      {{ tailscale_bootstrap_ip_envelope.get('out-data', '') | trim }}
+
+- name: Tailscale Bootstrap | Report result
+  ansible.builtin.debug:
+    msg:
+      - "Guest: {{ tailscale_bootstrap_guest }}"
+      - "VMID: {{ tailscale_bootstrap_vmid_effective }}"
+      - "Hostname: {{ tailscale_bootstrap_hostname_effective }}"
+      - "BackendState: {{ tailscale_bootstrap_final_status.BackendState }}"
+      - "Tailscale IPv4: {{ tailscale_bootstrap_ipv4 }}"
+      - >-
+        Authentication performed:
+        {{ not tailscale_bootstrap_connected | bool }}

--- a/terraform/proxmox/modules/ubuntu-cloudinit-vm/README.md
+++ b/terraform/proxmox/modules/ubuntu-cloudinit-vm/README.md
@@ -1,0 +1,49 @@
+<!-- BEGIN_TF_DOCS -->
+
+
+## Resources
+
+| Name | Type |
+|------|------|
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_ballooning_memory_mb"></a> [ballooning\_memory\_mb](#input\_ballooning\_memory\_mb) | Minimum ballooned memory in MiB; use 0 to disable ballooning. | `number` | `0` | no |
+| <a name="input_clone_retries"></a> [clone\_retries](#input\_clone\_retries) | Number of clone retries requested from the Proxmox provider. | `number` | `3` | no |
+| <a name="input_clone_template_vm_id"></a> [clone\_template\_vm\_id](#input\_clone\_template\_vm\_id) | VMID of the cloud-init template to clone. | `number` | n/a | yes |
+| <a name="input_cloud_init_user"></a> [cloud\_init\_user](#input\_cloud\_init\_user) | Cloud-init administrative username. | `string` | `"ubuntu"` | no |
+| <a name="input_cpu_cores"></a> [cpu\_cores](#input\_cpu\_cores) | Number of virtual CPU cores. | `number` | `2` | no |
+| <a name="input_cpu_sockets"></a> [cpu\_sockets](#input\_cpu\_sockets) | Number of virtual CPU sockets. | `number` | `1` | no |
+| <a name="input_cpu_type"></a> [cpu\_type](#input\_cpu\_type) | Proxmox CPU type. | `string` | `"host"` | no |
+| <a name="input_datastore_id"></a> [datastore\_id](#input\_datastore\_id) | Proxmox datastore used for the VM disk and cloud-init disk. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | Proxmox VM description. | `string` | `"Ubuntu cloud-init VM managed by OpenTofu"` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | VM system disk size in GiB. | `number` | `24` | no |
+| <a name="input_dns_domain"></a> [dns\_domain](#input\_dns\_domain) | DNS search domain supplied through cloud-init. | `string` | `""` | no |
+| <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | DNS servers supplied through cloud-init. | `list(string)` | n/a | yes |
+| <a name="input_ipv4_address"></a> [ipv4\_address](#input\_ipv4\_address) | Static IPv4 address in CIDR notation. | `string` | n/a | yes |
+| <a name="input_ipv4_gateway"></a> [ipv4\_gateway](#input\_ipv4\_gateway) | IPv4 default gateway. | `string` | n/a | yes |
+| <a name="input_memory_mb"></a> [memory\_mb](#input\_memory\_mb) | Dedicated VM memory in MiB. | `number` | `2048` | no |
+| <a name="input_name"></a> [name](#input\_name) | Proxmox VM name. | `string` | n/a | yes |
+| <a name="input_network_bridge"></a> [network\_bridge](#input\_network\_bridge) | Proxmox bridge connected to the VM network interface. | `string` | `"vmbr0"` | no |
+| <a name="input_node_name"></a> [node\_name](#input\_node\_name) | Proxmox node on which to create the VM. | `string` | n/a | yes |
+| <a name="input_on_boot"></a> [on\_boot](#input\_on\_boot) | Start the VM automatically when the Proxmox node boots. | `bool` | `true` | no |
+| <a name="input_protection"></a> [protection](#input\_protection) | Enable Proxmox VM protection. | `bool` | `false` | no |
+| <a name="input_qemu_agent_enabled"></a> [qemu\_agent\_enabled](#input\_qemu\_agent\_enabled) | Enable the QEMU guest agent integration. | `bool` | `true` | no |
+| <a name="input_ssh_public_keys"></a> [ssh\_public\_keys](#input\_ssh\_public\_keys) | SSH public keys installed for the cloud-init user. | `list(string)` | n/a | yes |
+| <a name="input_started"></a> [started](#input\_started) | Ensure the VM is started after creation. | `bool` | `true` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags applied to the Proxmox VM. | `list(string)` | <pre>[<br/>  "terraform",<br/>  "ubuntu",<br/>  "cloud-init"<br/>]</pre> | no |
+| <a name="input_vendor_data_file_id"></a> [vendor\_data\_file\_id](#input\_vendor\_data\_file\_id) | Optional Proxmox snippets file ID used as cloud-init vendor data. | `string` | `null` | no |
+| <a name="input_vlan_id"></a> [vlan\_id](#input\_vlan\_id) | Optional VLAN tag for the VM network interface. | `number` | `null` | no |
+| <a name="input_vm_id"></a> [vm\_id](#input\_vm\_id) | Proxmox VMID. | `number` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | Provider resource ID for the VM. |
+| <a name="output_ipv4_address"></a> [ipv4\_address](#output\_ipv4\_address) | Configured static IPv4 address in CIDR notation. |
+| <a name="output_name"></a> [name](#output\_name) | Proxmox VM name. |
+| <a name="output_vm_id"></a> [vm\_id](#output\_vm\_id) | Proxmox VMID. |
+<!-- END_TF_DOCS -->

--- a/terraform/proxmox/modules/ubuntu-cloudinit-vm/README.md
+++ b/terraform/proxmox/modules/ubuntu-cloudinit-vm/README.md
@@ -31,6 +31,9 @@
 | <a name="input_on_boot"></a> [on\_boot](#input\_on\_boot) | Start the VM automatically when the Proxmox node boots. | `bool` | `true` | no |
 | <a name="input_protection"></a> [protection](#input\_protection) | Enable Proxmox VM protection. | `bool` | `false` | no |
 | <a name="input_qemu_agent_enabled"></a> [qemu\_agent\_enabled](#input\_qemu\_agent\_enabled) | Enable the QEMU guest agent integration. | `bool` | `true` | no |
+| <a name="input_qemu_guest_agent_bootstrap_enabled"></a> [qemu\_guest\_agent\_bootstrap\_enabled](#input\_qemu\_guest\_agent\_bootstrap\_enabled) | Install and start qemu-guest-agent through non-secret cloud-init vendor data. | `bool` | `true` | no |
+| <a name="input_qemu_guest_agent_snippet_file_name"></a> [qemu\_guest\_agent\_snippet\_file\_name](#input\_qemu\_guest\_agent\_snippet\_file\_name) | Optional filename override for the generated QEMU guest-agent cloud-init snippet. | `string` | `null` | no |
+| <a name="input_snippet_datastore_id"></a> [snippet\_datastore\_id](#input\_snippet\_datastore\_id) | Proxmox datastore used for generated cloud-init snippets. | `string` | `"local"` | no |
 | <a name="input_ssh_public_keys"></a> [ssh\_public\_keys](#input\_ssh\_public\_keys) | SSH public keys installed for the cloud-init user. | `list(string)` | n/a | yes |
 | <a name="input_started"></a> [started](#input\_started) | Ensure the VM is started after creation. | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags applied to the Proxmox VM. | `list(string)` | <pre>[<br/>  "terraform",<br/>  "ubuntu",<br/>  "cloud-init"<br/>]</pre> | no |

--- a/terraform/proxmox/modules/ubuntu-cloudinit-vm/main.tf
+++ b/terraform/proxmox/modules/ubuntu-cloudinit-vm/main.tf
@@ -1,3 +1,45 @@
+locals {
+  qemu_guest_agent_snippet_enabled = (
+    var.qemu_agent_enabled &&
+    var.qemu_guest_agent_bootstrap_enabled &&
+    var.vendor_data_file_id == null
+  )
+
+  qemu_guest_agent_snippet_file_name = (
+    var.qemu_guest_agent_snippet_file_name != null
+    ? var.qemu_guest_agent_snippet_file_name
+    : "${var.name}-qemu-guest-agent.yaml"
+  )
+
+  qemu_guest_agent_snippet_file_id = (
+    "${var.snippet_datastore_id}:snippets/${local.qemu_guest_agent_snippet_file_name}"
+  )
+}
+
+resource "proxmox_virtual_environment_file" "qemu_guest_agent_cloud_init" {
+  count = local.qemu_guest_agent_snippet_enabled ? 1 : 0
+
+  content_type = "snippets"
+  datastore_id = var.snippet_datastore_id
+  node_name    = var.node_name
+
+  source_raw {
+    file_name = local.qemu_guest_agent_snippet_file_name
+
+    data = <<-EOF
+      #cloud-config
+      package_update: true
+      package_upgrade: false
+
+      packages:
+        - qemu-guest-agent
+
+      runcmd:
+        - systemctl enable --now qemu-guest-agent
+    EOF
+  }
+}
+
 resource "proxmox_virtual_environment_vm" "this" {
   name        = var.name
   description = var.description
@@ -8,6 +50,10 @@ resource "proxmox_virtual_environment_vm" "this" {
   on_boot    = var.on_boot
   protection = var.protection
   started    = var.started
+
+  depends_on = [
+    proxmox_virtual_environment_file.qemu_guest_agent_cloud_init,
+  ]
 
   clone {
     vm_id   = var.clone_template_vm_id
@@ -42,8 +88,16 @@ resource "proxmox_virtual_environment_vm" "this" {
   }
 
   initialization {
-    datastore_id        = var.datastore_id
-    vendor_data_file_id = var.vendor_data_file_id
+    datastore_id = var.datastore_id
+    vendor_data_file_id = (
+      var.vendor_data_file_id != null
+      ? var.vendor_data_file_id
+      : (
+        local.qemu_guest_agent_snippet_enabled
+        ? local.qemu_guest_agent_snippet_file_id
+        : null
+      )
+    )
 
     ip_config {
       ipv4 {

--- a/terraform/proxmox/modules/ubuntu-cloudinit-vm/main.tf
+++ b/terraform/proxmox/modules/ubuntu-cloudinit-vm/main.tf
@@ -1,0 +1,94 @@
+resource "proxmox_virtual_environment_vm" "this" {
+  name        = var.name
+  description = var.description
+  vm_id       = var.vm_id
+  node_name   = var.node_name
+
+  tags       = var.tags
+  on_boot    = var.on_boot
+  protection = var.protection
+  started    = var.started
+
+  clone {
+    vm_id   = var.clone_template_vm_id
+    full    = true
+    retries = var.clone_retries
+  }
+
+  agent {
+    enabled = var.qemu_agent_enabled
+  }
+
+  cpu {
+    cores   = var.cpu_cores
+    sockets = var.cpu_sockets
+    type    = var.cpu_type
+  }
+
+  memory {
+    dedicated = var.memory_mb
+    floating  = var.ballooning_memory_mb
+  }
+
+  serial_device {
+    device = "socket"
+  }
+
+  disk {
+    datastore_id = var.datastore_id
+    interface    = "scsi0"
+    size         = var.disk_size_gb
+    iothread     = true
+  }
+
+  initialization {
+    datastore_id        = var.datastore_id
+    vendor_data_file_id = var.vendor_data_file_id
+
+    ip_config {
+      ipv4 {
+        address = var.ipv4_address
+        gateway = var.ipv4_gateway
+      }
+    }
+
+    dns {
+      domain  = var.dns_domain
+      servers = var.dns_servers
+    }
+
+    user_account {
+      username = var.cloud_init_user
+      keys     = var.ssh_public_keys
+    }
+  }
+
+  network_device {
+    bridge  = var.network_bridge
+    vlan_id = var.vlan_id
+  }
+
+  operating_system {
+    type = "l26"
+  }
+
+  boot_order    = ["scsi0"]
+  scsi_hardware = "virtio-scsi-single"
+
+  lifecycle {
+    precondition {
+      condition     = length(var.dns_servers) > 0
+      error_message = "At least one DNS server must be supplied to the Ubuntu VM module."
+    }
+
+    precondition {
+      condition     = length(var.ssh_public_keys) > 0
+      error_message = "At least one SSH public key must be supplied to the Ubuntu VM module."
+    }
+
+    precondition {
+      condition     = var.ballooning_memory_mb <= var.memory_mb
+      error_message = "ballooning_memory_mb must not exceed memory_mb."
+    }
+  }
+}

--- a/terraform/proxmox/modules/ubuntu-cloudinit-vm/outputs.tf
+++ b/terraform/proxmox/modules/ubuntu-cloudinit-vm/outputs.tf
@@ -1,0 +1,19 @@
+output "id" {
+  description = "Provider resource ID for the VM."
+  value       = proxmox_virtual_environment_vm.this.id
+}
+
+output "name" {
+  description = "Proxmox VM name."
+  value       = proxmox_virtual_environment_vm.this.name
+}
+
+output "vm_id" {
+  description = "Proxmox VMID."
+  value       = proxmox_virtual_environment_vm.this.vm_id
+}
+
+output "ipv4_address" {
+  description = "Configured static IPv4 address in CIDR notation."
+  value       = var.ipv4_address
+}

--- a/terraform/proxmox/modules/ubuntu-cloudinit-vm/variables.tf
+++ b/terraform/proxmox/modules/ubuntu-cloudinit-vm/variables.tf
@@ -1,0 +1,204 @@
+variable "name" {
+  description = "Proxmox VM name."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.name) != ""
+    error_message = "name must not be empty."
+  }
+}
+
+variable "description" {
+  description = "Proxmox VM description."
+  type        = string
+  default     = "Ubuntu cloud-init VM managed by OpenTofu"
+}
+
+variable "vm_id" {
+  description = "Proxmox VMID."
+  type        = number
+
+  validation {
+    condition     = var.vm_id >= 100
+    error_message = "vm_id must be at least 100."
+  }
+}
+
+variable "node_name" {
+  description = "Proxmox node on which to create the VM."
+  type        = string
+}
+
+variable "clone_template_vm_id" {
+  description = "VMID of the cloud-init template to clone."
+  type        = number
+}
+
+variable "clone_retries" {
+  description = "Number of clone retries requested from the Proxmox provider."
+  type        = number
+  default     = 3
+}
+
+variable "tags" {
+  description = "Tags applied to the Proxmox VM."
+  type        = list(string)
+  default     = ["terraform", "ubuntu", "cloud-init"]
+}
+
+variable "on_boot" {
+  description = "Start the VM automatically when the Proxmox node boots."
+  type        = bool
+  default     = true
+}
+
+variable "protection" {
+  description = "Enable Proxmox VM protection."
+  type        = bool
+  default     = false
+}
+
+variable "started" {
+  description = "Ensure the VM is started after creation."
+  type        = bool
+  default     = true
+}
+
+variable "qemu_agent_enabled" {
+  description = "Enable the QEMU guest agent integration."
+  type        = bool
+  default     = true
+}
+
+variable "cpu_cores" {
+  description = "Number of virtual CPU cores."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.cpu_cores >= 1
+    error_message = "cpu_cores must be at least 1."
+  }
+}
+
+variable "cpu_sockets" {
+  description = "Number of virtual CPU sockets."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.cpu_sockets >= 1
+    error_message = "cpu_sockets must be at least 1."
+  }
+}
+
+variable "cpu_type" {
+  description = "Proxmox CPU type."
+  type        = string
+  default     = "host"
+}
+
+variable "memory_mb" {
+  description = "Dedicated VM memory in MiB."
+  type        = number
+  default     = 2048
+
+  validation {
+    condition     = var.memory_mb >= 512
+    error_message = "memory_mb must be at least 512 MiB."
+  }
+}
+
+variable "ballooning_memory_mb" {
+  description = "Minimum ballooned memory in MiB; use 0 to disable ballooning."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.ballooning_memory_mb >= 0
+    error_message = "ballooning_memory_mb must not be negative."
+  }
+}
+
+variable "datastore_id" {
+  description = "Proxmox datastore used for the VM disk and cloud-init disk."
+  type        = string
+}
+
+variable "disk_size_gb" {
+  description = "VM system disk size in GiB."
+  type        = number
+  default     = 24
+
+  validation {
+    condition     = var.disk_size_gb >= 8
+    error_message = "disk_size_gb must be at least 8 GiB."
+  }
+}
+
+variable "vendor_data_file_id" {
+  description = "Optional Proxmox snippets file ID used as cloud-init vendor data."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "ipv4_address" {
+  description = "Static IPv4 address in CIDR notation."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{1,3}(\\.[0-9]{1,3}){3}/[0-9]{1,2}$", var.ipv4_address)) && can(cidrhost(var.ipv4_address, 0))
+    error_message = "ipv4_address must be valid CIDR notation, for example 192.168.80.50/24."
+  }
+}
+
+variable "ipv4_gateway" {
+  description = "IPv4 default gateway."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{1,3}(\\.[0-9]{1,3}){3}$", var.ipv4_gateway)) && can(cidrhost("${var.ipv4_gateway}/32", 0))
+    error_message = "ipv4_gateway must be an IPv4 address."
+  }
+}
+
+variable "dns_servers" {
+  description = "DNS servers supplied through cloud-init."
+  type        = list(string)
+}
+
+variable "dns_domain" {
+  description = "DNS search domain supplied through cloud-init."
+  type        = string
+  default     = ""
+}
+
+variable "cloud_init_user" {
+  description = "Cloud-init administrative username."
+  type        = string
+  default     = "ubuntu"
+}
+
+variable "ssh_public_keys" {
+  description = "SSH public keys installed for the cloud-init user."
+  type        = list(string)
+}
+
+variable "network_bridge" {
+  description = "Proxmox bridge connected to the VM network interface."
+  type        = string
+  default     = "vmbr0"
+}
+
+variable "vlan_id" {
+  description = "Optional VLAN tag for the VM network interface."
+  type        = number
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.vlan_id == null || (var.vlan_id >= 1 && var.vlan_id <= 4094)
+    error_message = "vlan_id must be null or between 1 and 4094."
+  }
+}

--- a/terraform/proxmox/modules/ubuntu-cloudinit-vm/variables.tf
+++ b/terraform/proxmox/modules/ubuntu-cloudinit-vm/variables.tf
@@ -64,10 +64,37 @@ variable "started" {
   default     = true
 }
 
+variable "snippet_datastore_id" {
+  description = "Proxmox datastore used for generated cloud-init snippets."
+  type        = string
+  default     = "local"
+}
+
+variable "qemu_guest_agent_bootstrap_enabled" {
+  description = "Install and start qemu-guest-agent through non-secret cloud-init vendor data."
+  type        = bool
+  default     = true
+}
+
 variable "qemu_agent_enabled" {
   description = "Enable the QEMU guest agent integration."
   type        = bool
   default     = true
+}
+
+variable "qemu_guest_agent_snippet_file_name" {
+  description = "Optional filename override for the generated QEMU guest-agent cloud-init snippet."
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition = (
+      var.qemu_guest_agent_snippet_file_name == null ||
+      trimspace(var.qemu_guest_agent_snippet_file_name) != ""
+    )
+    error_message = "qemu_guest_agent_snippet_file_name must be null or a non-empty filename."
+  }
 }
 
 variable "cpu_cores" {

--- a/terraform/proxmox/modules/ubuntu-cloudinit-vm/versions.tf
+++ b/terraform/proxmox/modules/ubuntu-cloudinit-vm/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11.0"
+
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "0.111.1"
+    }
+  }
+}

--- a/terraform/proxmox/vms/n8n/.terraform.lock.hcl
+++ b/terraform/proxmox/vms/n8n/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/bpg/proxmox" {
+  version     = "0.111.1"
+  constraints = "0.111.1"
+  hashes = [
+    "h1:0qABXcf7ulwKRhKGoK4LYZ7ObyoFkPxHmCrL6jRhMgE=",
+    "h1:0xM4HmXdu0hLrauA8ugcxjZvYHA+PuRybUxrXZEAdRI=",
+    "h1:ML2D3UUZTM99yrll/EBXj7wBYMb8xmQgomqFNybEoxY=",
+    "h1:PFGpaC7xcdC8w9jpxZPLJ/FFbVK5hd/CArUY+oXXTu8=",
+    "h1:XoYUWDsGWvxSlir/sYiGzx1MkcPVUtWIgc6OWEdf/C8=",
+    "h1:Zn7LyCWL/Xn0yCHiigXFYEp3MIv0MOVzUfL657QOplY=",
+    "h1:dIGBUSoC89e/PbpBEjbZ/YOzAkzrG1kF6EYcqk+8IqE=",
+    "h1:eERpiB94PyhN2SqE9E1+6sgpk0Kn6qjy555R2cjfpug=",
+    "h1:ejD4OSOL98W/SA4jLDvxEwCW8NSdVGKLyKmgfAUROK8=",
+    "h1:iTQv4FVFhMVl2juw6lgrVTpGFrdmdNPj+NFY2Dms0SE=",
+    "h1:jcqEv/zW+heFIPq5xwXxgS9EuBmbjIM1MriwQjx75WE=",
+    "h1:xF+AQJqpRf30WbrfHgSeuLqDBptWhTIdVoMyv7j6yVo=",
+    "h1:xWV1Y6ItiFXNCJO9OtyINMx8cqT5XiTOK2Rne7Jyu3w=",
+    "zh:18fb7c31a08dde6bffa1a4d4a211e604d6d17eec7092fd59331b3db3c6f3742c",
+    "zh:1cd60761538289d4dd2a1086b3ae62a7b0bdd4b1a2f824e9a44e243413168dba",
+    "zh:2eb76f6fc8299b6820ff678c8252332cc3366e226b5ae2e61748fd2449c1ed92",
+    "zh:45e6f7ebd0bf48911d37060359a4f359b5743b3092e985295733990e406d0416",
+    "zh:4aa8ba912eae37975d2e983394d173e595ca34fc76b5bf220b37d0e99d76e98c",
+    "zh:58e0789923103a77d502a0a9fc3eb920625e8eb935ec2d4ac0d006aebd1d186c",
+    "zh:6df8aa85fb8865915537e946c19b02538ad188018a629759c213c6f03730f642",
+    "zh:6ed47bc00d0913a1d0880618fa1376115e9edab6b4a658c081061a7f0e4ca360",
+    "zh:c5b10ff4f33df7e4c29e8f1127d49845b561b37b57517e844fb0954d7923d65e",
+    "zh:d016510e14b738499f0db9d9b3aafe82fc6877fb4ab4e9f831fb68a8d70a1385",
+    "zh:d941f394069bbf24351b363da1c64383f487067aaee0a84f9b96476d4912e212",
+    "zh:ddf271dbc2632ae8ffa8de3972f243ee47d260cb2ac90aa784f2746d98e21a0f",
+    "zh:ed0caa3501c42f611b7e9622c9b1df69fd85dc25a3cd88d3076381829688cd62",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/terraform/proxmox/vms/n8n/README.md
+++ b/terraform/proxmox/vms/n8n/README.md
@@ -1,0 +1,63 @@
+<!-- BEGIN_TF_DOCS -->
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_n8n_vm"></a> [n8n\_vm](#module\_n8n\_vm) | ../../modules/ubuntu-cloudinit-vm | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [terraform_remote_state.netbox](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_clone_template_vm_id"></a> [clone\_template\_vm\_id](#input\_clone\_template\_vm\_id) | VMID of the Ubuntu 24.04 cloud-init template. | `number` | n/a | yes |
+| <a name="input_cloud_init_user"></a> [cloud\_init\_user](#input\_cloud\_init\_user) | Cloud-init administrative username. | `string` | `"ubuntu"` | no |
+| <a name="input_dns_ips"></a> [dns\_ips](#input\_dns\_ips) | Fallback DNS VIP map, normally sourced from NetBox outputs. | `map(string)` | `{}` | no |
+| <a name="input_enable_netbox_remote_state"></a> [enable\_netbox\_remote\_state](#input\_enable\_netbox\_remote\_state) | Read DNS topology from the terraform/netbox local state. | `bool` | `true` | no |
+| <a name="input_enable_tailscale_bootstrap"></a> [enable\_tailscale\_bootstrap](#input\_enable\_tailscale\_bootstrap) | Install and enrol Tailscale through a cloud-init vendor-data snippet. | `bool` | `true` | no |
+| <a name="input_netbox_state_path"></a> [netbox\_state\_path](#input\_netbox\_state\_path) | Path to the terraform/netbox state file. | `string` | `"../../../netbox/terraform.tfstate"` | no |
+| <a name="input_pm_api_token"></a> [pm\_api\_token](#input\_pm\_api\_token) | Proxmox API token in user@realm!tokenid=secret format. | `string` | n/a | yes |
+| <a name="input_pm_api_url"></a> [pm\_api\_url](#input\_pm\_api\_url) | Proxmox API URL, for example https://pve.example.com:8006/. | `string` | n/a | yes |
+| <a name="input_pm_ssh_host"></a> [pm\_ssh\_host](#input\_pm\_ssh\_host) | SSH address of the target Proxmox node. | `string` | n/a | yes |
+| <a name="input_pm_ssh_port"></a> [pm\_ssh\_port](#input\_pm\_ssh\_port) | SSH port of the target Proxmox node. | `number` | `22` | no |
+| <a name="input_pm_ssh_username"></a> [pm\_ssh\_username](#input\_pm\_ssh\_username) | SSH username used by the Proxmox provider for snippet operations. | `string` | `"root"` | no |
+| <a name="input_pm_tls_insecure"></a> [pm\_tls\_insecure](#input\_pm\_tls\_insecure) | Allow a self-signed Proxmox API certificate. | `bool` | `false` | no |
+| <a name="input_qemu_agent_enabled"></a> [qemu\_agent\_enabled](#input\_qemu\_agent\_enabled) | Enable QEMU guest-agent integration. | `bool` | `true` | no |
+| <a name="input_snippet_storage"></a> [snippet\_storage](#input\_snippet\_storage) | Proxmox snippets datastore for optional cloud-init vendor data. | `string` | `"local"` | no |
+| <a name="input_ssh_public_key_path"></a> [ssh\_public\_key\_path](#input\_ssh\_public\_key\_path) | Local path to the SSH public key installed by cloud-init. | `string` | n/a | yes |
+| <a name="input_tailscale_auth_key"></a> [tailscale\_auth\_key](#input\_tailscale\_auth\_key) | Tailscale auth key used only during initial cloud-init bootstrap. | `string` | `null` | no |
+| <a name="input_target_node"></a> [target\_node](#input\_target\_node) | Proxmox node on which to create the n8n VM. | `string` | n/a | yes |
+| <a name="input_vm_ballooning_memory_mb"></a> [vm\_ballooning\_memory\_mb](#input\_vm\_ballooning\_memory\_mb) | Minimum ballooned memory in MiB; 0 disables ballooning. | `number` | `0` | no |
+| <a name="input_vm_cpu_cores"></a> [vm\_cpu\_cores](#input\_vm\_cpu\_cores) | Number of n8n VM virtual CPU cores. | `number` | `2` | no |
+| <a name="input_vm_cpu_sockets"></a> [vm\_cpu\_sockets](#input\_vm\_cpu\_sockets) | Number of n8n VM virtual CPU sockets. | `number` | `1` | no |
+| <a name="input_vm_cpu_type"></a> [vm\_cpu\_type](#input\_vm\_cpu\_type) | Proxmox CPU type exposed to the n8n VM. | `string` | `"host"` | no |
+| <a name="input_vm_description"></a> [vm\_description](#input\_vm\_description) | Proxmox VM description. | `string` | `"Isolated n8n automation VM managed by OpenTofu"` | no |
+| <a name="input_vm_disk_size_gb"></a> [vm\_disk\_size\_gb](#input\_vm\_disk\_size\_gb) | n8n VM system disk size in GiB. | `number` | `24` | no |
+| <a name="input_vm_id"></a> [vm\_id](#input\_vm\_id) | VMID assigned to the n8n VM. | `number` | n/a | yes |
+| <a name="input_vm_ipv4_address"></a> [vm\_ipv4\_address](#input\_vm\_ipv4\_address) | Static n8n VM IPv4 address in CIDR notation. | `string` | n/a | yes |
+| <a name="input_vm_ipv4_gateway"></a> [vm\_ipv4\_gateway](#input\_vm\_ipv4\_gateway) | IPv4 default gateway for the n8n VM. | `string` | n/a | yes |
+| <a name="input_vm_memory_mb"></a> [vm\_memory\_mb](#input\_vm\_memory\_mb) | Dedicated memory for the n8n VM in MiB. | `number` | `2048` | no |
+| <a name="input_vm_name"></a> [vm\_name](#input\_vm\_name) | Proxmox VM name. | `string` | `"n8n"` | no |
+| <a name="input_vm_nameservers"></a> [vm\_nameservers](#input\_vm\_nameservers) | Fallback DNS servers used when NetBox remote state is disabled. | `list(string)` | `[]` | no |
+| <a name="input_vm_network_bridge"></a> [vm\_network\_bridge](#input\_vm\_network\_bridge) | Proxmox bridge connected to the n8n VM. | `string` | `"vmbr0"` | no |
+| <a name="input_vm_on_boot"></a> [vm\_on\_boot](#input\_vm\_on\_boot) | Start the n8n VM when the Proxmox node boots. | `bool` | `true` | no |
+| <a name="input_vm_protection"></a> [vm\_protection](#input\_vm\_protection) | Enable Proxmox VM protection. | `bool` | `false` | no |
+| <a name="input_vm_search_domain"></a> [vm\_search\_domain](#input\_vm\_search\_domain) | Fallback DNS search domain used when NetBox does not supply one. | `string` | `""` | no |
+| <a name="input_vm_started"></a> [vm\_started](#input\_vm\_started) | Ensure the n8n VM is started after creation. | `bool` | `true` | no |
+| <a name="input_vm_storage"></a> [vm\_storage](#input\_vm\_storage) | Proxmox datastore for VM and cloud-init disks. | `string` | n/a | yes |
+| <a name="input_vm_tags"></a> [vm\_tags](#input\_vm\_tags) | Tags applied to the n8n VM in Proxmox. | `list(string)` | <pre>[<br/>  "terraform",<br/>  "ubuntu",<br/>  "automation",<br/>  "n8n"<br/>]</pre> | no |
+| <a name="input_vm_vlan_id"></a> [vm\_vlan\_id](#input\_vm\_vlan\_id) | Optional VLAN tag for the n8n VM. | `number` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_n8n_vm_id"></a> [n8n\_vm\_id](#output\_n8n\_vm\_id) | Proxmox VMID assigned to the n8n VM. |
+| <a name="output_n8n_vm_ipv4_address"></a> [n8n\_vm\_ipv4\_address](#output\_n8n\_vm\_ipv4\_address) | Static IPv4 address configured for the n8n VM. |
+| <a name="output_n8n_vm_name"></a> [n8n\_vm\_name](#output\_n8n\_vm\_name) | Proxmox name of the n8n VM. |
+<!-- END_TF_DOCS -->

--- a/terraform/proxmox/vms/n8n/README.md
+++ b/terraform/proxmox/vms/n8n/README.md
@@ -19,7 +19,6 @@
 | <a name="input_cloud_init_user"></a> [cloud\_init\_user](#input\_cloud\_init\_user) | Cloud-init administrative username. | `string` | `"ubuntu"` | no |
 | <a name="input_dns_ips"></a> [dns\_ips](#input\_dns\_ips) | Fallback DNS VIP map, normally sourced from NetBox outputs. | `map(string)` | `{}` | no |
 | <a name="input_enable_netbox_remote_state"></a> [enable\_netbox\_remote\_state](#input\_enable\_netbox\_remote\_state) | Read DNS topology from the terraform/netbox local state. | `bool` | `true` | no |
-| <a name="input_enable_tailscale_bootstrap"></a> [enable\_tailscale\_bootstrap](#input\_enable\_tailscale\_bootstrap) | Install and enrol Tailscale through a cloud-init vendor-data snippet. | `bool` | `true` | no |
 | <a name="input_netbox_state_path"></a> [netbox\_state\_path](#input\_netbox\_state\_path) | Path to the terraform/netbox state file. | `string` | `"../../../netbox/terraform.tfstate"` | no |
 | <a name="input_pm_api_token"></a> [pm\_api\_token](#input\_pm\_api\_token) | Proxmox API token in user@realm!tokenid=secret format. | `string` | n/a | yes |
 | <a name="input_pm_api_url"></a> [pm\_api\_url](#input\_pm\_api\_url) | Proxmox API URL, for example https://pve.example.com:8006/. | `string` | n/a | yes |
@@ -28,9 +27,9 @@
 | <a name="input_pm_ssh_username"></a> [pm\_ssh\_username](#input\_pm\_ssh\_username) | SSH username used by the Proxmox provider for snippet operations. | `string` | `"root"` | no |
 | <a name="input_pm_tls_insecure"></a> [pm\_tls\_insecure](#input\_pm\_tls\_insecure) | Allow a self-signed Proxmox API certificate. | `bool` | `false` | no |
 | <a name="input_qemu_agent_enabled"></a> [qemu\_agent\_enabled](#input\_qemu\_agent\_enabled) | Enable QEMU guest-agent integration. | `bool` | `true` | no |
+| <a name="input_qemu_guest_agent_bootstrap_enabled"></a> [qemu\_guest\_agent\_bootstrap\_enabled](#input\_qemu\_guest\_agent\_bootstrap\_enabled) | Install qemu-guest-agent during first boot so Proxmox can bootstrap the guest. | `bool` | `true` | no |
 | <a name="input_snippet_storage"></a> [snippet\_storage](#input\_snippet\_storage) | Proxmox snippets datastore for optional cloud-init vendor data. | `string` | `"local"` | no |
 | <a name="input_ssh_public_key_path"></a> [ssh\_public\_key\_path](#input\_ssh\_public\_key\_path) | Local path to the SSH public key installed by cloud-init. | `string` | n/a | yes |
-| <a name="input_tailscale_auth_key"></a> [tailscale\_auth\_key](#input\_tailscale\_auth\_key) | Tailscale auth key used only during initial cloud-init bootstrap. | `string` | `null` | no |
 | <a name="input_target_node"></a> [target\_node](#input\_target\_node) | Proxmox node on which to create the n8n VM. | `string` | n/a | yes |
 | <a name="input_vm_ballooning_memory_mb"></a> [vm\_ballooning\_memory\_mb](#input\_vm\_ballooning\_memory\_mb) | Minimum ballooned memory in MiB; 0 disables ballooning. | `number` | `0` | no |
 | <a name="input_vm_cpu_cores"></a> [vm\_cpu\_cores](#input\_vm\_cpu\_cores) | Number of n8n VM virtual CPU cores. | `number` | `2` | no |

--- a/terraform/proxmox/vms/n8n/data.tf
+++ b/terraform/proxmox/vms/n8n/data.tf
@@ -1,0 +1,9 @@
+data "terraform_remote_state" "netbox" {
+  count = var.enable_netbox_remote_state ? 1 : 0
+
+  backend = "local"
+
+  config = {
+    path = var.netbox_state_path
+  }
+}

--- a/terraform/proxmox/vms/n8n/locals.tf
+++ b/terraform/proxmox/vms/n8n/locals.tf
@@ -1,0 +1,32 @@
+locals {
+  netbox_dns_ips       = var.enable_netbox_remote_state ? try(data.terraform_remote_state.netbox[0].outputs.dns_ips, {}) : {}
+  netbox_internal_zone = var.enable_netbox_remote_state ? try(data.terraform_remote_state.netbox[0].outputs.internal_zone, "") : ""
+
+  dns_ips = merge(
+    var.dns_ips,
+    local.netbox_dns_ips,
+  )
+
+  dns_vip_nameservers = distinct(compact([
+    trimspace(lookup(local.dns_ips, "dns_vip_a", "")),
+    trimspace(lookup(local.dns_ips, "dns_vip_b", "")),
+  ]))
+
+  configured_vm_nameservers = distinct(compact([
+    for nameserver in var.vm_nameservers : trimspace(nameserver)
+  ]))
+
+  use_dns_vips = var.enable_netbox_remote_state || length(local.configured_vm_nameservers) == 0
+  vm_nameservers = (
+    local.use_dns_vips
+    ? local.dns_vip_nameservers
+    : local.configured_vm_nameservers
+  )
+
+  vm_search_domain_source = (
+    trimspace(local.netbox_internal_zone) != ""
+    ? local.netbox_internal_zone
+    : var.vm_search_domain
+  )
+  vm_search_domain = trim(trimspace(local.vm_search_domain_source), ".")
+}

--- a/terraform/proxmox/vms/n8n/main.tf
+++ b/terraform/proxmox/vms/n8n/main.tf
@@ -1,32 +1,3 @@
-resource "proxmox_virtual_environment_file" "tailscale_cloud_init" {
-  count = var.enable_tailscale_bootstrap ? 1 : 0
-
-  content_type = "snippets"
-  datastore_id = var.snippet_storage
-  node_name    = var.target_node
-
-  source_raw {
-    file_name = "${var.vm_name}-tailscale-bootstrap.yaml"
-    data      = <<-EOF
-      #cloud-config
-      package_update: true
-      package_upgrade: false
-
-      runcmd:
-        - curl -fsSL https://tailscale.com/install.sh | sh
-        - systemctl enable --now tailscaled
-        - tailscale up --auth-key='${var.tailscale_auth_key != null ? var.tailscale_auth_key : ""}' --hostname='${var.vm_name}' --ssh
-    EOF
-  }
-
-  lifecycle {
-    precondition {
-      condition     = !var.enable_tailscale_bootstrap || try(trimspace(var.tailscale_auth_key), "") != ""
-      error_message = "tailscale_auth_key must be provided when enable_tailscale_bootstrap is true."
-    }
-  }
-}
-
 module "n8n_vm" {
   source = "../../modules/ubuntu-cloudinit-vm"
 
@@ -36,25 +7,27 @@ module "n8n_vm" {
   node_name            = var.target_node
   clone_template_vm_id = var.clone_template_vm_id
 
-  tags                 = var.vm_tags
-  on_boot              = var.vm_on_boot
-  protection           = var.vm_protection
-  started              = var.vm_started
-  qemu_agent_enabled   = var.qemu_agent_enabled
-  cpu_cores            = var.vm_cpu_cores
-  cpu_sockets          = var.vm_cpu_sockets
-  cpu_type             = var.vm_cpu_type
-  memory_mb            = var.vm_memory_mb
-  ballooning_memory_mb = var.vm_ballooning_memory_mb
-  datastore_id         = var.vm_storage
-  disk_size_gb         = var.vm_disk_size_gb
-  vendor_data_file_id  = var.enable_tailscale_bootstrap ? proxmox_virtual_environment_file.tailscale_cloud_init[0].id : null
-  ipv4_address         = var.vm_ipv4_address
-  ipv4_gateway         = var.vm_ipv4_gateway
-  dns_servers          = local.vm_nameservers
-  dns_domain           = local.vm_search_domain
-  cloud_init_user      = var.cloud_init_user
-  ssh_public_keys      = [trimspace(file(pathexpand(var.ssh_public_key_path)))]
-  network_bridge       = var.vm_network_bridge
-  vlan_id              = var.vm_vlan_id
+  tags                               = var.vm_tags
+  on_boot                            = var.vm_on_boot
+  protection                         = var.vm_protection
+  started                            = var.vm_started
+  qemu_agent_enabled                 = var.qemu_agent_enabled
+  cpu_cores                          = var.vm_cpu_cores
+  cpu_sockets                        = var.vm_cpu_sockets
+  cpu_type                           = var.vm_cpu_type
+  memory_mb                          = var.vm_memory_mb
+  ballooning_memory_mb               = var.vm_ballooning_memory_mb
+  datastore_id                       = var.vm_storage
+  disk_size_gb                       = var.vm_disk_size_gb
+  ipv4_address                       = var.vm_ipv4_address
+  ipv4_gateway                       = var.vm_ipv4_gateway
+  dns_servers                        = local.vm_nameservers
+  dns_domain                         = local.vm_search_domain
+  cloud_init_user                    = var.cloud_init_user
+  ssh_public_keys                    = [trimspace(file(pathexpand(var.ssh_public_key_path)))]
+  snippet_datastore_id               = var.snippet_storage
+  qemu_guest_agent_bootstrap_enabled = var.qemu_guest_agent_bootstrap_enabled
+  qemu_guest_agent_snippet_file_name = "${var.vm_name}-tailscale-bootstrap.yaml"
+  network_bridge                     = var.vm_network_bridge
+  vlan_id                            = var.vm_vlan_id
 }

--- a/terraform/proxmox/vms/n8n/main.tf
+++ b/terraform/proxmox/vms/n8n/main.tf
@@ -27,7 +27,6 @@ module "n8n_vm" {
   ssh_public_keys                    = [trimspace(file(pathexpand(var.ssh_public_key_path)))]
   snippet_datastore_id               = var.snippet_storage
   qemu_guest_agent_bootstrap_enabled = var.qemu_guest_agent_bootstrap_enabled
-  qemu_guest_agent_snippet_file_name = "${var.vm_name}-tailscale-bootstrap.yaml"
   network_bridge                     = var.vm_network_bridge
   vlan_id                            = var.vm_vlan_id
 }

--- a/terraform/proxmox/vms/n8n/main.tf
+++ b/terraform/proxmox/vms/n8n/main.tf
@@ -1,0 +1,60 @@
+resource "proxmox_virtual_environment_file" "tailscale_cloud_init" {
+  count = var.enable_tailscale_bootstrap ? 1 : 0
+
+  content_type = "snippets"
+  datastore_id = var.snippet_storage
+  node_name    = var.target_node
+
+  source_raw {
+    file_name = "${var.vm_name}-tailscale-bootstrap.yaml"
+    data      = <<-EOF
+      #cloud-config
+      package_update: true
+      package_upgrade: false
+
+      runcmd:
+        - curl -fsSL https://tailscale.com/install.sh | sh
+        - systemctl enable --now tailscaled
+        - tailscale up --auth-key='${var.tailscale_auth_key != null ? var.tailscale_auth_key : ""}' --hostname='${var.vm_name}' --ssh
+    EOF
+  }
+
+  lifecycle {
+    precondition {
+      condition     = !var.enable_tailscale_bootstrap || try(trimspace(var.tailscale_auth_key), "") != ""
+      error_message = "tailscale_auth_key must be provided when enable_tailscale_bootstrap is true."
+    }
+  }
+}
+
+module "n8n_vm" {
+  source = "../../modules/ubuntu-cloudinit-vm"
+
+  name                 = var.vm_name
+  description          = var.vm_description
+  vm_id                = var.vm_id
+  node_name            = var.target_node
+  clone_template_vm_id = var.clone_template_vm_id
+
+  tags                 = var.vm_tags
+  on_boot              = var.vm_on_boot
+  protection           = var.vm_protection
+  started              = var.vm_started
+  qemu_agent_enabled   = var.qemu_agent_enabled
+  cpu_cores            = var.vm_cpu_cores
+  cpu_sockets          = var.vm_cpu_sockets
+  cpu_type             = var.vm_cpu_type
+  memory_mb            = var.vm_memory_mb
+  ballooning_memory_mb = var.vm_ballooning_memory_mb
+  datastore_id         = var.vm_storage
+  disk_size_gb         = var.vm_disk_size_gb
+  vendor_data_file_id  = var.enable_tailscale_bootstrap ? proxmox_virtual_environment_file.tailscale_cloud_init[0].id : null
+  ipv4_address         = var.vm_ipv4_address
+  ipv4_gateway         = var.vm_ipv4_gateway
+  dns_servers          = local.vm_nameservers
+  dns_domain           = local.vm_search_domain
+  cloud_init_user      = var.cloud_init_user
+  ssh_public_keys      = [trimspace(file(pathexpand(var.ssh_public_key_path)))]
+  network_bridge       = var.vm_network_bridge
+  vlan_id              = var.vm_vlan_id
+}

--- a/terraform/proxmox/vms/n8n/outputs.tf
+++ b/terraform/proxmox/vms/n8n/outputs.tf
@@ -1,0 +1,14 @@
+output "n8n_vm_id" {
+  description = "Proxmox VMID assigned to the n8n VM."
+  value       = module.n8n_vm.vm_id
+}
+
+output "n8n_vm_name" {
+  description = "Proxmox name of the n8n VM."
+  value       = module.n8n_vm.name
+}
+
+output "n8n_vm_ipv4_address" {
+  description = "Static IPv4 address configured for the n8n VM."
+  value       = module.n8n_vm.ipv4_address
+}

--- a/terraform/proxmox/vms/n8n/private.auto.tfvars.sample
+++ b/terraform/proxmox/vms/n8n/private.auto.tfvars.sample
@@ -1,0 +1,29 @@
+pm_api_url      = "https://192.168.xx.xx:8006/"
+pm_tls_insecure = true
+
+target_node         = "pve1"
+clone_template_vm_id = 9002
+vm_storage          = "local-zfs"
+snippet_storage     = "local"
+
+vm_id             = 9010
+vm_ipv4_address   = "192.168.xx.xx/24"
+vm_ipv4_gateway   = "192.168.xx.x"
+vm_network_bridge = "vmbr1"
+vm_vlan_id        = null
+
+cloud_init_user     = "ubuntu"
+ssh_public_key_path = "~/.ssh/proxmox_terraform.pub"
+
+# Used only when enable_netbox_remote_state is false or its outputs are not
+# intended to supply DNS for this root.
+vm_nameservers  = ["192.168.xx.xx", "192.168.xx.xx"]
+vm_search_domain = "internal.example.com"
+
+netbox_state_path = "../../../netbox/terraform.tfstate"
+
+# Optional fallback values when the NetBox state is disabled or incomplete.
+dns_ips = {
+  dns_vip_a = "192.168.xx.xx"
+  dns_vip_b = "192.168.xx.xx"
+}

--- a/terraform/proxmox/vms/n8n/provider.tf
+++ b/terraform/proxmox/vms/n8n/provider.tf
@@ -1,0 +1,16 @@
+provider "proxmox" {
+  endpoint  = var.pm_api_url
+  api_token = var.pm_api_token
+  insecure  = var.pm_tls_insecure
+
+  ssh {
+    agent    = true
+    username = var.pm_ssh_username
+
+    node {
+      name    = var.target_node
+      address = var.pm_ssh_host
+      port    = var.pm_ssh_port
+    }
+  }
+}

--- a/terraform/proxmox/vms/n8n/secrets.auto.tfvars.sample
+++ b/terraform/proxmox/vms/n8n/secrets.auto.tfvars.sample
@@ -1,0 +1,5 @@
+pm_api_token       = "terraform@pve!terraform-token=some-secret-key"
+pm_ssh_username    = "user"
+pm_ssh_host        = "100.00.00.00"
+pm_ssh_port        = 22
+tailscale_auth_key = "tskey-auth-...."

--- a/terraform/proxmox/vms/n8n/secrets.auto.tfvars.sample
+++ b/terraform/proxmox/vms/n8n/secrets.auto.tfvars.sample
@@ -2,4 +2,3 @@ pm_api_token       = "terraform@pve!terraform-token=some-secret-key"
 pm_ssh_username    = "user"
 pm_ssh_host        = "100.00.00.00"
 pm_ssh_port        = 22
-tailscale_auth_key = "tskey-auth-...."

--- a/terraform/proxmox/vms/n8n/terraform.tfvars
+++ b/terraform/proxmox/vms/n8n/terraform.tfvars
@@ -18,5 +18,6 @@ vm_on_boot    = true
 vm_protection = false
 vm_started    = true
 
+qemu_guest_agent_bootstrap_enabled = true
+
 enable_netbox_remote_state = true
-enable_tailscale_bootstrap = true

--- a/terraform/proxmox/vms/n8n/terraform.tfvars
+++ b/terraform/proxmox/vms/n8n/terraform.tfvars
@@ -1,0 +1,22 @@
+vm_name        = "n8n"
+vm_description = "Isolated n8n automation VM managed by OpenTofu"
+
+vm_cpu_cores            = 2
+vm_cpu_sockets          = 1
+vm_memory_mb            = 2048
+vm_ballooning_memory_mb = 0
+vm_disk_size_gb         = 24
+
+vm_tags = [
+  "terraform",
+  "ubuntu",
+  "automation",
+  "n8n",
+]
+
+vm_on_boot    = true
+vm_protection = false
+vm_started    = true
+
+enable_netbox_remote_state = true
+enable_tailscale_bootstrap = true

--- a/terraform/proxmox/vms/n8n/variables.tf
+++ b/terraform/proxmox/vms/n8n/variables.tf
@@ -1,0 +1,215 @@
+variable "pm_api_url" {
+  description = "Proxmox API URL, for example https://pve.example.com:8006/."
+  type        = string
+}
+
+variable "pm_api_token" {
+  description = "Proxmox API token in user@realm!tokenid=secret format."
+  type        = string
+  sensitive   = true
+}
+
+variable "pm_tls_insecure" {
+  description = "Allow a self-signed Proxmox API certificate."
+  type        = bool
+  default     = false
+}
+
+variable "pm_ssh_username" {
+  description = "SSH username used by the Proxmox provider for snippet operations."
+  type        = string
+  default     = "root"
+}
+
+variable "pm_ssh_host" {
+  description = "SSH address of the target Proxmox node."
+  type        = string
+}
+
+variable "pm_ssh_port" {
+  description = "SSH port of the target Proxmox node."
+  type        = number
+  default     = 22
+}
+
+variable "target_node" {
+  description = "Proxmox node on which to create the n8n VM."
+  type        = string
+}
+
+variable "clone_template_vm_id" {
+  description = "VMID of the Ubuntu 24.04 cloud-init template."
+  type        = number
+}
+
+variable "vm_storage" {
+  description = "Proxmox datastore for VM and cloud-init disks."
+  type        = string
+}
+
+variable "snippet_storage" {
+  description = "Proxmox snippets datastore for optional cloud-init vendor data."
+  type        = string
+  default     = "local"
+}
+
+variable "vm_id" {
+  description = "VMID assigned to the n8n VM."
+  type        = number
+}
+
+variable "vm_name" {
+  description = "Proxmox VM name."
+  type        = string
+  default     = "n8n"
+}
+
+variable "vm_description" {
+  description = "Proxmox VM description."
+  type        = string
+  default     = "Isolated n8n automation VM managed by OpenTofu"
+}
+
+variable "vm_tags" {
+  description = "Tags applied to the n8n VM in Proxmox."
+  type        = list(string)
+  default     = ["terraform", "ubuntu", "automation", "n8n"]
+}
+
+variable "vm_on_boot" {
+  description = "Start the n8n VM when the Proxmox node boots."
+  type        = bool
+  default     = true
+}
+
+variable "vm_protection" {
+  description = "Enable Proxmox VM protection."
+  type        = bool
+  default     = false
+}
+
+variable "vm_started" {
+  description = "Ensure the n8n VM is started after creation."
+  type        = bool
+  default     = true
+}
+
+variable "qemu_agent_enabled" {
+  description = "Enable QEMU guest-agent integration."
+  type        = bool
+  default     = true
+}
+
+variable "vm_cpu_cores" {
+  description = "Number of n8n VM virtual CPU cores."
+  type        = number
+  default     = 2
+}
+
+variable "vm_cpu_sockets" {
+  description = "Number of n8n VM virtual CPU sockets."
+  type        = number
+  default     = 1
+}
+
+variable "vm_cpu_type" {
+  description = "Proxmox CPU type exposed to the n8n VM."
+  type        = string
+  default     = "host"
+}
+
+variable "vm_memory_mb" {
+  description = "Dedicated memory for the n8n VM in MiB."
+  type        = number
+  default     = 2048
+}
+
+variable "vm_ballooning_memory_mb" {
+  description = "Minimum ballooned memory in MiB; 0 disables ballooning."
+  type        = number
+  default     = 0
+}
+
+variable "vm_disk_size_gb" {
+  description = "n8n VM system disk size in GiB."
+  type        = number
+  default     = 24
+}
+
+variable "vm_ipv4_address" {
+  description = "Static n8n VM IPv4 address in CIDR notation."
+  type        = string
+}
+
+variable "vm_ipv4_gateway" {
+  description = "IPv4 default gateway for the n8n VM."
+  type        = string
+}
+
+variable "vm_network_bridge" {
+  description = "Proxmox bridge connected to the n8n VM."
+  type        = string
+  default     = "vmbr0"
+}
+
+variable "vm_vlan_id" {
+  description = "Optional VLAN tag for the n8n VM."
+  type        = number
+  default     = null
+  nullable    = true
+}
+
+variable "vm_nameservers" {
+  description = "Fallback DNS servers used when NetBox remote state is disabled."
+  type        = list(string)
+  default     = []
+}
+
+variable "vm_search_domain" {
+  description = "Fallback DNS search domain used when NetBox does not supply one."
+  type        = string
+  default     = ""
+}
+
+variable "cloud_init_user" {
+  description = "Cloud-init administrative username."
+  type        = string
+  default     = "ubuntu"
+}
+
+variable "ssh_public_key_path" {
+  description = "Local path to the SSH public key installed by cloud-init."
+  type        = string
+}
+
+variable "enable_tailscale_bootstrap" {
+  description = "Install and enrol Tailscale through a cloud-init vendor-data snippet."
+  type        = bool
+  default     = true
+}
+
+variable "tailscale_auth_key" {
+  description = "Tailscale auth key used only during initial cloud-init bootstrap."
+  type        = string
+  sensitive   = true
+  default     = null
+  nullable    = true
+}
+
+variable "enable_netbox_remote_state" {
+  description = "Read DNS topology from the terraform/netbox local state."
+  type        = bool
+  default     = true
+}
+
+variable "netbox_state_path" {
+  description = "Path to the terraform/netbox state file."
+  type        = string
+  default     = "../../../netbox/terraform.tfstate"
+}
+
+variable "dns_ips" {
+  description = "Fallback DNS VIP map, normally sourced from NetBox outputs."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/proxmox/vms/n8n/variables.tf
+++ b/terraform/proxmox/vms/n8n/variables.tf
@@ -100,6 +100,12 @@ variable "qemu_agent_enabled" {
   default     = true
 }
 
+variable "qemu_guest_agent_bootstrap_enabled" {
+  description = "Install qemu-guest-agent during first boot so Proxmox can bootstrap the guest."
+  type        = bool
+  default     = true
+}
+
 variable "vm_cpu_cores" {
   description = "Number of n8n VM virtual CPU cores."
   type        = number
@@ -180,20 +186,6 @@ variable "cloud_init_user" {
 variable "ssh_public_key_path" {
   description = "Local path to the SSH public key installed by cloud-init."
   type        = string
-}
-
-variable "enable_tailscale_bootstrap" {
-  description = "Install and enrol Tailscale through a cloud-init vendor-data snippet."
-  type        = bool
-  default     = true
-}
-
-variable "tailscale_auth_key" {
-  description = "Tailscale auth key used only during initial cloud-init bootstrap."
-  type        = string
-  sensitive   = true
-  default     = null
-  nullable    = true
 }
 
 variable "enable_netbox_remote_state" {

--- a/terraform/proxmox/vms/n8n/versions.tf
+++ b/terraform/proxmox/vms/n8n/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11.0"
+
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "0.111.1"
+    }
+  }
+}

--- a/terraform/scripts/tofu-all.sh
+++ b/terraform/scripts/tofu-all.sh
@@ -13,6 +13,7 @@ ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 mapfile -t TOFU_DIRS < <(
   find "${ROOT_DIR}/terraform" \
     -path '*/.terraform' -prune -o \
+    -path '*/modules' -prune -o \
     -name '*.tf' -printf '%h\n' |
     sort -u
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable Proxmox Ubuntu cloud-init VM module (template clone, static IPv4 networking, cloud-init SSH keys) with optional QEMU guest-agent cloud-init bootstrapping.
  * Added an n8n VM deployment with configurable sizing, storage, and DNS (optionally NetBox-backed), plus outputs for VM ID/name/IP.
  * Added Tailscale bootstrapping via an Ansible role and a QEMU guest-agent workflow (including guest selection and auth).
* **Documentation**
  * Added/updated generated Terraform module docs and sample variable files; added role documentation.
* **Bug Fixes / Improvements**
  * Added input validations for DNS/SSH keys and memory ballooning limits.
* **Chores**
  * Pinned Terraform/OpenTofu versions/providers and improved OpenTofu working-directory discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->