### PR TITLE
feat(postgres): add Restic remote backups and restore validation

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -244,6 +244,8 @@
         - postgres_backup_remote_init
         - postgres_backup_remote_run
         - postgres_backup_remote_maintenance
+        - postgres_backup_restore_validation_setup
+        - postgres_backup_restore_validation_run
         - postgres_restore
         - postgres_admin
         - postgres_admin_uptime_kuma

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -240,6 +240,10 @@
         - postgres_backup
         - postgres_backup_setup
         - postgres_backup_run
+        - postgres_backup_remote_setup
+        - postgres_backup_remote_init
+        - postgres_backup_remote_run
+        - postgres_backup_remote_maintenance
         - postgres_restore
         - postgres_admin
         - postgres_admin_uptime_kuma

--- a/ansible/roles/postgres/README.md
+++ b/ansible/roles/postgres/README.md
@@ -10,7 +10,7 @@
 
 | Field                | Value           |
 |--------------------- |-----------------|
-| Readme update        | 2026/08/11 |
+| Readme update        | 2026/08/12 |
 
 
 
@@ -65,10 +65,54 @@
 | [postgres_backup_local_retention_days](defaults/main.yml#L72)   | int | `7` |    
 | [postgres_backup_failed_retention_days](defaults/main.yml#L73)   | int | `2` |    
 | [postgres_backup_metrics_file](defaults/main.yml#L74)   | str | `/var/lib/node_exporter/textfile_collector_postgres/postgres_logical_backup.prom` |    
-| [postgres_restore_dbs_dir](defaults/main.yml#L80)   | str | `/tmp` |    
-| [postgres_restore_dbs_drop_existing](defaults/main.yml#L81)   | bool | `True` |    
-| [postgres_restore_dbs_map](defaults/main.yml#L86)   | list | `[]` |    
-| [postgres_fix_owner_map](defaults/main.yml#L101)   | list | `[]` |    
+| [postgres_backup_remote_manage](defaults/main.yml#L80)   | bool | `False` |    
+| [postgres_backup_remote_enabled](defaults/main.yml#L81)   | bool | `False` |    
+| [postgres_backup_remote_restic_path](defaults/main.yml#L82)   | str | `/usr/bin/restic` |    
+| [postgres_backup_remote_script_path](defaults/main.yml#L83)   | str | `/usr/local/sbin/postgres-logical-backup-remote` |    
+| [postgres_backup_remote_state_dir](defaults/main.yml#L84)   | str | `/var/lib/postgres-logical-backup-remote` |    
+| [postgres_backup_remote_repository](defaults/main.yml#L85)   | str |  |    
+| [postgres_backup_remote_config_dir](defaults/main.yml#L86)   | str | `/etc/restic/postgres-logical-backup` |    
+| [postgres_backup_remote_repository_file](defaults/main.yml#L87)   | str | `{{ postgres_backup_remote_config_dir }}/repository` |    
+| [postgres_backup_remote_password_file](defaults/main.yml#L88)   | str | `{{ postgres_backup_remote_config_dir }}/password` |    
+| [postgres_backup_remote_environment_file](defaults/main.yml#L89)   | str | `{{ postgres_backup_remote_config_dir }}/backend.env` |    
+| [postgres_backup_remote_managed_secret_files_manifest](defaults/main.yml#L90)   | str | `<multiline value: folded_strip>` |    
+| [postgres_backup_remote_password_secret](defaults/main.yml#L92)   | dict | `{}` |    
+| [postgres_backup_remote_password_secret.**path**](defaults/main.yml#L93)   | str | `/Restic/Postgres` |    
+| [postgres_backup_remote_password_secret.**name**](defaults/main.yml#L94)   | str | `PASSWORD` |    
+| [postgres_backup_remote_backend_environment](defaults/main.yml#L95)   | dict | `{}` |    
+| [postgres_backup_remote_backend_secrets](defaults/main.yml#L96)   | list | `[]` |    
+| [postgres_backup_remote_secret_files](defaults/main.yml#L97)   | list | `[]` |    
+| [postgres_backup_remote_options](defaults/main.yml#L98)   | list | `[]` |    
+| [postgres_backup_remote_retry_lock](defaults/main.yml#L99)   | str | `10m` |    
+| [postgres_backup_remote_timer_name](defaults/main.yml#L100)   | str | `postgres-logical-backup-remote` |    
+| [postgres_backup_remote_timer_on_calendar](defaults/main.yml#L101)   | str | `*-*-* 04:00:00` |    
+| [postgres_backup_remote_timer_randomized_delay_sec](defaults/main.yml#L102)   | str | `30m` |    
+| [postgres_backup_remote_maintenance_timer_name](defaults/main.yml#L103)   | str | `postgres-logical-backup-remote-maintenance` |    
+| [postgres_backup_remote_maintenance_timer_on_calendar](defaults/main.yml#L104)   | str | `Sun *-*-* 05:00:00` |    
+| [postgres_backup_remote_maintenance_timer_randomized_delay_sec](defaults/main.yml#L105)   | str | `30m` |    
+| [postgres_backup_remote_maintenance_host](defaults/main.yml#L106)   | str | `<multiline value: folded_strip>` |    
+| [postgres_backup_remote_snapshot_host](defaults/main.yml#L108)   | str | `{{ postgres_patroni_scope }}` |    
+| [postgres_backup_remote_keep_daily](defaults/main.yml#L109)   | int | `14` |    
+| [postgres_backup_remote_keep_weekly](defaults/main.yml#L110)   | int | `8` |    
+| [postgres_backup_remote_keep_monthly](defaults/main.yml#L111)   | int | `12` |    
+| [postgres_backup_remote_metrics_file](defaults/main.yml#L112)   | str | `<multiline value: folded_strip>` |    
+| [postgres_backup_restore_validation_manage](defaults/main.yml#L119)   | bool | `False` |    
+| [postgres_backup_restore_validation_enabled](defaults/main.yml#L120)   | bool | `False` |    
+| [postgres_backup_restore_validation_host](defaults/main.yml#L121)   | str | `{{ postgres_backup_remote_maintenance_host }}` |    
+| [postgres_backup_restore_validation_script_path](defaults/main.yml#L122)   | str | `/usr/local/sbin/postgres-logical-backup-restore-validate` |    
+| [postgres_backup_restore_validation_runuser_path](defaults/main.yml#L123)   | str | `/usr/sbin/runuser` |    
+| [postgres_backup_restore_validation_work_root](defaults/main.yml#L124)   | str | `/var/lib/postgres-logical-backup-restore-validation` |    
+| [postgres_backup_restore_validation_timer_name](defaults/main.yml#L125)   | str | `postgres-logical-backup-restore-validation` |    
+| [postgres_backup_restore_validation_timer_on_calendar](defaults/main.yml#L126)   | str | `Sun *-*-* 07:00:00` |    
+| [postgres_backup_restore_validation_timer_randomized_delay_sec](defaults/main.yml#L127)   | str | `30m` |    
+| [postgres_backup_restore_validation_port](defaults/main.yml#L128)   | int | `55432` |    
+| [postgres_backup_restore_validation_max_snapshot_age_hours](defaults/main.yml#L129)   | int | `48` |    
+| [postgres_backup_restore_validation_min_free_bytes](defaults/main.yml#L130)   | int | `5368709120` |    
+| [postgres_backup_restore_validation_metrics_file](defaults/main.yml#L131)   | str | `<multiline value: folded_strip>` |    
+| [postgres_restore_dbs_dir](defaults/main.yml#L138)   | str | `/tmp` |    
+| [postgres_restore_dbs_drop_existing](defaults/main.yml#L139)   | bool | `True` |    
+| [postgres_restore_dbs_map](defaults/main.yml#L144)   | list | `[]` |    
+| [postgres_fix_owner_map](defaults/main.yml#L159)   | list | `[]` |    
 
 
 
@@ -89,6 +133,16 @@
 | Configure PostgreSQL logical backups | ansible.builtin.include_tasks | True | postgres,postgres_backup,postgres_backup_setup,postgres_backup_run |
 | Run PostgreSQL logical backup manually | ansible.builtin.include_tasks | True | postgres_backup,postgres_backup_run |
 | Report PostgreSQL logical backup manual check-mode plan | ansible.builtin.debug | True | postgres_backup,postgres_backup_run |
+| Configure PostgreSQL remote logical backups | ansible.builtin.include_tasks | True | postgres,postgres_backup_remote_setup,postgres_backup_remote_init,postgres_backup_remote_run,postgres_backup_remote_maintenance,postgres_backup_restore_validation_setup,postgres_backup_restore_validation_run |
+| Initialize PostgreSQL remote backup repository explicitly | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,i,n,i,t |
+| Run PostgreSQL remote backup uploader manually | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,r,u,n |
+| Run PostgreSQL remote backup maintenance manually | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,m,a,i,n,t,e,n,a,n,c,e |
+| Report PostgreSQL remote backup init check-mode plan | ansible.builtin.debug | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,i,n,i,t |
+| Report PostgreSQL remote backup upload check-mode plan | ansible.builtin.debug | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,r,u,n |
+| Report PostgreSQL remote backup maintenance check-mode plan | ansible.builtin.debug | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,m,a,i,n,t,e,n,a,n,c,e |
+| Configure PostgreSQL backup restore validation | ansible.builtin.include_tasks | True | postgres,postgres_backup_restore_validation_setup,postgres_backup_restore_validation_run |
+| Run PostgreSQL backup restore validation manually | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,s,t,o,r,e,_,v,a,l,i,d,a,t,i,o,n,_,r,u,n |
+| Report PostgreSQL backup restore validation check-mode plan | ansible.builtin.debug | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,s,t,o,r,e,_,v,a,l,i,d,a,t,i,o,n,_,r,u,n |
 | Restore PostgreSQL single database from pg_dump backup | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,r,e,s,t,o,r,e |
 | Reset PostgreSQL/Patroni node destructively | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,a,d,m,i,n,_,n,u,k,e,_,n,o,d,e |
 | Fix database ownership and privileges | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,a,d,m,i,n,_,f,i,x,_,o,w,n,e,r |
@@ -176,6 +230,82 @@
 | Logical backup run ¦ Validate leader inventory mapping | ansible.builtin.assert | False |
 | Logical backup run ¦ Invoke installed leader-gated runner | ansible.builtin.command | False |
 | Logical backup run ¦ Report status and location | ansible.builtin.debug | False |
+
+#### File: tasks/sub_tasks/backup_remote_action.yml
+
+| Name | Module | Has Conditions |
+| ---- | ------ | -------------- |
+| Remote logical backup action ¦ Validate explicit action | ansible.builtin.assert | False |
+| Remote logical backup action ¦ Invoke host-local runner | ansible.builtin.command | False |
+| Remote logical backup action ¦ Report result | ansible.builtin.debug | False |
+
+#### File: tasks/sub_tasks/backup_remote_secret_reconcile.yml
+
+| Name | Module | Has Conditions |
+| ---- | ------ | -------------- |
+| Remote logical backup secret reconciliation ¦ Inspect managed-file manifest | ansible.builtin.stat | False |
+| Remote logical backup secret reconciliation ¦ Validate managed-file manifest type | ansible.builtin.assert | False |
+| Remote logical backup secret reconciliation ¦ Read managed-file manifest | ansible.builtin.slurp | True |
+| Remote logical backup secret reconciliation ¦ Decode previously managed paths | ansible.builtin.set_fact | False |
+| Remote logical backup secret reconciliation ¦ Validate previous managed paths | ansible.builtin.assert | False |
+| Remote logical backup secret reconciliation ¦ Validate unique previous managed paths | ansible.builtin.assert | False |
+| Remote logical backup secret reconciliation ¦ Remove obsolete managed secret files | ansible.builtin.file | False |
+| Remote logical backup secret reconciliation ¦ Publish managed-file manifest atomically | ansible.builtin.copy | False |
+
+#### File: tasks/sub_tasks/backup_remote_setup.yml
+
+| Name | Module | Has Conditions | Tags |
+| ---- | ------ | -------------- | -----|
+| Remote logical backup ¦ Validate configuration | ansible.builtin.assert | False |  |
+| Remote logical backup ¦ Validate backend environment entries | ansible.builtin.assert | False |  |
+| Remote logical backup ¦ Validate backend secret declarations | ansible.builtin.assert | False |  |
+| Remote logical backup ¦ Validate unique backend secret environment names | ansible.builtin.assert | False |  |
+| Remote logical backup ¦ Validate secret file declarations | ansible.builtin.assert | False |  |
+| Remote logical backup ¦ Validate unique secret file paths | ansible.builtin.assert | False |  |
+| Remote logical backup ¦ Validate additional Restic options | ansible.builtin.assert | False |  |
+| Remote logical backup ¦ Install Restic package | ansible.builtin.apt | True |  |
+| Remote logical backup ¦ Create protected configuration directory | ansible.builtin.file | True |  |
+| Remote logical backup ¦ Create protected state directories | ansible.builtin.file | True |  |
+| Remote logical backup ¦ Ensure PostgreSQL metrics directory exists | ansible.builtin.file | True |  |
+| Remote logical backup ¦ Pre-create remote metrics file | ansible.builtin.file | True |  |
+| Remote logical backup ¦ Reset resolved credential state | ansible.builtin.set_fact | True |  |
+| Remote logical backup ¦ Resolve repository password through controller Infisical parameters | ansible.builtin.set_fact | True |  |
+| Remote logical backup ¦ Resolve backend environment secrets through controller | ansible.builtin.set_fact | True |  |
+| Remote logical backup ¦ Resolve backend secret files through controller | ansible.builtin.set_fact | True |  |
+| Remote logical backup ¦ Build deterministic check-mode credentials | ansible.builtin.set_fact | True |  |
+| Remote logical backup ¦ Build deterministic check-mode backend secrets | ansible.builtin.set_fact | True |  |
+| Remote logical backup ¦ Build deterministic check-mode secret files | ansible.builtin.set_fact | True |  |
+| Remote logical backup ¦ Validate resolved credentials | ansible.builtin.assert | True |  |
+| Remote logical backup ¦ Write repository location | ansible.builtin.copy | True |  |
+| Remote logical backup ¦ Write repository password | ansible.builtin.copy | True |  |
+| Remote logical backup ¦ Write protected backend environment | ansible.builtin.template | True |  |
+| Remote logical backup ¦ Write protected backend secret files | ansible.builtin.copy | True |  |
+| Remote logical backup ¦ Remove inactive core credential files | ansible.builtin.file | True |  |
+| Remote logical backup ¦ Remove declared inactive secret files | ansible.builtin.file | True |  |
+| Remote logical backup ¦ Build desired managed secret-file paths | ansible.builtin.set_fact | True |  |
+| Remote logical backup ¦ Reconcile managed secret files | ansible.builtin.include_tasks | True |  |
+| Remote logical backup ¦ Install host-local runner | ansible.builtin.template | True |  |
+| Remote logical backup ¦ Manage uploader systemd job | ansible.builtin.include_role | True |  |
+| Remote logical backup ¦ Manage maintenance systemd job | ansible.builtin.include_role | True |  |
+
+#### File: tasks/sub_tasks/backup_restore_validation_action.yml
+
+| Name | Module | Has Conditions |
+| ---- | ------ | -------------- |
+| Backup restore validation action ¦ Validate explicit action | ansible.builtin.assert | False |
+| Backup restore validation action ¦ Invoke host-local runner | ansible.builtin.command | False |
+| Backup restore validation action ¦ Report result | ansible.builtin.debug | False |
+
+#### File: tasks/sub_tasks/backup_restore_validation_setup.yml
+
+| Name | Module | Has Conditions | Tags |
+| ---- | ------ | -------------- | -----|
+| Backup restore validation ¦ Validate configuration | ansible.builtin.assert | False |  |
+| Backup restore validation ¦ Create protected work root | ansible.builtin.file | True |  |
+| Backup restore validation ¦ Ensure PostgreSQL metrics directory exists | ansible.builtin.file | True |  |
+| Backup restore validation ¦ Pre-create metrics file | ansible.builtin.file | True |  |
+| Backup restore validation ¦ Install host-local runner | ansible.builtin.template | True |  |
+| Backup restore validation ¦ Manage systemd job | ansible.builtin.include_role | True |  |
 
 #### File: tasks/sub_tasks/backup_setup.yml
 

--- a/ansible/roles/postgres/README.md
+++ b/ansible/roles/postgres/README.md
@@ -108,11 +108,13 @@
 | [postgres_backup_restore_validation_port](defaults/main.yml#L128)   | int | `55432` |    
 | [postgres_backup_restore_validation_max_snapshot_age_hours](defaults/main.yml#L129)   | int | `48` |    
 | [postgres_backup_restore_validation_min_free_bytes](defaults/main.yml#L130)   | int | `5368709120` |    
-| [postgres_backup_restore_validation_metrics_file](defaults/main.yml#L131)   | str | `<multiline value: folded_strip>` |    
-| [postgres_restore_dbs_dir](defaults/main.yml#L138)   | str | `/tmp` |    
-| [postgres_restore_dbs_drop_existing](defaults/main.yml#L139)   | bool | `True` |    
-| [postgres_restore_dbs_map](defaults/main.yml#L144)   | list | `[]` |    
-| [postgres_fix_owner_map](defaults/main.yml#L159)   | list | `[]` |    
+| [postgres_backup_restore_validation_encoding](defaults/main.yml#L131)   | str | `UTF8` |    
+| [postgres_backup_restore_validation_locale](defaults/main.yml#L132)   | str | `C.UTF-8` |    
+| [postgres_backup_restore_validation_metrics_file](defaults/main.yml#L133)   | str | `<multiline value: folded_strip>` |    
+| [postgres_restore_dbs_dir](defaults/main.yml#L140)   | str | `/tmp` |    
+| [postgres_restore_dbs_drop_existing](defaults/main.yml#L141)   | bool | `True` |    
+| [postgres_restore_dbs_map](defaults/main.yml#L146)   | list | `[]` |    
+| [postgres_fix_owner_map](defaults/main.yml#L161)   | list | `[]` |    
 
 
 
@@ -134,15 +136,15 @@
 | Run PostgreSQL logical backup manually | ansible.builtin.include_tasks | True | postgres_backup,postgres_backup_run |
 | Report PostgreSQL logical backup manual check-mode plan | ansible.builtin.debug | True | postgres_backup,postgres_backup_run |
 | Configure PostgreSQL remote logical backups | ansible.builtin.include_tasks | True | postgres,postgres_backup_remote_setup,postgres_backup_remote_init,postgres_backup_remote_run,postgres_backup_remote_maintenance,postgres_backup_restore_validation_setup,postgres_backup_restore_validation_run |
-| Initialize PostgreSQL remote backup repository explicitly | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,i,n,i,t |
-| Run PostgreSQL remote backup uploader manually | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,r,u,n |
-| Run PostgreSQL remote backup maintenance manually | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,m,a,i,n,t,e,n,a,n,c,e |
-| Report PostgreSQL remote backup init check-mode plan | ansible.builtin.debug | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,i,n,i,t |
-| Report PostgreSQL remote backup upload check-mode plan | ansible.builtin.debug | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,r,u,n |
-| Report PostgreSQL remote backup maintenance check-mode plan | ansible.builtin.debug | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,m,o,t,e,_,m,a,i,n,t,e,n,a,n,c,e |
+| Initialize PostgreSQL remote backup repository explicitly | ansible.builtin.include_tasks | True | postgres_backup_remote_init |
+| Run PostgreSQL remote backup uploader manually | ansible.builtin.include_tasks | True | postgres_backup_remote_run |
+| Run PostgreSQL remote backup maintenance manually | ansible.builtin.include_tasks | True | postgres_backup_remote_maintenance |
+| Report PostgreSQL remote backup init check-mode plan | ansible.builtin.debug | True | postgres_backup_remote_init |
+| Report PostgreSQL remote backup upload check-mode plan | ansible.builtin.debug | True | postgres_backup_remote_run |
+| Report PostgreSQL remote backup maintenance check-mode plan | ansible.builtin.debug | True | postgres_backup_remote_maintenance |
 | Configure PostgreSQL backup restore validation | ansible.builtin.include_tasks | True | postgres,postgres_backup_restore_validation_setup,postgres_backup_restore_validation_run |
-| Run PostgreSQL backup restore validation manually | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,s,t,o,r,e,_,v,a,l,i,d,a,t,i,o,n,_,r,u,n |
-| Report PostgreSQL backup restore validation check-mode plan | ansible.builtin.debug | True | p,o,s,t,g,r,e,s,_,b,a,c,k,u,p,_,r,e,s,t,o,r,e,_,v,a,l,i,d,a,t,i,o,n,_,r,u,n |
+| Run PostgreSQL backup restore validation manually | ansible.builtin.include_tasks | True | postgres_backup_restore_validation_run |
+| Report PostgreSQL backup restore validation check-mode plan | ansible.builtin.debug | True | postgres_backup_restore_validation_run |
 | Restore PostgreSQL single database from pg_dump backup | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,r,e,s,t,o,r,e |
 | Reset PostgreSQL/Patroni node destructively | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,a,d,m,i,n,_,n,u,k,e,_,n,o,d,e |
 | Fix database ownership and privileges | ansible.builtin.include_tasks | True | p,o,s,t,g,r,e,s,_,a,d,m,i,n,_,f,i,x,_,o,w,n,e,r |
@@ -264,6 +266,8 @@
 | Remote logical backup ¦ Validate unique secret file paths | ansible.builtin.assert | False |  |
 | Remote logical backup ¦ Validate additional Restic options | ansible.builtin.assert | False |  |
 | Remote logical backup ¦ Install Restic package | ansible.builtin.apt | True |  |
+| Remote logical backup ¦ Query installed Restic version | ansible.builtin.command | True |  |
+| Remote logical backup ¦ Require supported Restic version | ansible.builtin.assert | True |  |
 | Remote logical backup ¦ Create protected configuration directory | ansible.builtin.file | True |  |
 | Remote logical backup ¦ Create protected state directories | ansible.builtin.file | True |  |
 | Remote logical backup ¦ Ensure PostgreSQL metrics directory exists | ansible.builtin.file | True |  |
@@ -285,8 +289,8 @@
 | Remote logical backup ¦ Build desired managed secret-file paths | ansible.builtin.set_fact | True |  |
 | Remote logical backup ¦ Reconcile managed secret files | ansible.builtin.include_tasks | True |  |
 | Remote logical backup ¦ Install host-local runner | ansible.builtin.template | True |  |
-| Remote logical backup ¦ Manage uploader systemd job | ansible.builtin.include_role | True |  |
-| Remote logical backup ¦ Manage maintenance systemd job | ansible.builtin.include_role | True |  |
+| Remote logical backup ¦ Manage uploader systemd job | ansible.builtin.include_role | False |  |
+| Remote logical backup ¦ Manage maintenance systemd job | ansible.builtin.include_role | False |  |
 
 #### File: tasks/sub_tasks/backup_restore_validation_action.yml
 
@@ -305,7 +309,7 @@
 | Backup restore validation ¦ Ensure PostgreSQL metrics directory exists | ansible.builtin.file | True |  |
 | Backup restore validation ¦ Pre-create metrics file | ansible.builtin.file | True |  |
 | Backup restore validation ¦ Install host-local runner | ansible.builtin.template | True |  |
-| Backup restore validation ¦ Manage systemd job | ansible.builtin.include_role | True |  |
+| Backup restore validation ¦ Manage systemd job | ansible.builtin.include_role | False |  |
 
 #### File: tasks/sub_tasks/backup_setup.yml
 

--- a/ansible/roles/postgres/defaults/main.yml
+++ b/ansible/roles/postgres/defaults/main.yml
@@ -128,6 +128,8 @@ postgres_backup_restore_validation_timer_randomized_delay_sec: 30m
 postgres_backup_restore_validation_port: 55432
 postgres_backup_restore_validation_max_snapshot_age_hours: 48
 postgres_backup_restore_validation_min_free_bytes: 5368709120
+postgres_backup_restore_validation_encoding: UTF8
+postgres_backup_restore_validation_locale: C.UTF-8
 postgres_backup_restore_validation_metrics_file: >-
   /var/lib/node_exporter/textfile_collector_postgres/postgres_logical_backup_restore_validation.prom
 

--- a/ansible/roles/postgres/defaults/main.yml
+++ b/ansible/roles/postgres/defaults/main.yml
@@ -74,6 +74,45 @@ postgres_backup_failed_retention_days: 2
 postgres_backup_metrics_file: /var/lib/node_exporter/textfile_collector_postgres/postgres_logical_backup.prom
 
 ################################
+# LOGICAL BACKUPS - REMOTE / RESTIC
+################################
+
+postgres_backup_remote_manage: false
+postgres_backup_remote_enabled: false
+postgres_backup_remote_restic_path: /usr/bin/restic
+postgres_backup_remote_script_path: /usr/local/sbin/postgres-logical-backup-remote
+postgres_backup_remote_state_dir: /var/lib/postgres-logical-backup-remote
+postgres_backup_remote_repository: ""
+postgres_backup_remote_config_dir: /etc/restic/postgres-logical-backup
+postgres_backup_remote_repository_file: "{{ postgres_backup_remote_config_dir }}/repository"
+postgres_backup_remote_password_file: "{{ postgres_backup_remote_config_dir }}/password"
+postgres_backup_remote_environment_file: "{{ postgres_backup_remote_config_dir }}/backend.env"
+postgres_backup_remote_managed_secret_files_manifest: >-
+  {{ postgres_backup_remote_config_dir }}/.managed-secret-files
+postgres_backup_remote_password_secret:
+  path: /Restic/Postgres
+  name: PASSWORD
+postgres_backup_remote_backend_environment: {}
+postgres_backup_remote_backend_secrets: []
+postgres_backup_remote_secret_files: []
+postgres_backup_remote_options: []
+postgres_backup_remote_retry_lock: 10m
+postgres_backup_remote_timer_name: postgres-logical-backup-remote
+postgres_backup_remote_timer_on_calendar: "*-*-* 04:00:00"
+postgres_backup_remote_timer_randomized_delay_sec: 30m
+postgres_backup_remote_maintenance_timer_name: postgres-logical-backup-remote-maintenance
+postgres_backup_remote_maintenance_timer_on_calendar: "Sun *-*-* 05:00:00"
+postgres_backup_remote_maintenance_timer_randomized_delay_sec: 30m
+postgres_backup_remote_maintenance_host: >-
+  {{ (groups['tags_postgres'] | default([]) | sort | first) | default('') }}
+postgres_backup_remote_snapshot_host: "{{ postgres_patroni_scope }}"
+postgres_backup_remote_keep_daily: 14
+postgres_backup_remote_keep_weekly: 8
+postgres_backup_remote_keep_monthly: 12
+postgres_backup_remote_metrics_file: >-
+  /var/lib/node_exporter/textfile_collector_postgres/postgres_logical_backup_remote.prom
+
+################################
 # RESTORE (DATABASES)
 ################################
 

--- a/ansible/roles/postgres/defaults/main.yml
+++ b/ansible/roles/postgres/defaults/main.yml
@@ -113,6 +113,25 @@ postgres_backup_remote_metrics_file: >-
   /var/lib/node_exporter/textfile_collector_postgres/postgres_logical_backup_remote.prom
 
 ################################
+# LOGICAL BACKUPS - RESTORE VALIDATION
+################################
+
+postgres_backup_restore_validation_manage: false
+postgres_backup_restore_validation_enabled: false
+postgres_backup_restore_validation_host: "{{ postgres_backup_remote_maintenance_host }}"
+postgres_backup_restore_validation_script_path: /usr/local/sbin/postgres-logical-backup-restore-validate
+postgres_backup_restore_validation_runuser_path: /usr/sbin/runuser
+postgres_backup_restore_validation_work_root: /var/lib/postgres-logical-backup-restore-validation
+postgres_backup_restore_validation_timer_name: postgres-logical-backup-restore-validation
+postgres_backup_restore_validation_timer_on_calendar: "Sun *-*-* 07:00:00"
+postgres_backup_restore_validation_timer_randomized_delay_sec: 30m
+postgres_backup_restore_validation_port: 55432
+postgres_backup_restore_validation_max_snapshot_age_hours: 48
+postgres_backup_restore_validation_min_free_bytes: 5368709120
+postgres_backup_restore_validation_metrics_file: >-
+  /var/lib/node_exporter/textfile_collector_postgres/postgres_logical_backup_restore_validation.prom
+
+################################
 # RESTORE (DATABASES)
 ################################
 

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -149,10 +149,12 @@
   ansible.builtin.include_tasks:
     file: sub_tasks/backup_remote_action.yml
     apply:
-      tags: postgres_backup_remote_init
+      tags:
+        - postgres_backup_remote_init
   vars:
     postgres_backup_remote_action: init
-  tags: postgres_backup_remote_init
+  tags:
+    - postgres_backup_remote_init
 
 - name: Run PostgreSQL remote backup uploader manually
   when:
@@ -162,10 +164,12 @@
   ansible.builtin.include_tasks:
     file: sub_tasks/backup_remote_action.yml
     apply:
-      tags: postgres_backup_remote_run
+      tags:
+        - postgres_backup_remote_run
   vars:
     postgres_backup_remote_action: upload
-  tags: postgres_backup_remote_run
+  tags:
+    - postgres_backup_remote_run
 
 - name: Run PostgreSQL remote backup maintenance manually
   when:
@@ -176,10 +180,12 @@
   ansible.builtin.include_tasks:
     file: sub_tasks/backup_remote_action.yml
     apply:
-      tags: postgres_backup_remote_maintenance
+      tags:
+        - postgres_backup_remote_maintenance
   vars:
     postgres_backup_remote_action: maintenance
-  tags: postgres_backup_remote_maintenance
+  tags:
+    - postgres_backup_remote_maintenance
 
 - name: Report PostgreSQL remote backup init check-mode plan
   when:
@@ -189,7 +195,8 @@
     - "'postgres_backup_remote_init' in (ansible_run_tags | default([]))"
   ansible.builtin.debug:
     msg: Check mode - would initialize the configured PostgreSQL Restic repository.
-  tags: postgres_backup_remote_init
+  tags:
+    - postgres_backup_remote_init
 
 - name: Report PostgreSQL remote backup upload check-mode plan
   when:
@@ -200,7 +207,8 @@
     msg: >-
       Check mode - would upload eligible completed PostgreSQL logical backups
       to the configured Restic repository.
-  tags: postgres_backup_remote_run
+  tags:
+    - postgres_backup_remote_run
 
 - name: Report PostgreSQL remote backup maintenance check-mode plan
   when:
@@ -212,7 +220,8 @@
     msg: >-
       Check mode - would apply scoped PostgreSQL Restic retention and prune
       unreferenced repository data.
-  tags: postgres_backup_remote_maintenance
+  tags:
+    - postgres_backup_remote_maintenance
 
 - name: Configure PostgreSQL backup restore validation
   when: "'tags_postgres' in group_names"
@@ -237,8 +246,10 @@
   ansible.builtin.include_tasks:
     file: sub_tasks/backup_restore_validation_action.yml
     apply:
-      tags: postgres_backup_restore_validation_run
-  tags: postgres_backup_restore_validation_run
+      tags:
+        - postgres_backup_restore_validation_run
+  tags:
+    - postgres_backup_restore_validation_run
 
 - name: Report PostgreSQL backup restore validation check-mode plan
   when:
@@ -250,7 +261,8 @@
     msg: >-
       Check mode: would select a recent PostgreSQL Restic snapshot and validate
       every database dump in an isolated temporary PostgreSQL cluster.
-  tags: postgres_backup_restore_validation_run
+  tags:
+    - postgres_backup_restore_validation_run
 
 - name: Restore PostgreSQL single database from pg_dump backup
   when:

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -129,12 +129,16 @@
         - postgres_backup_remote_init
         - postgres_backup_remote_run
         - postgres_backup_remote_maintenance
+        - postgres_backup_restore_validation_setup
+        - postgres_backup_restore_validation_run
   tags:
     - postgres
     - postgres_backup_remote_setup
     - postgres_backup_remote_init
     - postgres_backup_remote_run
     - postgres_backup_remote_maintenance
+    - postgres_backup_restore_validation_setup
+    - postgres_backup_restore_validation_run
 
 - name: Initialize PostgreSQL remote backup repository explicitly
   when:
@@ -209,6 +213,44 @@
       Check mode - would apply scoped PostgreSQL Restic retention and prune
       unreferenced repository data.
   tags: postgres_backup_remote_maintenance
+
+- name: Configure PostgreSQL backup restore validation
+  when: "'tags_postgres' in group_names"
+  ansible.builtin.include_tasks:
+    file: sub_tasks/backup_restore_validation_setup.yml
+    apply:
+      tags:
+        - postgres
+        - postgres_backup_restore_validation_setup
+        - postgres_backup_restore_validation_run
+  tags:
+    - postgres
+    - postgres_backup_restore_validation_setup
+    - postgres_backup_restore_validation_run
+
+- name: Run PostgreSQL backup restore validation manually
+  when:
+    - "'tags_postgres' in group_names"
+    - inventory_hostname == postgres_backup_restore_validation_host
+    - not ansible_check_mode
+    - "'postgres_backup_restore_validation_run' in (ansible_run_tags | default([]))"
+  ansible.builtin.include_tasks:
+    file: sub_tasks/backup_restore_validation_action.yml
+    apply:
+      tags: postgres_backup_restore_validation_run
+  tags: postgres_backup_restore_validation_run
+
+- name: Report PostgreSQL backup restore validation check-mode plan
+  when:
+    - "'tags_postgres' in group_names"
+    - inventory_hostname == postgres_backup_restore_validation_host
+    - ansible_check_mode
+    - "'postgres_backup_restore_validation_run' in (ansible_run_tags | default([]))"
+  ansible.builtin.debug:
+    msg: >-
+      Check mode: would select a recent PostgreSQL Restic snapshot and validate
+      every database dump in an isolated temporary PostgreSQL cluster.
+  tags: postgres_backup_restore_validation_run
 
 - name: Restore PostgreSQL single database from pg_dump backup
   when:

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -118,6 +118,98 @@
     - postgres_backup
     - postgres_backup_run
 
+- name: Configure PostgreSQL remote logical backups
+  when: "'tags_postgres' in group_names"
+  ansible.builtin.include_tasks:
+    file: sub_tasks/backup_remote_setup.yml
+    apply:
+      tags:
+        - postgres
+        - postgres_backup_remote_setup
+        - postgres_backup_remote_init
+        - postgres_backup_remote_run
+        - postgres_backup_remote_maintenance
+  tags:
+    - postgres
+    - postgres_backup_remote_setup
+    - postgres_backup_remote_init
+    - postgres_backup_remote_run
+    - postgres_backup_remote_maintenance
+
+- name: Initialize PostgreSQL remote backup repository explicitly
+  when:
+    - "'tags_postgres' in group_names"
+    - inventory_hostname == postgres_backup_remote_maintenance_host
+    - not ansible_check_mode
+    - "'postgres_backup_remote_init' in (ansible_run_tags | default([]))"
+  ansible.builtin.include_tasks:
+    file: sub_tasks/backup_remote_action.yml
+    apply:
+      tags: postgres_backup_remote_init
+  vars:
+    postgres_backup_remote_action: init
+  tags: postgres_backup_remote_init
+
+- name: Run PostgreSQL remote backup uploader manually
+  when:
+    - "'tags_postgres' in group_names"
+    - not ansible_check_mode
+    - "'postgres_backup_remote_run' in (ansible_run_tags | default([]))"
+  ansible.builtin.include_tasks:
+    file: sub_tasks/backup_remote_action.yml
+    apply:
+      tags: postgres_backup_remote_run
+  vars:
+    postgres_backup_remote_action: upload
+  tags: postgres_backup_remote_run
+
+- name: Run PostgreSQL remote backup maintenance manually
+  when:
+    - "'tags_postgres' in group_names"
+    - inventory_hostname == postgres_backup_remote_maintenance_host
+    - not ansible_check_mode
+    - "'postgres_backup_remote_maintenance' in (ansible_run_tags | default([]))"
+  ansible.builtin.include_tasks:
+    file: sub_tasks/backup_remote_action.yml
+    apply:
+      tags: postgres_backup_remote_maintenance
+  vars:
+    postgres_backup_remote_action: maintenance
+  tags: postgres_backup_remote_maintenance
+
+- name: Report PostgreSQL remote backup init check-mode plan
+  when:
+    - "'tags_postgres' in group_names"
+    - inventory_hostname == postgres_backup_remote_maintenance_host
+    - ansible_check_mode
+    - "'postgres_backup_remote_init' in (ansible_run_tags | default([]))"
+  ansible.builtin.debug:
+    msg: Check mode - would initialize the configured PostgreSQL Restic repository.
+  tags: postgres_backup_remote_init
+
+- name: Report PostgreSQL remote backup upload check-mode plan
+  when:
+    - "'tags_postgres' in group_names"
+    - ansible_check_mode
+    - "'postgres_backup_remote_run' in (ansible_run_tags | default([]))"
+  ansible.builtin.debug:
+    msg: >-
+      Check mode - would upload eligible completed PostgreSQL logical backups
+      to the configured Restic repository.
+  tags: postgres_backup_remote_run
+
+- name: Report PostgreSQL remote backup maintenance check-mode plan
+  when:
+    - "'tags_postgres' in group_names"
+    - inventory_hostname == postgres_backup_remote_maintenance_host
+    - ansible_check_mode
+    - "'postgres_backup_remote_maintenance' in (ansible_run_tags | default([]))"
+  ansible.builtin.debug:
+    msg: >-
+      Check mode - would apply scoped PostgreSQL Restic retention and prune
+      unreferenced repository data.
+  tags: postgres_backup_remote_maintenance
+
 - name: Restore PostgreSQL single database from pg_dump backup
   when:
     - inventory_hostname == services_controller_host

--- a/ansible/roles/postgres/tasks/sub_tasks/backup_remote_action.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/backup_remote_action.yml
@@ -1,0 +1,47 @@
+---
+
+- name: Remote logical backup action | Validate explicit action
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_remote_manage
+      - postgres_backup_remote_repository | trim | length > 0
+      - postgres_backup_remote_action in ['init', 'upload', 'maintenance']
+    fail_msg: >-
+      PostgreSQL remote backup actions require remote management and a
+      configured repository.
+
+- name: Remote logical backup action | Invoke host-local runner
+  become: true
+  become_user: root
+  ansible.builtin.command:
+    argv:
+      - "{{ postgres_backup_remote_script_path }}"
+      - "{{ postgres_backup_remote_action }}"
+  register: postgres_backup_remote_action_result
+  changed_when: >-
+    (
+      postgres_backup_remote_action == 'init'
+      and 'POSTGRES_BACKUP_REMOTE_RESULT=INITIALIZED'
+      in (postgres_backup_remote_action_result.stdout_lines | default([]))
+    )
+    or (
+      postgres_backup_remote_action == 'upload'
+      and postgres_backup_remote_action_result.stdout_lines
+      | default([])
+      | select('match', '^POSTGRES_BACKUP_REMOTE_RESULT=UPLOADED_COUNT=[1-9][0-9]*$')
+      | list
+      | length > 0
+    )
+    or postgres_backup_remote_action == 'maintenance'
+
+- name: Remote logical backup action | Report result
+  ansible.builtin.debug:
+    msg: >-
+      {{
+        postgres_backup_remote_action_result.stdout_lines
+        | default([])
+        | select('match', '^POSTGRES_BACKUP_REMOTE_RESULT=')
+        | list
+        | last
+        | default('POSTGRES_BACKUP_REMOTE_RESULT=NO_RESULT_REPORTED', true)
+      }}

--- a/ansible/roles/postgres/tasks/sub_tasks/backup_remote_secret_reconcile.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/backup_remote_secret_reconcile.yml
@@ -1,0 +1,120 @@
+---
+
+- name: Remote logical backup secret reconciliation | Inspect managed-file manifest
+  ansible.builtin.stat:
+    path: "{{ postgres_backup_remote_managed_secret_files_manifest }}"
+    follow: false
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+  register: postgres_backup_remote_managed_secret_files_manifest_stat
+
+- name: Remote logical backup secret reconciliation | Validate managed-file manifest type
+  ansible.builtin.assert:
+    that:
+      - >-
+        not postgres_backup_remote_managed_secret_files_manifest_stat.stat.exists
+        or (
+          postgres_backup_remote_managed_secret_files_manifest_stat.stat.isreg
+          and not postgres_backup_remote_managed_secret_files_manifest_stat.stat.islnk
+        )
+    fail_msg: PostgreSQL remote backup managed-secret manifest must be a regular file.
+
+- name: Remote logical backup secret reconciliation | Read managed-file manifest
+  when: postgres_backup_remote_managed_secret_files_manifest_stat.stat.exists
+  no_log: true
+  diff: false
+  ansible.builtin.slurp:
+    src: "{{ postgres_backup_remote_managed_secret_files_manifest }}"
+  register: postgres_backup_remote_managed_secret_files_manifest_content
+
+- name: Remote logical backup secret reconciliation | Decode previously managed paths
+  no_log: true
+  diff: false
+  ansible.builtin.set_fact:
+    postgres_backup_remote_previous_secret_file_paths: >-
+      {{
+        (
+          postgres_backup_remote_managed_secret_files_manifest_content.content
+          | default('')
+          | b64decode
+        ).splitlines()
+        | reject('equalto', '')
+        | list
+      }}
+
+- name: Remote logical backup secret reconciliation | Validate previous managed paths
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_remote_previous_secret_file_path is string
+      - postgres_backup_remote_previous_secret_file_path is match('^/')
+      - postgres_backup_remote_previous_secret_file_path | dirname == postgres_backup_remote_config_dir
+      - >-
+        postgres_backup_remote_previous_secret_file_path
+        == postgres_backup_remote_config_dir
+           ~ '/'
+           ~ (postgres_backup_remote_previous_secret_file_path | basename)
+      - >-
+        postgres_backup_remote_previous_secret_file_path
+        | basename
+        is match('^[A-Za-z0-9_.-]+$')
+      - postgres_backup_remote_previous_secret_file_path | basename not in ['.', '..']
+      - "'//' not in postgres_backup_remote_previous_secret_file_path"
+      - >-
+        postgres_backup_remote_previous_secret_file_path.split('/')
+        | intersect(['.', '..'])
+        | length == 0
+      - postgres_backup_remote_previous_secret_file_path not in postgres_backup_remote_reserved_config_files
+    fail_msg: PostgreSQL remote backup managed-secret manifest contains an unsafe path.
+  vars:
+    postgres_backup_remote_reserved_config_files:
+      - "{{ postgres_backup_remote_repository_file }}"
+      - "{{ postgres_backup_remote_password_file }}"
+      - "{{ postgres_backup_remote_environment_file }}"
+      - "{{ postgres_backup_remote_managed_secret_files_manifest }}"
+  loop: "{{ postgres_backup_remote_previous_secret_file_paths }}"
+  loop_control:
+    loop_var: postgres_backup_remote_previous_secret_file_path
+    label: managed-secret-file
+
+- name: Remote logical backup secret reconciliation | Validate unique previous managed paths
+  ansible.builtin.assert:
+    that:
+      - >-
+        postgres_backup_remote_previous_secret_file_paths | unique | length
+        == postgres_backup_remote_previous_secret_file_paths | length
+    fail_msg: PostgreSQL remote backup managed-secret manifest contains duplicate paths.
+
+- name: Remote logical backup secret reconciliation | Remove obsolete managed secret files
+  no_log: true
+  diff: false
+  ansible.builtin.file:
+    path: "{{ postgres_backup_remote_obsolete_secret_file_path }}"
+    state: absent
+  loop: >-
+    {{
+      postgres_backup_remote_previous_secret_file_paths
+      | difference(postgres_backup_remote_desired_secret_file_paths)
+    }}
+  loop_control:
+    loop_var: postgres_backup_remote_obsolete_secret_file_path
+    label: obsolete-managed-secret-file
+
+- name: Remote logical backup secret reconciliation | Publish managed-file manifest atomically
+  no_log: true
+  diff: false
+  ansible.builtin.copy:
+    content: >-
+      {{
+        (postgres_backup_remote_desired_secret_file_paths | sort | join('\n'))
+        ~ (
+          '\n'
+          if postgres_backup_remote_desired_secret_file_paths | length > 0
+          else ''
+        )
+      }}
+    dest: "{{ postgres_backup_remote_managed_secret_files_manifest }}"
+    owner: root
+    group: root
+    mode: "0600"
+    unsafe_writes: false

--- a/ansible/roles/postgres/tasks/sub_tasks/backup_remote_setup.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/backup_remote_setup.yml
@@ -1,0 +1,720 @@
+---
+
+- name: Remote logical backup | Validate configuration
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_remote_manage is boolean
+      - postgres_backup_remote_enabled is boolean
+      - postgres_backup_remote_repository is string
+      - "'\n' not in postgres_backup_remote_repository"
+      - postgres_backup_remote_restic_path is string
+      - postgres_backup_remote_restic_path is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_remote_script_path is string
+      - postgres_backup_remote_script_path is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_remote_script_path != postgres_backup_script_path
+      - postgres_backup_remote_state_dir is string
+      - postgres_backup_remote_state_dir is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_remote_state_dir != '/'
+      - postgres_backup_remote_config_dir is string
+      - postgres_backup_remote_config_dir is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_remote_config_dir != '/'
+      - postgres_backup_remote_config_dir[-1:] != '/'
+      - "'//' not in postgres_backup_remote_config_dir"
+      - postgres_backup_remote_config_dir.split('/') | intersect(['.', '..']) | length == 0
+      - postgres_backup_remote_config_dir != postgres_backup_root
+      - postgres_backup_remote_state_dir != postgres_backup_root
+      - postgres_backup_remote_config_dir != postgres_backup_remote_state_dir
+      - postgres_backup_remote_repository_file is string
+      - postgres_backup_remote_repository_file is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_remote_password_file is string
+      - postgres_backup_remote_password_file is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_remote_environment_file is string
+      - postgres_backup_remote_environment_file is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_remote_managed_secret_files_manifest is string
+      - postgres_backup_remote_managed_secret_files_manifest is match('^/[A-Za-z0-9_./-]+$')
+      - >-
+        postgres_backup_remote_managed_secret_files_manifest
+        | basename
+        is match('^[A-Za-z0-9_.-]+$')
+      - postgres_backup_remote_managed_secret_files_manifest | basename not in ['.', '..']
+      - "'//' not in postgres_backup_remote_managed_secret_files_manifest"
+      - >-
+        postgres_backup_remote_managed_secret_files_manifest.split('/')
+        | intersect(['.', '..'])
+        | length == 0
+      - postgres_backup_remote_repository_file | dirname == postgres_backup_remote_config_dir
+      - postgres_backup_remote_password_file | dirname == postgres_backup_remote_config_dir
+      - postgres_backup_remote_environment_file | dirname == postgres_backup_remote_config_dir
+      - >-
+        postgres_backup_remote_managed_secret_files_manifest | dirname
+        == postgres_backup_remote_config_dir
+      - >-
+        postgres_backup_remote_managed_secret_files_manifest
+        == postgres_backup_remote_config_dir
+           ~ '/'
+           ~ (postgres_backup_remote_managed_secret_files_manifest | basename)
+      - >-
+        [
+          postgres_backup_remote_repository_file,
+          postgres_backup_remote_password_file,
+          postgres_backup_remote_environment_file,
+          postgres_backup_remote_managed_secret_files_manifest
+        ]
+        | unique
+        | length == 4
+      - postgres_backup_remote_password_secret is mapping
+      - postgres_backup_remote_password_secret.keys() | difference(['path', 'name']) | length == 0
+      - postgres_backup_remote_password_secret.path | default('') is string
+      - postgres_backup_remote_password_secret.path | default('') | trim | length > 0
+      - postgres_backup_remote_password_secret.name | default('') is string
+      - postgres_backup_remote_password_secret.name | default('') | trim | length > 0
+      - postgres_backup_remote_backend_environment is mapping
+      - postgres_backup_remote_backend_secrets is sequence
+      - postgres_backup_remote_backend_secrets is not string
+      - postgres_backup_remote_backend_secrets is not mapping
+      - postgres_backup_remote_secret_files is sequence
+      - postgres_backup_remote_secret_files is not string
+      - postgres_backup_remote_secret_files is not mapping
+      - postgres_backup_remote_options is sequence
+      - postgres_backup_remote_options is not string
+      - postgres_backup_remote_options is not mapping
+      - postgres_backup_remote_retry_lock is string
+      - postgres_backup_remote_retry_lock | trim | length > 0
+      - >-
+        postgres_backup_remote_retry_lock
+        is match('^(?:[0-9]+(?:\.[0-9]+)?(?:ns|us|ms|s|m|h))+$')
+      - postgres_backup_remote_timer_name is string
+      - postgres_backup_remote_timer_name is match('^[A-Za-z0-9_.@-]+$')
+      - postgres_backup_remote_timer_name != postgres_backup_timer_name
+      - postgres_backup_remote_timer_name != postgres_backup_remote_maintenance_timer_name
+      - postgres_backup_remote_timer_on_calendar is string
+      - postgres_backup_remote_timer_on_calendar | trim | length > 0
+      - postgres_backup_remote_timer_randomized_delay_sec is string
+      - postgres_backup_remote_timer_randomized_delay_sec | trim | length > 0
+      - postgres_backup_remote_maintenance_timer_name is string
+      - postgres_backup_remote_maintenance_timer_name is match('^[A-Za-z0-9_.@-]+$')
+      - postgres_backup_remote_maintenance_timer_on_calendar is string
+      - postgres_backup_remote_maintenance_timer_on_calendar | trim | length > 0
+      - postgres_backup_remote_maintenance_timer_randomized_delay_sec is string
+      - postgres_backup_remote_maintenance_timer_randomized_delay_sec | trim | length > 0
+      - postgres_backup_remote_maintenance_host is string
+      - not postgres_backup_remote_manage
+        or postgres_backup_remote_maintenance_host in groups['tags_postgres']
+      - postgres_backup_remote_snapshot_host is string
+      - postgres_backup_remote_snapshot_host is match('^[A-Za-z0-9_.-]+$')
+      - postgres_patroni_scope is match('^[A-Za-z0-9_.-]+$')
+      - postgres_backup_remote_keep_daily is integer
+      - postgres_backup_remote_keep_daily is not boolean
+      - postgres_backup_remote_keep_daily >= 1
+      - postgres_backup_remote_keep_weekly is integer
+      - postgres_backup_remote_keep_weekly is not boolean
+      - postgres_backup_remote_keep_weekly >= 1
+      - postgres_backup_remote_keep_monthly is integer
+      - postgres_backup_remote_keep_monthly is not boolean
+      - postgres_backup_remote_keep_monthly >= 1
+      - postgres_backup_remote_metrics_file is string
+      - postgres_backup_remote_metrics_file is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_remote_metrics_file != postgres_backup_metrics_file
+      - not postgres_backup_remote_enabled or postgres_backup_remote_manage
+      - not postgres_backup_remote_enabled
+        or postgres_backup_remote_repository | trim | length > 0
+      - >-
+        ansible_run_tags | default([])
+        | intersect([
+          'postgres_backup_remote_init',
+          'postgres_backup_remote_run',
+          'postgres_backup_remote_maintenance'
+        ])
+        | length == 0
+        or postgres_backup_remote_manage
+      - >-
+        ansible_run_tags | default([])
+        | intersect([
+          'postgres_backup_remote_init',
+          'postgres_backup_remote_run',
+          'postgres_backup_remote_maintenance'
+        ])
+        | length == 0
+        or postgres_backup_remote_repository | trim | length > 0
+    fail_msg: PostgreSQL remote logical backup configuration is invalid.
+
+- name: Remote logical backup | Validate backend environment entries
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_remote_environment_entry.key is match('^[A-Za-z_][A-Za-z0-9_]*$')
+      - postgres_backup_remote_environment_entry.value is string
+      - postgres_backup_remote_environment_entry.key not in postgres_backup_remote_reserved_environment_names
+    fail_msg: PostgreSQL remote backend environment entries must be safe string assignments.
+  vars:
+    postgres_backup_remote_reserved_environment_names:
+      - BASH_ENV
+      - BASHOPTS
+      - BASH_XTRACEFD
+      - CDPATH
+      - ENV
+      - GLOBIGNORE
+      - IFS
+      - LD_LIBRARY_PATH
+      - LD_PRELOAD
+      - PATH
+      - POSIXLY_CORRECT
+      - RESTIC_PASSWORD
+      - RESTIC_PASSWORD_COMMAND
+      - RESTIC_PASSWORD_FILE
+      - RESTIC_REPOSITORY
+      - RESTIC_REPOSITORY_FILE
+      - SHELLOPTS
+  loop: "{{ postgres_backup_remote_backend_environment | dict2items }}"
+  loop_control:
+    loop_var: postgres_backup_remote_environment_entry
+    label: "{{ postgres_backup_remote_environment_entry.key }}"
+
+- name: Remote logical backup | Validate backend secret declarations
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_remote_backend_secret is mapping
+      - postgres_backup_remote_backend_secret.keys() | difference(['env', 'path', 'name']) | length == 0
+      - postgres_backup_remote_backend_secret.env | default('') is match('^[A-Za-z_][A-Za-z0-9_]*$')
+      - postgres_backup_remote_backend_secret.env | default('') not in postgres_backup_remote_reserved_environment_names
+      - postgres_backup_remote_backend_secret.path | default('') is string
+      - postgres_backup_remote_backend_secret.path | default('') | trim | length > 0
+      - postgres_backup_remote_backend_secret.name | default('') is string
+      - postgres_backup_remote_backend_secret.name | default('') | trim | length > 0
+    fail_msg: PostgreSQL remote backend secret declarations are invalid.
+  vars:
+    postgres_backup_remote_reserved_environment_names:
+      - BASH_ENV
+      - BASHOPTS
+      - BASH_XTRACEFD
+      - CDPATH
+      - ENV
+      - GLOBIGNORE
+      - IFS
+      - LD_LIBRARY_PATH
+      - LD_PRELOAD
+      - PATH
+      - POSIXLY_CORRECT
+      - RESTIC_PASSWORD
+      - RESTIC_PASSWORD_COMMAND
+      - RESTIC_PASSWORD_FILE
+      - RESTIC_REPOSITORY
+      - RESTIC_REPOSITORY_FILE
+      - SHELLOPTS
+  loop: "{{ postgres_backup_remote_backend_secrets }}"
+  loop_control:
+    loop_var: postgres_backup_remote_backend_secret
+    label: "{{ postgres_backup_remote_backend_secret.env | default('invalid-environment') }}"
+
+- name: Remote logical backup | Validate unique backend secret environment names
+  ansible.builtin.assert:
+    that:
+      - >-
+        postgres_backup_remote_backend_secrets | map(attribute='env') | list | unique | length
+        == postgres_backup_remote_backend_secrets | length
+      - >-
+        postgres_backup_remote_backend_secrets
+        | map(attribute='env')
+        | select('in', postgres_backup_remote_backend_environment.keys())
+        | list
+        | length == 0
+    fail_msg: PostgreSQL remote backend secret environment names must be unique and non-overlapping.
+
+- name: Remote logical backup | Validate secret file declarations
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_remote_secret_file is mapping
+      - postgres_backup_remote_secret_file.keys() | difference(['path', 'infisical', 'mode']) | length == 0
+      - postgres_backup_remote_secret_file.path | default('') is string
+      - postgres_backup_remote_secret_file.path | default('') is match('^/')
+      - postgres_backup_remote_secret_file.path | default('') | dirname == postgres_backup_remote_config_dir
+      - >-
+        postgres_backup_remote_secret_file.path | default('')
+        == postgres_backup_remote_config_dir
+           ~ '/'
+           ~ (postgres_backup_remote_secret_file.path | default('') | basename)
+      - postgres_backup_remote_secret_file.path | default('') | basename is match('^[A-Za-z0-9_.-]+$')
+      - postgres_backup_remote_secret_file.path | default('') | basename not in ['.', '..']
+      - "'//' not in (postgres_backup_remote_secret_file.path | default(''))"
+      - >-
+        (postgres_backup_remote_secret_file.path | default('')).split('/')
+        | intersect(['.', '..'])
+        | length == 0
+      - postgres_backup_remote_secret_file.path | default('') not in postgres_backup_remote_reserved_config_files
+      - postgres_backup_remote_secret_file.mode | default('0600') == '0600'
+      - postgres_backup_remote_secret_file.infisical | default({}) is mapping
+      - >-
+        postgres_backup_remote_secret_file.infisical.keys() | default([])
+        | difference(['path', 'name'])
+        | length == 0
+      - postgres_backup_remote_secret_file.infisical.path | default('') is string
+      - postgres_backup_remote_secret_file.infisical.path | default('') | trim | length > 0
+      - postgres_backup_remote_secret_file.infisical.name | default('') is string
+      - postgres_backup_remote_secret_file.infisical.name | default('') | trim | length > 0
+    fail_msg: PostgreSQL remote secret-file declarations are invalid.
+  vars:
+    postgres_backup_remote_reserved_config_files:
+      - "{{ postgres_backup_remote_repository_file }}"
+      - "{{ postgres_backup_remote_password_file }}"
+      - "{{ postgres_backup_remote_environment_file }}"
+      - "{{ postgres_backup_remote_managed_secret_files_manifest }}"
+  loop: "{{ postgres_backup_remote_secret_files }}"
+  loop_control:
+    loop_var: postgres_backup_remote_secret_file
+    label: "{{ postgres_backup_remote_secret_file.path | default('invalid-secret-file') }}"
+
+- name: Remote logical backup | Validate unique secret file paths
+  ansible.builtin.assert:
+    that:
+      - >-
+        postgres_backup_remote_secret_files | map(attribute='path') | list | unique | length
+        == postgres_backup_remote_secret_files | length
+    fail_msg: PostgreSQL remote secret-file paths must be unique.
+
+- name: Remote logical backup | Validate additional Restic options
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_remote_option is string
+      - postgres_backup_remote_option | trim | length > 0
+      - "'\n' not in postgres_backup_remote_option"
+      - >-
+        not postgres_backup_remote_option
+        is match(
+          '^(?:-r|--repo|--repository|--repository-file|--password|--password-command|--password-file)(?:=|$)'
+        )
+    fail_msg: Additional Restic options must be non-secret individual arguments.
+  loop: "{{ postgres_backup_remote_options }}"
+  loop_control:
+    loop_var: postgres_backup_remote_option
+    label: additional-option
+
+- name: Remote logical backup | Install Restic package
+  when: postgres_backup_remote_manage
+  ansible.builtin.apt:
+    name: restic
+    state: present
+
+- name: Remote logical backup | Create protected configuration directory
+  when: postgres_backup_remote_manage
+  ansible.builtin.file:
+    path: "{{ postgres_backup_remote_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+
+- name: Remote logical backup | Create protected state directories
+  when: postgres_backup_remote_manage
+  ansible.builtin.file:
+    path: "{{ postgres_backup_remote_state_path.path }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+  loop:
+    - path: "{{ postgres_backup_remote_state_dir }}"
+    - path: "{{ postgres_backup_remote_state_dir }}/uploaded"
+  loop_control:
+    loop_var: postgres_backup_remote_state_path
+    label: "{{ postgres_backup_remote_state_path.path }}"
+
+- name: Remote logical backup | Ensure PostgreSQL metrics directory exists
+  when: postgres_backup_remote_manage
+  ansible.builtin.file:
+    path: "{{ postgres_backup_remote_metrics_file | dirname }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0755"
+
+- name: Remote logical backup | Pre-create remote metrics file
+  when: postgres_backup_remote_manage
+  ansible.builtin.file:
+    path: "{{ postgres_backup_remote_metrics_file }}"
+    state: touch
+    owner: root
+    group: root
+    mode: "0644"
+    access_time: preserve
+    modification_time: preserve
+
+- name: Remote logical backup | Reset resolved credential state
+  when: postgres_backup_remote_manage
+  no_log: true
+  diff: false
+  ansible.builtin.set_fact:
+    postgres_backup_remote_resolved_password: ""
+    postgres_backup_remote_resolved_backend_environment: >-
+      {{ postgres_backup_remote_backend_environment }}
+    postgres_backup_remote_resolved_secret_files: []
+
+- name: Remote logical backup | Resolve repository password through controller Infisical parameters
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+    - not ansible_check_mode
+  no_log: true
+  diff: false
+  ansible.builtin.set_fact:
+    postgres_backup_remote_resolved_password: >-
+      {{
+        lookup(
+          'infisical.vault.read_secrets',
+          **(
+            hostvars[services_controller_host].infisical_lookup_default_params
+            | combine({
+              'path': postgres_backup_remote_password_secret.path,
+              'secret_name': postgres_backup_remote_password_secret.name
+            })
+          )
+        ).value
+      }}
+  delegate_to: "{{ services_controller_host }}"
+
+- name: Remote logical backup | Resolve backend environment secrets through controller
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+    - not ansible_check_mode
+  no_log: true
+  diff: false
+  ansible.builtin.set_fact:
+    postgres_backup_remote_resolved_backend_environment: >-
+      {{
+        postgres_backup_remote_resolved_backend_environment
+        | combine({
+          postgres_backup_remote_backend_secret.env: lookup(
+            'infisical.vault.read_secrets',
+            **(
+              hostvars[services_controller_host].infisical_lookup_default_params
+              | combine({
+                'path': postgres_backup_remote_backend_secret.path,
+                'secret_name': postgres_backup_remote_backend_secret.name
+              })
+            )
+          ).value
+        })
+      }}
+  loop: "{{ postgres_backup_remote_backend_secrets }}"
+  loop_control:
+    loop_var: postgres_backup_remote_backend_secret
+    label: "{{ postgres_backup_remote_backend_secret.env }}"
+  delegate_to: "{{ services_controller_host }}"
+
+- name: Remote logical backup | Resolve backend secret files through controller
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+    - not ansible_check_mode
+  no_log: true
+  diff: false
+  ansible.builtin.set_fact:
+    postgres_backup_remote_resolved_secret_files: >-
+      {{
+        postgres_backup_remote_resolved_secret_files
+        + [postgres_backup_remote_secret_file | combine({
+          'value': lookup(
+            'infisical.vault.read_secrets',
+            **(
+              hostvars[services_controller_host].infisical_lookup_default_params
+              | combine({
+                'path': postgres_backup_remote_secret_file.infisical.path,
+                'secret_name': postgres_backup_remote_secret_file.infisical.name
+              })
+            )
+          ).value
+        })]
+      }}
+  loop: "{{ postgres_backup_remote_secret_files }}"
+  loop_control:
+    loop_var: postgres_backup_remote_secret_file
+    label: "{{ postgres_backup_remote_secret_file.path }}"
+  delegate_to: "{{ services_controller_host }}"
+
+- name: Remote logical backup | Build deterministic check-mode credentials
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+    - ansible_check_mode
+  no_log: true
+  diff: false
+  ansible.builtin.set_fact:
+    postgres_backup_remote_resolved_password: CHECK_MODE_RESTIC_PASSWORD
+
+- name: Remote logical backup | Build deterministic check-mode backend secrets
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+    - ansible_check_mode
+  no_log: true
+  diff: false
+  ansible.builtin.set_fact:
+    postgres_backup_remote_resolved_backend_environment: >-
+      {{
+        postgres_backup_remote_resolved_backend_environment
+        | combine({postgres_backup_remote_backend_secret.env: 'CHECK_MODE_BACKEND_SECRET'})
+      }}
+  loop: "{{ postgres_backup_remote_backend_secrets }}"
+  loop_control:
+    loop_var: postgres_backup_remote_backend_secret
+    label: "{{ postgres_backup_remote_backend_secret.env }}"
+
+- name: Remote logical backup | Build deterministic check-mode secret files
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+    - ansible_check_mode
+  no_log: true
+  diff: false
+  ansible.builtin.set_fact:
+    postgres_backup_remote_resolved_secret_files: >-
+      {{
+        postgres_backup_remote_resolved_secret_files
+        + [postgres_backup_remote_secret_file | combine({'value': 'CHECK_MODE_SECRET_FILE'})]
+      }}
+  loop: "{{ postgres_backup_remote_secret_files }}"
+  loop_control:
+    loop_var: postgres_backup_remote_secret_file
+    label: "{{ postgres_backup_remote_secret_file.path }}"
+
+- name: Remote logical backup | Validate resolved credentials
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+  no_log: true
+  diff: false
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_remote_resolved_password | string | length > 0
+      - >-
+        postgres_backup_remote_resolved_backend_environment.values()
+        | map('string')
+        | select('equalto', '')
+        | list
+        | length == 0
+      - >-
+        postgres_backup_remote_resolved_secret_files
+        | map(attribute='value')
+        | map('string')
+        | select('equalto', '')
+        | list
+        | length == 0
+    fail_msg: PostgreSQL remote backup credential resolution returned an empty value.
+
+- name: Remote logical backup | Write repository location
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+  no_log: true
+  diff: false
+  ansible.builtin.copy:
+    content: "{{ postgres_backup_remote_repository | trim }}\n"
+    dest: "{{ postgres_backup_remote_repository_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Remote logical backup | Write repository password
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+  no_log: true
+  diff: false
+  ansible.builtin.copy:
+    content: "{{ postgres_backup_remote_resolved_password }}"
+    dest: "{{ postgres_backup_remote_password_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Remote logical backup | Write protected backend environment
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+  no_log: true
+  diff: false
+  ansible.builtin.template:
+    src: postgres-logical-backup-remote.env.j2
+    dest: "{{ postgres_backup_remote_environment_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Remote logical backup | Write protected backend secret files
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length > 0
+  no_log: true
+  diff: false
+  ansible.builtin.copy:
+    content: "{{ postgres_backup_remote_resolved_secret_file.value }}"
+    dest: "{{ postgres_backup_remote_resolved_secret_file.path }}"
+    owner: root
+    group: root
+    mode: "0600"
+  loop: "{{ postgres_backup_remote_resolved_secret_files }}"
+  loop_control:
+    loop_var: postgres_backup_remote_resolved_secret_file
+    label: protected-secret-file
+
+- name: Remote logical backup | Remove inactive core credential files
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length == 0
+  no_log: true
+  diff: false
+  ansible.builtin.file:
+    path: "{{ postgres_backup_remote_inactive_config_file }}"
+    state: absent
+  loop:
+    - "{{ postgres_backup_remote_repository_file }}"
+    - "{{ postgres_backup_remote_password_file }}"
+    - "{{ postgres_backup_remote_environment_file }}"
+  loop_control:
+    loop_var: postgres_backup_remote_inactive_config_file
+    label: protected-config-file
+
+- name: Remote logical backup | Remove declared inactive secret files
+  when:
+    - postgres_backup_remote_manage
+    - postgres_backup_remote_repository | trim | length == 0
+  no_log: true
+  diff: false
+  ansible.builtin.file:
+    path: "{{ postgres_backup_remote_secret_file.path }}"
+    state: absent
+  loop: "{{ postgres_backup_remote_secret_files }}"
+  loop_control:
+    loop_var: postgres_backup_remote_secret_file
+    label: protected-secret-file
+
+- name: Remote logical backup | Build desired managed secret-file paths
+  when: postgres_backup_remote_manage
+  no_log: true
+  diff: false
+  ansible.builtin.set_fact:
+    postgres_backup_remote_desired_secret_file_paths: >-
+      {{
+        (
+          postgres_backup_remote_secret_files
+          | map(attribute='path')
+          | list
+          | sort
+        )
+        if postgres_backup_remote_repository | trim | length > 0
+        else []
+      }}
+
+- name: Remote logical backup | Reconcile managed secret files
+  when: postgres_backup_remote_manage
+  ansible.builtin.include_tasks:
+    file: backup_remote_secret_reconcile.yml
+    apply:
+      tags:
+        - postgres
+        - postgres_backup_remote_setup
+        - postgres_backup_remote_init
+        - postgres_backup_remote_run
+        - postgres_backup_remote_maintenance
+  tags:
+    - postgres
+    - postgres_backup_remote_setup
+    - postgres_backup_remote_init
+    - postgres_backup_remote_run
+    - postgres_backup_remote_maintenance
+
+- name: Remote logical backup | Install host-local runner
+  when: postgres_backup_remote_manage
+  ansible.builtin.template:
+    src: postgres-logical-backup-remote.sh.j2
+    dest: "{{ postgres_backup_remote_script_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Remote logical backup | Manage uploader systemd job
+  when: postgres_backup_remote_manage
+  ansible.builtin.include_role:
+    name: systemd_jobs
+    apply:
+      tags:
+        - postgres
+        - systemd_jobs
+        - postgres_backup_remote_setup
+        - postgres_backup_remote_init
+        - postgres_backup_remote_run
+        - postgres_backup_remote_maintenance
+  vars:
+    systemd_jobs: # noqa var-naming[no-role-prefix]
+      - name: "{{ postgres_backup_remote_timer_name }}"
+        description: Upload completed PostgreSQL logical backups to Restic
+        service:
+          type: oneshot
+          exec_start: "{{ postgres_backup_remote_script_path }} upload"
+          user: root
+          group: root
+          working_directory: "{{ postgres_backup_remote_state_dir }}"
+          wants:
+            - network-online.target
+          after:
+            - network-online.target
+          nice: 10
+          io_scheduling_class: best-effort
+          io_scheduling_priority: 7
+        timer:
+          description: Upload completed PostgreSQL logical backups to Restic
+          on_calendar: "{{ postgres_backup_remote_timer_on_calendar }}"
+          randomized_delay_sec: "{{ postgres_backup_remote_timer_randomized_delay_sec }}"
+          persistent: true
+        enabled: "{{ postgres_backup_remote_enabled }}"
+  tags:
+    - postgres
+    - systemd_jobs
+    - postgres_backup_remote_setup
+    - postgres_backup_remote_init
+    - postgres_backup_remote_run
+    - postgres_backup_remote_maintenance
+
+- name: Remote logical backup | Manage maintenance systemd job
+  when:
+    - postgres_backup_remote_manage
+    - inventory_hostname == postgres_backup_remote_maintenance_host
+  ansible.builtin.include_role:
+    name: systemd_jobs
+    apply:
+      tags:
+        - postgres
+        - systemd_jobs
+        - postgres_backup_remote_setup
+        - postgres_backup_remote_init
+        - postgres_backup_remote_run
+        - postgres_backup_remote_maintenance
+  vars:
+    systemd_jobs: # noqa var-naming[no-role-prefix]
+      - name: "{{ postgres_backup_remote_maintenance_timer_name }}"
+        description: Apply PostgreSQL Restic retention and prune repository data
+        service:
+          type: oneshot
+          exec_start: "{{ postgres_backup_remote_script_path }} maintenance"
+          user: root
+          group: root
+          working_directory: "{{ postgres_backup_remote_state_dir }}"
+          wants:
+            - network-online.target
+          after:
+            - network-online.target
+          nice: 10
+          io_scheduling_class: best-effort
+          io_scheduling_priority: 7
+        timer:
+          description: Maintain PostgreSQL logical backup Restic snapshots
+          on_calendar: "{{ postgres_backup_remote_maintenance_timer_on_calendar }}"
+          randomized_delay_sec: "{{ postgres_backup_remote_maintenance_timer_randomized_delay_sec }}"
+          persistent: true
+        enabled: "{{ postgres_backup_remote_enabled }}"
+  tags:
+    - postgres
+    - systemd_jobs
+    - postgres_backup_remote_setup
+    - postgres_backup_remote_init
+    - postgres_backup_remote_run
+    - postgres_backup_remote_maintenance

--- a/ansible/roles/postgres/tasks/sub_tasks/backup_remote_setup.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/backup_remote_setup.yml
@@ -615,12 +615,16 @@
         - postgres_backup_remote_init
         - postgres_backup_remote_run
         - postgres_backup_remote_maintenance
+        - postgres_backup_restore_validation_setup
+        - postgres_backup_restore_validation_run
   tags:
     - postgres
     - postgres_backup_remote_setup
     - postgres_backup_remote_init
     - postgres_backup_remote_run
     - postgres_backup_remote_maintenance
+    - postgres_backup_restore_validation_setup
+    - postgres_backup_restore_validation_run
 
 - name: Remote logical backup | Install host-local runner
   when: postgres_backup_remote_manage
@@ -643,6 +647,8 @@
         - postgres_backup_remote_init
         - postgres_backup_remote_run
         - postgres_backup_remote_maintenance
+        - postgres_backup_restore_validation_setup
+        - postgres_backup_restore_validation_run
   vars:
     systemd_jobs: # noqa var-naming[no-role-prefix]
       - name: "{{ postgres_backup_remote_timer_name }}"
@@ -673,6 +679,8 @@
     - postgres_backup_remote_init
     - postgres_backup_remote_run
     - postgres_backup_remote_maintenance
+    - postgres_backup_restore_validation_setup
+    - postgres_backup_restore_validation_run
 
 - name: Remote logical backup | Manage maintenance systemd job
   when:
@@ -688,6 +696,8 @@
         - postgres_backup_remote_init
         - postgres_backup_remote_run
         - postgres_backup_remote_maintenance
+        - postgres_backup_restore_validation_setup
+        - postgres_backup_restore_validation_run
   vars:
     systemd_jobs: # noqa var-naming[no-role-prefix]
       - name: "{{ postgres_backup_remote_maintenance_timer_name }}"
@@ -718,3 +728,5 @@
     - postgres_backup_remote_init
     - postgres_backup_remote_run
     - postgres_backup_remote_maintenance
+    - postgres_backup_restore_validation_setup
+    - postgres_backup_restore_validation_run

--- a/ansible/roles/postgres/tasks/sub_tasks/backup_remote_setup.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/backup_remote_setup.yml
@@ -293,6 +293,36 @@
     name: restic
     state: present
 
+- name: Remote logical backup | Query installed Restic version
+  when:
+    - postgres_backup_remote_manage
+    - not ansible_check_mode
+  ansible.builtin.command:
+    argv:
+      - "{{ postgres_backup_remote_restic_path }}"
+      - version
+  register: postgres_backup_remote_restic_version_result
+  changed_when: false
+
+- name: Remote logical backup | Require supported Restic version
+  when:
+    - postgres_backup_remote_manage
+    - not ansible_check_mode
+  ansible.builtin.assert:
+    that:
+      - >-
+        postgres_backup_remote_restic_version_result.stdout
+        is match('^restic [0-9]+\.[0-9]+\.[0-9]+(?:[-+~][^ ]+)?(?: |$)')
+      - >-
+        (
+          postgres_backup_remote_restic_version_result.stdout
+          | regex_replace('^restic ([0-9]+\.[0-9]+\.[0-9]+).*', '\1')
+        )
+        is version('0.17.1', '>=')
+    fail_msg: >-
+      PostgreSQL remote backups require Restic 0.17.1 or newer for
+      differentiated repository and password failure exit codes.
+
 - name: Remote logical backup | Create protected configuration directory
   when: postgres_backup_remote_manage
   ansible.builtin.file:
@@ -636,7 +666,6 @@
     mode: "0755"
 
 - name: Remote logical backup | Manage uploader systemd job
-  when: postgres_backup_remote_manage
   ansible.builtin.include_role:
     name: systemd_jobs
     apply:
@@ -671,7 +700,8 @@
           on_calendar: "{{ postgres_backup_remote_timer_on_calendar }}"
           randomized_delay_sec: "{{ postgres_backup_remote_timer_randomized_delay_sec }}"
           persistent: true
-        enabled: "{{ postgres_backup_remote_enabled }}"
+        enabled: >-
+          {{ postgres_backup_remote_manage and postgres_backup_remote_enabled }}
   tags:
     - postgres
     - systemd_jobs
@@ -683,9 +713,6 @@
     - postgres_backup_restore_validation_run
 
 - name: Remote logical backup | Manage maintenance systemd job
-  when:
-    - postgres_backup_remote_manage
-    - inventory_hostname == postgres_backup_remote_maintenance_host
   ansible.builtin.include_role:
     name: systemd_jobs
     apply:
@@ -720,7 +747,12 @@
           on_calendar: "{{ postgres_backup_remote_maintenance_timer_on_calendar }}"
           randomized_delay_sec: "{{ postgres_backup_remote_maintenance_timer_randomized_delay_sec }}"
           persistent: true
-        enabled: "{{ postgres_backup_remote_enabled }}"
+        enabled: >-
+          {{
+            postgres_backup_remote_manage
+            and postgres_backup_remote_enabled
+            and inventory_hostname == postgres_backup_remote_maintenance_host
+          }}
   tags:
     - postgres
     - systemd_jobs

--- a/ansible/roles/postgres/tasks/sub_tasks/backup_restore_validation_action.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/backup_restore_validation_action.yml
@@ -1,0 +1,38 @@
+---
+
+- name: Backup restore validation action | Validate explicit action
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_restore_validation_manage
+      - postgres_backup_remote_manage
+      - postgres_backup_remote_repository | trim | length > 0
+      - inventory_hostname == postgres_backup_restore_validation_host
+    fail_msg: >-
+      PostgreSQL backup restore validation requires its managed designated host
+      and a configured remote Restic repository.
+
+- name: Backup restore validation action | Invoke host-local runner
+  become: true
+  become_user: root
+  ansible.builtin.command:
+    argv:
+      - "{{ postgres_backup_restore_validation_script_path }}"
+  register: postgres_backup_restore_validation_action_result
+  changed_when: >-
+    'POSTGRES_BACKUP_RESTORE_VALIDATION_RESULT=VALIDATED'
+    in (postgres_backup_restore_validation_action_result.stdout_lines | default([]))
+
+- name: Backup restore validation action | Report result
+  ansible.builtin.debug:
+    msg: >-
+      {{
+        postgres_backup_restore_validation_action_result.stdout_lines
+        | default([])
+        | select('match', '^POSTGRES_BACKUP_RESTORE_VALIDATION_RESULT=')
+        | list
+        | last
+        | default(
+          'POSTGRES_BACKUP_RESTORE_VALIDATION_RESULT=NO_RESULT_REPORTED',
+          true
+        )
+      }}

--- a/ansible/roles/postgres/tasks/sub_tasks/backup_restore_validation_setup.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/backup_restore_validation_setup.yml
@@ -81,6 +81,12 @@
       - postgres_backup_restore_validation_min_free_bytes is integer
       - postgres_backup_restore_validation_min_free_bytes is not boolean
       - postgres_backup_restore_validation_min_free_bytes >= 0
+      - postgres_backup_restore_validation_encoding is string
+      - postgres_backup_restore_validation_encoding | trim | length > 0
+      - "'\n' not in postgres_backup_restore_validation_encoding"
+      - postgres_backup_restore_validation_locale is string
+      - postgres_backup_restore_validation_locale | trim | length > 0
+      - "'\n' not in postgres_backup_restore_validation_locale"
       - postgres_backup_restore_validation_metrics_file is string
       - postgres_backup_restore_validation_metrics_file
         is match('^/[A-Za-z0-9_./-]+$')
@@ -145,9 +151,6 @@
     mode: "0755"
 
 - name: Backup restore validation | Manage systemd job
-  when:
-    - postgres_backup_restore_validation_manage
-    - inventory_hostname == postgres_backup_restore_validation_host
   ansible.builtin.include_role:
     name: systemd_jobs
     apply:
@@ -179,7 +182,12 @@
           randomized_delay_sec: >-
             {{ postgres_backup_restore_validation_timer_randomized_delay_sec }}
           persistent: true
-        enabled: "{{ postgres_backup_restore_validation_enabled }}"
+        enabled: >-
+          {{
+            postgres_backup_restore_validation_manage
+            and postgres_backup_restore_validation_enabled
+            and inventory_hostname == postgres_backup_restore_validation_host
+          }}
   tags:
     - postgres
     - systemd_jobs

--- a/ansible/roles/postgres/tasks/sub_tasks/backup_restore_validation_setup.yml
+++ b/ansible/roles/postgres/tasks/sub_tasks/backup_restore_validation_setup.yml
@@ -1,0 +1,187 @@
+---
+
+- name: Backup restore validation | Validate configuration
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_restore_validation_manage is boolean
+      - postgres_backup_restore_validation_enabled is boolean
+      - not postgres_backup_restore_validation_enabled
+        or postgres_backup_restore_validation_manage
+      - not postgres_backup_restore_validation_manage
+        or postgres_backup_remote_manage
+      - not postgres_backup_restore_validation_manage
+        or postgres_backup_remote_repository | trim | length > 0
+      - postgres_backup_restore_validation_host is string
+      - not postgres_backup_restore_validation_manage
+        or postgres_backup_restore_validation_host
+           in (groups['tags_postgres'] | default([]))
+      - postgres_backup_restore_validation_script_path is string
+      - postgres_backup_restore_validation_script_path
+        is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_restore_validation_script_path
+        not in [postgres_backup_script_path, postgres_backup_remote_script_path]
+      - postgres_backup_restore_validation_runuser_path is string
+      - postgres_backup_restore_validation_runuser_path
+        is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_restore_validation_work_root is string
+      - postgres_backup_restore_validation_work_root
+        is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_restore_validation_work_root != '/'
+      - postgres_backup_restore_validation_work_root[-1:] != '/'
+      - "'//' not in postgres_backup_restore_validation_work_root"
+      - >-
+        postgres_backup_restore_validation_work_root.split('/')
+        | intersect(['.', '..'])
+        | length == 0
+      - postgres_backup_restore_validation_work_root
+        not in [
+          postgres_backup_root,
+          postgres_backup_remote_state_dir,
+          postgres_backup_remote_config_dir,
+          postgres_patroni_data_dir
+        ]
+      - >-
+        not (
+          postgres_backup_restore_validation_work_root
+          is match('^' ~ (postgres_backup_root | regex_escape) ~ '(?:/|$)')
+        )
+      - >-
+        not (
+          postgres_backup_root
+          is match(
+            '^'
+            ~ (postgres_backup_restore_validation_work_root | regex_escape)
+            ~ '(?:/|$)'
+          )
+        )
+      - postgres_backup_restore_validation_timer_name is string
+      - postgres_backup_restore_validation_timer_name
+        is match('^[A-Za-z0-9_.@-]+$')
+      - postgres_backup_restore_validation_timer_name
+        not in [
+          postgres_backup_timer_name,
+          postgres_backup_remote_timer_name,
+          postgres_backup_remote_maintenance_timer_name
+        ]
+      - postgres_backup_restore_validation_timer_on_calendar is string
+      - postgres_backup_restore_validation_timer_on_calendar | trim | length > 0
+      - postgres_backup_restore_validation_timer_randomized_delay_sec is string
+      - >-
+        postgres_backup_restore_validation_timer_randomized_delay_sec
+        | trim
+        | length > 0
+      - postgres_backup_restore_validation_port is integer
+      - postgres_backup_restore_validation_port is not boolean
+      - postgres_backup_restore_validation_port >= 1
+      - postgres_backup_restore_validation_port <= 65535
+      - postgres_backup_restore_validation_port != postgres_patroni_postgres_port
+      - postgres_backup_restore_validation_max_snapshot_age_hours is integer
+      - postgres_backup_restore_validation_max_snapshot_age_hours is not boolean
+      - postgres_backup_restore_validation_max_snapshot_age_hours >= 1
+      - postgres_backup_restore_validation_min_free_bytes is integer
+      - postgres_backup_restore_validation_min_free_bytes is not boolean
+      - postgres_backup_restore_validation_min_free_bytes >= 0
+      - postgres_backup_restore_validation_metrics_file is string
+      - postgres_backup_restore_validation_metrics_file
+        is match('^/[A-Za-z0-9_./-]+$')
+      - postgres_backup_restore_validation_metrics_file
+        not in [postgres_backup_metrics_file, postgres_backup_remote_metrics_file]
+      - postgres_patroni_bin_dir is string
+      - postgres_patroni_bin_dir is match('^/[A-Za-z0-9_./-]+$')
+      - >-
+        'postgres_backup_restore_validation_run'
+        not in (ansible_run_tags | default([]))
+        or postgres_backup_restore_validation_manage
+      - >-
+        'postgres_backup_restore_validation_run'
+        not in (ansible_run_tags | default([]))
+        or postgres_backup_remote_repository | trim | length > 0
+    fail_msg: PostgreSQL backup restore-validation configuration is invalid.
+
+- name: Backup restore validation | Create protected work root
+  when:
+    - postgres_backup_restore_validation_manage
+    - inventory_hostname == postgres_backup_restore_validation_host
+  ansible.builtin.file:
+    path: "{{ postgres_backup_restore_validation_work_root }}"
+    state: directory
+    owner: root
+    group: postgres
+    mode: "0710"
+
+- name: Backup restore validation | Ensure PostgreSQL metrics directory exists
+  when:
+    - postgres_backup_restore_validation_manage
+    - inventory_hostname == postgres_backup_restore_validation_host
+  ansible.builtin.file:
+    path: "{{ postgres_backup_restore_validation_metrics_file | dirname }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0755"
+
+- name: Backup restore validation | Pre-create metrics file
+  when:
+    - postgres_backup_restore_validation_manage
+    - inventory_hostname == postgres_backup_restore_validation_host
+  ansible.builtin.file:
+    path: "{{ postgres_backup_restore_validation_metrics_file }}"
+    state: touch
+    owner: root
+    group: root
+    mode: "0644"
+    access_time: preserve
+    modification_time: preserve
+
+- name: Backup restore validation | Install host-local runner
+  when:
+    - postgres_backup_restore_validation_manage
+    - inventory_hostname == postgres_backup_restore_validation_host
+  ansible.builtin.template:
+    src: postgres-logical-backup-restore-validate.sh.j2
+    dest: "{{ postgres_backup_restore_validation_script_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Backup restore validation | Manage systemd job
+  when:
+    - postgres_backup_restore_validation_manage
+    - inventory_hostname == postgres_backup_restore_validation_host
+  ansible.builtin.include_role:
+    name: systemd_jobs
+    apply:
+      tags:
+        - postgres
+        - systemd_jobs
+        - postgres_backup_restore_validation_setup
+        - postgres_backup_restore_validation_run
+  vars:
+    systemd_jobs: # noqa var-naming[no-role-prefix]
+      - name: "{{ postgres_backup_restore_validation_timer_name }}"
+        description: Validate PostgreSQL logical backups restored from Restic
+        service:
+          type: oneshot
+          exec_start: "{{ postgres_backup_restore_validation_script_path }}"
+          user: root
+          group: root
+          working_directory: "{{ postgres_backup_restore_validation_work_root }}"
+          wants:
+            - network-online.target
+          after:
+            - network-online.target
+          nice: 10
+          io_scheduling_class: best-effort
+          io_scheduling_priority: 7
+        timer:
+          description: Validate PostgreSQL logical backups restored from Restic
+          on_calendar: "{{ postgres_backup_restore_validation_timer_on_calendar }}"
+          randomized_delay_sec: >-
+            {{ postgres_backup_restore_validation_timer_randomized_delay_sec }}
+          persistent: true
+        enabled: "{{ postgres_backup_restore_validation_enabled }}"
+  tags:
+    - postgres
+    - systemd_jobs
+    - postgres_backup_restore_validation_setup
+    - postgres_backup_restore_validation_run

--- a/ansible/roles/postgres/templates/postgres-logical-backup-remote.env.j2
+++ b/ansible/roles/postgres/templates/postgres-logical-backup-remote.env.j2
@@ -1,0 +1,3 @@
+{% for environment_name, environment_value in postgres_backup_remote_resolved_backend_environment | dictsort %}
+{{ environment_name }}='{{ environment_value | string | replace("'", "'\"'\"'") }}'
+{% endfor %}

--- a/ansible/roles/postgres/templates/postgres-logical-backup-remote.sh.j2
+++ b/ansible/roles/postgres/templates/postgres-logical-backup-remote.sh.j2
@@ -175,8 +175,8 @@ set_repository_upload_directory() {
   REPOSITORY_UPLOADED_DIR="$UPLOADED_DIR/$REPOSITORY_ID"
   [[ ! -e "$REPOSITORY_UPLOADED_DIR" || -d "$REPOSITORY_UPLOADED_DIR" ]] ||
     fail "Restic repository upload-state path exists but is not a directory."
-  mkdir -p -m 0700 -- "$REPOSITORY_UPLOADED_DIR"
-  chmod 0700 "$REPOSITORY_UPLOADED_DIR"
+  mkdir -p -- "$REPOSITORY_UPLOADED_DIR"
+  chmod 0700 -- "$REPOSITORY_UPLOADED_DIR"
 }
 
 require_initialized_repository() {

--- a/ansible/roles/postgres/templates/postgres-logical-backup-remote.sh.j2
+++ b/ansible/roles/postgres/templates/postgres-logical-backup-remote.sh.j2
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+readonly BACKUP_ROOT='{{ postgres_backup_root | string | replace("'", "'\"'\"'") }}'
+readonly STATE_DIR='{{ postgres_backup_remote_state_dir | string | replace("'", "'\"'\"'") }}'
+readonly UPLOADED_DIR="$STATE_DIR/uploaded"
+readonly PYTHON_BIN="/usr/bin/python3"
+readonly LOCK_FILE="$STATE_DIR/remote.lock"
+readonly METRICS_FILE='{{ postgres_backup_remote_metrics_file | string | replace("'", "'\"'\"'") }}'
+readonly RESTIC_BIN='{{ postgres_backup_remote_restic_path | string | replace("'", "'\"'\"'") }}'
+readonly REPOSITORY_FILE='{{ postgres_backup_remote_repository_file | string | replace("'", "'\"'\"'") }}'
+readonly PASSWORD_FILE='{{ postgres_backup_remote_password_file | string | replace("'", "'\"'\"'") }}'
+readonly BACKEND_ENV_FILE='{{ postgres_backup_remote_environment_file | string | replace("'", "'\"'\"'") }}'
+readonly SNAPSHOT_HOST='{{ postgres_backup_remote_snapshot_host | string | replace("'", "'\"'\"'") }}'
+readonly CLUSTER_SCOPE='{{ postgres_patroni_scope | string | replace("'", "'\"'\"'") }}'
+readonly SOURCE_MEMBER='{{ inventory_hostname | string | replace("'", "'\"'\"'") }}'
+readonly KEEP_DAILY={{ postgres_backup_remote_keep_daily }}
+readonly KEEP_WEEKLY={{ postgres_backup_remote_keep_weekly }}
+readonly KEEP_MONTHLY={{ postgres_backup_remote_keep_monthly }}
+readonly RETRY_LOCK='{{ postgres_backup_remote_retry_lock | string | replace("'", "'\"'\"'") }}'
+
+RESTIC_OPTIONS=(
+{% for postgres_backup_remote_option in postgres_backup_remote_options %}
+  '{{ postgres_backup_remote_option | string | replace("'", "'\"'\"'") }}'
+{% endfor %}
+)
+
+MODE="${1:-upload}"
+ATTEMPT_EPOCH=0
+RUN_START_EPOCH=0
+REPORT_FAILURE_METRICS=0
+LAST_SUCCESS_EPOCH=0
+UPLOADED_COUNT=0
+PENDING_COUNT=0
+CANDIDATES_FILE=""
+MARKER_TMP=""
+REPOSITORY_CONFIG=""
+REPOSITORY_ID=""
+REPOSITORY_UPLOADED_DIR=""
+
+log() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  return 1
+}
+
+existing_metric() {
+  local metric_name="$1"
+  local default_value="$2"
+  local metric_value=""
+
+  if [[ -r "$METRICS_FILE" ]]; then
+    metric_value="$(awk -v name="$metric_name" '$1 == name { print $2; exit }' "$METRICS_FILE")"
+  fi
+
+  if [[ "$metric_value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$metric_value"
+  else
+    printf '%s\n' "$default_value"
+  fi
+}
+
+write_metrics() {
+  local attempt_epoch="$1"
+  local success_epoch="$2"
+  local run_success="$3"
+  local duration_seconds="$4"
+  local uploaded_count="$5"
+  local pending_count="$6"
+  local metrics_tmp
+
+  metrics_tmp="$(mktemp "${METRICS_FILE}.tmp.XXXXXX")"
+  {
+    printf '# HELP postgres_backup_remote_last_attempt_timestamp_seconds Unix timestamp of the last remote upload attempt.\n'
+    printf '# TYPE postgres_backup_remote_last_attempt_timestamp_seconds gauge\n'
+    printf 'postgres_backup_remote_last_attempt_timestamp_seconds %s\n' "$attempt_epoch"
+    printf '# HELP postgres_backup_remote_last_success_timestamp_seconds Unix timestamp of the last successful remote upload.\n'
+    printf '# TYPE postgres_backup_remote_last_success_timestamp_seconds gauge\n'
+    printf 'postgres_backup_remote_last_success_timestamp_seconds %s\n' "$success_epoch"
+    printf '# HELP postgres_backup_remote_last_run_success Whether the last uploader run completed successfully.\n'
+    printf '# TYPE postgres_backup_remote_last_run_success gauge\n'
+    printf 'postgres_backup_remote_last_run_success %s\n' "$run_success"
+    printf '# HELP postgres_backup_remote_last_duration_seconds Duration of the last uploader run.\n'
+    printf '# TYPE postgres_backup_remote_last_duration_seconds gauge\n'
+    printf 'postgres_backup_remote_last_duration_seconds %s\n' "$duration_seconds"
+    printf '# HELP postgres_backup_remote_last_uploaded_count Backups uploaded by the last uploader run.\n'
+    printf '# TYPE postgres_backup_remote_last_uploaded_count gauge\n'
+    printf 'postgres_backup_remote_last_uploaded_count %s\n' "$uploaded_count"
+    printf '# HELP postgres_backup_remote_pending_count Eligible local backups still pending upload.\n'
+    printf '# TYPE postgres_backup_remote_pending_count gauge\n'
+    printf 'postgres_backup_remote_pending_count %s\n' "$pending_count"
+  } > "$metrics_tmp"
+  chmod 0644 "$metrics_tmp"
+  mv -f -- "$metrics_tmp" "$METRICS_FILE"
+}
+
+cleanup_transients() {
+  if [[ -n "$CANDIDATES_FILE" ]]; then
+    rm -f -- "$CANDIDATES_FILE"
+  fi
+  if [[ -n "$MARKER_TMP" ]]; then
+    rm -f -- "$MARKER_TMP"
+  fi
+}
+
+on_error() {
+  local exit_status="$?"
+  local failure_epoch
+  local duration_seconds
+
+  trap - ERR
+  set +e
+  failure_epoch="$(date +%s)"
+  duration_seconds=$((failure_epoch - RUN_START_EPOCH))
+
+  if [[ "$MODE" == upload ]] && (( REPORT_FAILURE_METRICS == 1 )); then
+    write_metrics \
+      "$ATTEMPT_EPOCH" \
+      "$LAST_SUCCESS_EPOCH" \
+      0 \
+      "$duration_seconds" \
+      "$UPLOADED_COUNT" \
+      "$PENDING_COUNT"
+  fi
+
+  log "PostgreSQL remote backup $MODE operation failed." >&2
+  exit "$exit_status"
+}
+
+run_restic() {
+  "$RESTIC_BIN" "${RESTIC_OPTIONS[@]}" --retry-lock "$RETRY_LOCK" "$@"
+}
+
+eligible_backup() {
+  local candidate="$1"
+  local backup_id
+
+  backup_id="$(basename -- "$candidate")"
+  [[ "$backup_id" =~ ^[0-9]{8}T[0-9]{6}Z$ ]] || return 1
+  [[ -f "$candidate/SUCCESS" ]] || return 1
+  return 0
+}
+
+probe_repository() {
+  local probe_output=""
+  local probe_status=0
+
+  probe_output="$(run_restic cat config)" || probe_status=$?
+  if (( probe_status == 0 )); then
+    REPOSITORY_CONFIG="$probe_output"
+  else
+    REPOSITORY_CONFIG=""
+  fi
+  return "$probe_status"
+}
+
+set_repository_upload_directory() {
+  local repository_id=""
+
+  [[ -x "$PYTHON_BIN" ]] || fail "Python 3 is required to parse the Restic repository config."
+  if ! repository_id="$(
+    printf '%s' "$REPOSITORY_CONFIG" |
+      "$PYTHON_BIN" -c 'import json, re, sys; repository_id = json.load(sys.stdin).get("id"); isinstance(repository_id, str) and re.fullmatch(r"[0-9a-f]{64}", repository_id) or sys.exit(1); print(repository_id, end="")' 2> /dev/null
+  )"; then
+    fail "Restic repository config is not valid JSON with a string id."
+  fi
+  [[ "$repository_id" =~ ^[0-9a-f]{64}$ ]] ||
+    fail "Restic repository config id is empty or does not match the expected 64-character lowercase hexadecimal format."
+
+  REPOSITORY_ID="$repository_id"
+  REPOSITORY_UPLOADED_DIR="$UPLOADED_DIR/$REPOSITORY_ID"
+  [[ ! -e "$REPOSITORY_UPLOADED_DIR" || -d "$REPOSITORY_UPLOADED_DIR" ]] ||
+    fail "Restic repository upload-state path exists but is not a directory."
+  mkdir -p -m 0700 -- "$REPOSITORY_UPLOADED_DIR"
+  chmod 0700 "$REPOSITORY_UPLOADED_DIR"
+}
+
+require_initialized_repository() {
+  local probe_status=0
+
+  probe_repository || probe_status=$?
+  case "$probe_status" in
+    0)
+      return 0
+      ;;
+    10)
+      fail "Configured Restic repository is not initialized; run the explicit init action."
+      ;;
+    12)
+      fail "Configured Restic repository rejected its password."
+      ;;
+    *)
+      fail "Configured Restic repository/backend access failed with exit code $probe_status."
+      ;;
+  esac
+}
+
+initialize_repository() {
+  local probe_status=0
+
+  REPORT_FAILURE_METRICS=0
+  probe_repository || probe_status=$?
+  case "$probe_status" in
+    0)
+      log "Configured Restic repository is already initialized and accessible."
+      log "POSTGRES_BACKUP_REMOTE_RESULT=ALREADY_INITIALIZED"
+      ;;
+    10)
+      run_restic init
+      log "Configured Restic repository initialized explicitly."
+      log "POSTGRES_BACKUP_REMOTE_RESULT=INITIALIZED"
+      ;;
+    12)
+      fail "Configured Restic repository rejected its password; refusing initialization."
+      ;;
+    *)
+      fail "Configured Restic repository/backend access failed with exit code $probe_status; refusing initialization."
+      ;;
+  esac
+}
+
+upload_backups() {
+  local candidate
+  local backup_id
+  local marker
+  local success_epoch
+  local duration_seconds
+
+  require_initialized_repository
+  set_repository_upload_directory
+
+  CANDIDATES_FILE="$(mktemp "$STATE_DIR/.candidates.XXXXXX")"
+  if ! find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 -type d -print0 \
+    | LC_ALL=C sort -z > "$CANDIDATES_FILE"; then
+    fail "Unable to enumerate local PostgreSQL backup directories."
+  fi
+
+  while IFS= read -r -d '' candidate; do
+    if eligible_backup "$candidate"; then
+      backup_id="$(basename -- "$candidate")"
+      if [[ ! -f "$REPOSITORY_UPLOADED_DIR/$backup_id" ]]; then
+        PENDING_COUNT=$((PENDING_COUNT + 1))
+      fi
+    fi
+  done < "$CANDIDATES_FILE"
+
+  write_metrics "$ATTEMPT_EPOCH" "$LAST_SUCCESS_EPOCH" 0 0 0 "$PENDING_COUNT"
+
+  while IFS= read -r -d '' candidate; do
+    eligible_backup "$candidate" || continue
+    backup_id="$(basename -- "$candidate")"
+    marker="$REPOSITORY_UPLOADED_DIR/$backup_id"
+    [[ ! -f "$marker" ]] || continue
+
+    [[ -f "$candidate/SHA256SUMS" ]] || fail "Backup $backup_id has no SHA256SUMS file."
+    if ! (cd "$candidate" && sha256sum --check SHA256SUMS); then
+      fail "Checksum verification failed for backup $backup_id."
+    fi
+
+    log "Uploading completed PostgreSQL logical backup $backup_id."
+    if ! run_restic backup \
+      --host "$SNAPSHOT_HOST" \
+      --group-by host \
+      --tag postgres-logical-backup \
+      --tag "cluster=$CLUSTER_SCOPE" \
+      --tag "backup-id=$backup_id" \
+      --tag "source-member=$SOURCE_MEMBER" \
+      "$candidate"; then
+      fail "Restic backup failed for local backup $backup_id."
+    fi
+
+    MARKER_TMP="$(mktemp "$REPOSITORY_UPLOADED_DIR/.${backup_id}.XXXXXX")"
+    printf 'uploaded_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$MARKER_TMP"
+    chmod 0600 "$MARKER_TMP"
+    mv -f -- "$MARKER_TMP" "$marker"
+    MARKER_TMP=""
+
+    UPLOADED_COUNT=$((UPLOADED_COUNT + 1))
+    PENDING_COUNT=$((PENDING_COUNT - 1))
+    LAST_SUCCESS_EPOCH="$(date +%s)"
+  done < "$CANDIDATES_FILE"
+
+  success_epoch="$(date +%s)"
+  duration_seconds=$((success_epoch - RUN_START_EPOCH))
+  write_metrics \
+    "$ATTEMPT_EPOCH" \
+    "$LAST_SUCCESS_EPOCH" \
+    1 \
+    "$duration_seconds" \
+    "$UPLOADED_COUNT" \
+    "$PENDING_COUNT"
+
+  REPORT_FAILURE_METRICS=0
+  log "PostgreSQL remote upload completed; uploaded $UPLOADED_COUNT backup(s), $PENDING_COUNT pending."
+  log "POSTGRES_BACKUP_REMOTE_RESULT=UPLOADED_COUNT=$UPLOADED_COUNT"
+}
+
+maintain_repository() {
+  REPORT_FAILURE_METRICS=0
+  require_initialized_repository
+
+  run_restic forget \
+    --prune \
+    --host "$SNAPSHOT_HOST" \
+    --tag postgres-logical-backup \
+    --group-by host \
+    --keep-daily "$KEEP_DAILY" \
+    --keep-weekly "$KEEP_WEEKLY" \
+    --keep-monthly "$KEEP_MONTHLY"
+  log "Scoped PostgreSQL Restic retention and prune completed."
+  log "POSTGRES_BACKUP_REMOTE_RESULT=MAINTENANCE_COMPLETE"
+}
+
+trap cleanup_transients EXIT
+trap on_error ERR
+
+case "$MODE" in
+  init | upload | maintenance)
+    ;;
+  *)
+    fail "Usage: $0 {init|upload|maintenance}"
+    ;;
+esac
+
+exec 9> "$LOCK_FILE"
+if ! flock --nonblock 9; then
+  REPORT_FAILURE_METRICS=0
+  trap - ERR
+  log "Another local PostgreSQL remote backup operation is already running; skipping."
+  log "POSTGRES_BACKUP_REMOTE_RESULT=SKIPPED_OVERLAP"
+  exit 0
+fi
+
+if [[ "$MODE" == upload ]]; then
+  ATTEMPT_EPOCH="$(date +%s)"
+  RUN_START_EPOCH="$ATTEMPT_EPOCH"
+  LAST_SUCCESS_EPOCH="$(existing_metric postgres_backup_remote_last_success_timestamp_seconds 0)"
+  REPORT_FAILURE_METRICS=1
+  write_metrics "$ATTEMPT_EPOCH" "$LAST_SUCCESS_EPOCH" 0 0 0 0
+fi
+
+[[ -x "$RESTIC_BIN" ]] || fail "Restic binary is missing or not executable."
+[[ -s "$REPOSITORY_FILE" ]] || fail "Restic repository file is missing or empty."
+[[ -s "$PASSWORD_FILE" ]] || fail "Restic password file is missing or empty."
+
+if [[ -s "$BACKEND_ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$BACKEND_ENV_FILE"
+  set +a
+fi
+export RESTIC_REPOSITORY_FILE="$REPOSITORY_FILE"
+export RESTIC_PASSWORD_FILE="$PASSWORD_FILE"
+
+case "$MODE" in
+  init)
+    initialize_repository
+    ;;
+  upload)
+    upload_backups
+    ;;
+  maintenance)
+    maintain_repository
+    ;;
+esac

--- a/ansible/roles/postgres/templates/postgres-logical-backup-restore-validate.sh.j2
+++ b/ansible/roles/postgres/templates/postgres-logical-backup-restore-validate.sh.j2
@@ -1,0 +1,841 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+readonly BACKUP_ROOT='{{ postgres_backup_root | string | replace("'", "'\"'\"'") }}'
+readonly WORK_ROOT='{{ postgres_backup_restore_validation_work_root | string | replace("'", "'\"'\"'") }}'
+readonly METRICS_FILE='{{ postgres_backup_restore_validation_metrics_file | string | replace("'", "'\"'\"'") }}'
+readonly RESTIC_BIN='{{ postgres_backup_remote_restic_path | string | replace("'", "'\"'\"'") }}'
+readonly REPOSITORY_FILE='{{ postgres_backup_remote_repository_file | string | replace("'", "'\"'\"'") }}'
+readonly PASSWORD_FILE='{{ postgres_backup_remote_password_file | string | replace("'", "'\"'\"'") }}'
+readonly BACKEND_ENV_FILE='{{ postgres_backup_remote_environment_file | string | replace("'", "'\"'\"'") }}'
+readonly SNAPSHOT_HOST='{{ postgres_backup_remote_snapshot_host | string | replace("'", "'\"'\"'") }}'
+readonly CLUSTER_SCOPE='{{ postgres_patroni_scope | string | replace("'", "'\"'\"'") }}'
+readonly POSTGRES_BIN_DIR='{{ postgres_patroni_bin_dir | string | replace("'", "'\"'\"'") }}'
+readonly RETRY_LOCK='{{ postgres_backup_remote_retry_lock | string | replace("'", "'\"'\"'") }}'
+readonly VALIDATION_PORT={{ postgres_backup_restore_validation_port }}
+readonly MAX_SNAPSHOT_AGE_HOURS={{ postgres_backup_restore_validation_max_snapshot_age_hours }}
+readonly MIN_FREE_BYTES={{ postgres_backup_restore_validation_min_free_bytes }}
+readonly VALIDATION_DATABASE="postgres_restore_validation"
+readonly PYTHON_BIN="/usr/bin/python3"
+readonly RUNUSER_BIN='{{ postgres_backup_restore_validation_runuser_path | string | replace("'", "'\"'\"'") }}'
+readonly PROC_ROOT="${POSTGRES_BACKUP_RESTORE_VALIDATION_PROC_ROOT:-/proc}"
+readonly LOCK_FILE="$WORK_ROOT/validation.lock"
+readonly INITDB="$POSTGRES_BIN_DIR/initdb"
+readonly PG_CTL="$POSTGRES_BIN_DIR/pg_ctl"
+readonly CREATEDB="$POSTGRES_BIN_DIR/createdb"
+readonly DROPDB="$POSTGRES_BIN_DIR/dropdb"
+readonly PG_RESTORE="$POSTGRES_BIN_DIR/pg_restore"
+readonly PSQL="$POSTGRES_BIN_DIR/psql"
+
+RESTIC_OPTIONS=(
+{% for postgres_backup_remote_option in postgres_backup_remote_options %}
+  '{{ postgres_backup_remote_option | string | replace("'", "'\"'\"'") }}'
+{% endfor %}
+)
+
+export PATH="$POSTGRES_BIN_DIR:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PGPASSFILE=/dev/null
+unset PGHOST PGPORT PGDATABASE PGUSER PGSERVICE PGSERVICEFILE PGPASSWORD
+
+ATTEMPT_EPOCH=0
+RUN_START_EPOCH=0
+REPORT_FAILURE_METRICS=0
+LAST_SUCCESS_EPOCH=0
+LAST_SUCCESS_DATABASE_COUNT=0
+LAST_SUCCESS_SNAPSHOT_EPOCH=0
+RUN_DIR=""
+CLUSTER_DIR=""
+PGDATA=""
+SOCKET_DIR=""
+CLUSTER_START_ATTEMPTED=0
+POSTGRES_UID=""
+STALE_POSTMASTER_PID=""
+STALE_POSTMASTER_DATA_DIR=""
+
+log() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  return 1
+}
+
+existing_metric() {
+  local metric_name="$1"
+  local default_value="$2"
+  local metric_value=""
+
+  if [[ -r "$METRICS_FILE" ]]; then
+    metric_value="$(awk -v name="$metric_name" '$1 == name { print $2; exit }' "$METRICS_FILE")"
+  fi
+
+  if [[ "$metric_value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$metric_value"
+  else
+    printf '%s\n' "$default_value"
+  fi
+}
+
+write_metrics() {
+  local attempt_epoch="$1"
+  local success_epoch="$2"
+  local run_success="$3"
+  local duration_seconds="$4"
+  local database_count="$5"
+  local snapshot_epoch="$6"
+  local metrics_tmp
+
+  metrics_tmp="$(mktemp "${METRICS_FILE}.tmp.XXXXXX")"
+  {
+    printf '# HELP postgres_backup_restore_validation_last_attempt_timestamp_seconds Unix timestamp of the last restore-validation attempt.\n'
+    printf '# TYPE postgres_backup_restore_validation_last_attempt_timestamp_seconds gauge\n'
+    printf 'postgres_backup_restore_validation_last_attempt_timestamp_seconds %s\n' "$attempt_epoch"
+    printf '# HELP postgres_backup_restore_validation_last_success_timestamp_seconds Unix timestamp of the last successful full restore validation.\n'
+    printf '# TYPE postgres_backup_restore_validation_last_success_timestamp_seconds gauge\n'
+    printf 'postgres_backup_restore_validation_last_success_timestamp_seconds %s\n' "$success_epoch"
+    printf '# HELP postgres_backup_restore_validation_last_run_success Whether the last restore-validation attempt succeeded.\n'
+    printf '# TYPE postgres_backup_restore_validation_last_run_success gauge\n'
+    printf 'postgres_backup_restore_validation_last_run_success %s\n' "$run_success"
+    printf '# HELP postgres_backup_restore_validation_last_duration_seconds Duration of the last restore-validation attempt.\n'
+    printf '# TYPE postgres_backup_restore_validation_last_duration_seconds gauge\n'
+    printf 'postgres_backup_restore_validation_last_duration_seconds %s\n' "$duration_seconds"
+    printf '# HELP postgres_backup_restore_validation_last_database_count Databases restored by the latest successful validation.\n'
+    printf '# TYPE postgres_backup_restore_validation_last_database_count gauge\n'
+    printf 'postgres_backup_restore_validation_last_database_count %s\n' "$database_count"
+    printf '# HELP postgres_backup_restore_validation_last_snapshot_timestamp_seconds Restic snapshot timestamp used by the latest successful validation.\n'
+    printf '# TYPE postgres_backup_restore_validation_last_snapshot_timestamp_seconds gauge\n'
+    printf 'postgres_backup_restore_validation_last_snapshot_timestamp_seconds %s\n' "$snapshot_epoch"
+  } > "$metrics_tmp"
+  chmod 0644 "$metrics_tmp"
+  mv -f -- "$metrics_tmp" "$METRICS_FILE"
+}
+
+run_restic() {
+  "$RESTIC_BIN" "${RESTIC_OPTIONS[@]}" --retry-lock "$RETRY_LOCK" "$@"
+}
+
+valid_run_directory() {
+  local candidate="$1"
+  local candidate_name
+
+  candidate_name="$(basename -- "$candidate")"
+  [[ "$(dirname -- "$candidate")" == "$WORK_ROOT" ]] || return 1
+  [[ "$candidate" == "$WORK_ROOT/$candidate_name" ]] || return 1
+  [[ "$candidate_name" =~ ^run-[0-9]{8}T[0-9]{6}Z-[0-9]+-[A-Za-z0-9]{6}$ ]]
+}
+
+cleanup_current_run() {
+  local cleanup_status=0
+  local cluster_stopped=1
+
+  if (( CLUSTER_START_ATTEMPTED == 1 )) && [[ -n "$PGDATA" && -f "$PGDATA/postmaster.pid" ]]; then
+    if ! "$RUNUSER_BIN" -u postgres -- \
+      "$PG_CTL" -D "$PGDATA" -m fast -w -t 60 stop; then
+      log "ERROR: Failed to stop the temporary PostgreSQL validation cluster." >&2
+      cleanup_status=1
+      cluster_stopped=0
+    fi
+  fi
+  if (( cluster_stopped == 1 )); then
+    CLUSTER_START_ATTEMPTED=0
+  fi
+
+  if [[ -n "$RUN_DIR" ]]; then
+    if ! valid_run_directory "$RUN_DIR"; then
+      log "ERROR: Refusing to remove an unbounded restore-validation path." >&2
+      cleanup_status=1
+    elif (( cluster_stopped == 1 )); then
+      if ! rm -rf -- "$RUN_DIR"; then
+        log "ERROR: Failed to remove restore-validation workspace $RUN_DIR." >&2
+        cleanup_status=1
+      else
+        RUN_DIR=""
+      fi
+    fi
+  fi
+
+  return "$cleanup_status"
+}
+
+on_exit() {
+  local exit_status="$?"
+  local cleanup_status=0
+  local failure_epoch
+  local duration_seconds
+
+  trap - EXIT INT TERM
+  set +e
+  cleanup_current_run || cleanup_status=$?
+  if (( exit_status == 0 && cleanup_status != 0 )); then
+    exit_status="$cleanup_status"
+  fi
+
+  if (( exit_status != 0 && REPORT_FAILURE_METRICS == 1 )); then
+    failure_epoch="$(date +%s)"
+    duration_seconds=$((failure_epoch - RUN_START_EPOCH))
+    write_metrics \
+      "$ATTEMPT_EPOCH" \
+      "$LAST_SUCCESS_EPOCH" \
+      0 \
+      "$duration_seconds" \
+      "$LAST_SUCCESS_DATABASE_COUNT" \
+      "$LAST_SUCCESS_SNAPSHOT_EPOCH" || exit_status=1
+    log "PostgreSQL backup restore validation failed." >&2
+  fi
+
+  exit "$exit_status"
+}
+
+read_postmaster_pid() {
+  local pid_file="$1"
+  local -a postmaster_lines=()
+
+  STALE_POSTMASTER_PID=""
+  STALE_POSTMASTER_DATA_DIR=""
+  if ! mapfile -t -n 2 postmaster_lines < "$pid_file"; then
+    return 1
+  fi
+  (( ${{ '{' }}#postmaster_lines[@]} >= 1 )) || return 1
+  [[ "${postmaster_lines[0]}" =~ ^[1-9][0-9]*$ ]] || return 1
+  STALE_POSTMASTER_PID="${postmaster_lines[0]}"
+  if (( ${{ '{' }}#postmaster_lines[@]} >= 2 )); then
+    STALE_POSTMASTER_DATA_DIR="${postmaster_lines[1]}"
+  fi
+}
+
+process_is_alive() {
+  local pid="$1"
+  local process_dir="$PROC_ROOT/$pid"
+
+  [[ -d "$process_dir" && ! -L "$process_dir" ]]
+}
+
+process_belongs_to_validator_pgdata() {
+  local pid="$1"
+  local expected_pgdata="$2"
+  local recorded_pgdata="$3"
+  local process_dir="$PROC_ROOT/$pid"
+  local process_uid=""
+  local process_executable=""
+  local status_key=""
+  local status_value=""
+  local status_remainder=""
+  local argument_index
+  local data_argument_count=0
+  local -a process_arguments=()
+
+  process_is_alive "$pid" || return 1
+  [[ "$recorded_pgdata" == "$expected_pgdata" ]] || return 2
+  if [[ ! -f "$process_dir/status" || -L "$process_dir/status" ]]; then
+    process_is_alive "$pid" || return 1
+    return 2
+  fi
+  while IFS=$' \t' read -r status_key status_value status_remainder; do
+    if [[ "$status_key" == "Uid:" ]]; then
+      process_uid="$status_value"
+      break
+    fi
+  done < "$process_dir/status"
+  [[ "$process_uid" == "$POSTGRES_UID" ]] || {
+    process_is_alive "$pid" || return 1
+    return 2
+  }
+
+  process_executable="$(readlink -- "$process_dir/exe")" || {
+    process_is_alive "$pid" || return 1
+    return 2
+  }
+  [[ "$(basename -- "$process_executable")" == "postgres" ]] || {
+    process_is_alive "$pid" || return 1
+    return 2
+  }
+  if [[ ! -f "$process_dir/cmdline" || -L "$process_dir/cmdline" ]]; then
+    process_is_alive "$pid" || return 1
+    return 2
+  fi
+  if ! mapfile -d '' -t process_arguments < "$process_dir/cmdline"; then
+    process_is_alive "$pid" || return 1
+    return 2
+  fi
+  for ((argument_index = 0; argument_index + 1 < ${{ '{' }}#process_arguments[@]}; argument_index++)); do
+    if [[ "${process_arguments[$argument_index]}" == "-D" ]]; then
+      data_argument_count=$((data_argument_count + 1))
+      [[ "${process_arguments[$((argument_index + 1))]}" == "$expected_pgdata" ]] || return 2
+    fi
+  done
+  (( data_argument_count == 1 )) || return 2
+  process_is_alive "$pid" || return 1
+}
+
+remove_bounded_stale_workspace() {
+  local candidate="$1"
+
+  if ! valid_run_directory "$candidate"; then
+    fail "Refusing to remove an unbounded stale restore-validation path."
+    return 1
+  fi
+  log "Removing stale restore-validation workspace $candidate"
+  if ! rm -rf -- "$candidate"; then
+    fail "Unable to remove stale restore-validation workspace $candidate."
+    return 1
+  fi
+}
+
+cleanup_stale_workspace() {
+  local candidate="$1"
+  local stale_cluster_dir="$candidate/cluster"
+  local stale_pgdata="$stale_cluster_dir/data"
+  local pid_file="$stale_pgdata/postmaster.pid"
+  local identity_status=0
+
+  if [[ ! -e "$pid_file" && ! -L "$pid_file" ]]; then
+    remove_bounded_stale_workspace "$candidate"
+    return
+  fi
+  if [[ ! -d "$stale_cluster_dir" || -L "$stale_cluster_dir" || \
+    ! -d "$stale_pgdata" || -L "$stale_pgdata" || \
+    ! -f "$pid_file" || -L "$pid_file" ]]; then
+    fail "Stale restore-validation workspace has unsafe PostgreSQL state."
+    return 1
+  fi
+  if ! read_postmaster_pid "$pid_file"; then
+    fail "Stale restore-validation workspace has a malformed postmaster.pid; refusing cleanup."
+    return 1
+  fi
+  if ! process_is_alive "$STALE_POSTMASTER_PID"; then
+    log "Stale PostgreSQL PID $STALE_POSTMASTER_PID is not alive; no stop is required."
+    remove_bounded_stale_workspace "$candidate"
+    return
+  fi
+
+  process_belongs_to_validator_pgdata \
+    "$STALE_POSTMASTER_PID" \
+    "$stale_pgdata" \
+    "$STALE_POSTMASTER_DATA_DIR" || identity_status=$?
+  case "$identity_status" in
+    0)
+      ;;
+    1)
+      log "Stale PostgreSQL PID $STALE_POSTMASTER_PID exited before cleanup; no stop is required."
+      remove_bounded_stale_workspace "$candidate"
+      return
+      ;;
+    *)
+      fail "Refusing to stop live PID $STALE_POSTMASTER_PID: process identity does not match validation PGDATA $stale_pgdata."
+      return 1
+      ;;
+  esac
+
+  identity_status=0
+  process_belongs_to_validator_pgdata \
+    "$STALE_POSTMASTER_PID" \
+    "$stale_pgdata" \
+    "$STALE_POSTMASTER_DATA_DIR" || identity_status=$?
+  case "$identity_status" in
+    0)
+      ;;
+    1)
+      log "Stale PostgreSQL PID $STALE_POSTMASTER_PID exited before stop; no stop is required."
+      remove_bounded_stale_workspace "$candidate"
+      return
+      ;;
+    *)
+      fail "Refusing to stop live PID $STALE_POSTMASTER_PID after revalidation: process identity does not match validation PGDATA $stale_pgdata."
+      return 1
+      ;;
+  esac
+
+  if ! "$RUNUSER_BIN" -u postgres -- \
+    "$PG_CTL" -D "$stale_pgdata" -m fast -w -t 60 stop; then
+    if ! process_is_alive "$STALE_POSTMASTER_PID"; then
+      log "Stale PostgreSQL PID $STALE_POSTMASTER_PID exited during cleanup; no further stop is required."
+      remove_bounded_stale_workspace "$candidate"
+      return
+    fi
+    fail "Unable to stop the proven stale PostgreSQL validation cluster at $stale_pgdata."
+    return 1
+  fi
+  remove_bounded_stale_workspace "$candidate"
+}
+
+remove_stale_run_directories() {
+  local candidates_file
+  local candidate
+
+  candidates_file="$(mktemp "$WORK_ROOT/.stale-runs.XXXXXX")"
+  if ! find "$WORK_ROOT" -mindepth 1 -maxdepth 1 -type d -name 'run-*' -print0 \
+    > "$candidates_file"; then
+    rm -f -- "$candidates_file"
+    fail "Unable to enumerate stale restore-validation workspaces."
+    return 1
+  fi
+
+  while IFS= read -r -d '' candidate; do
+    if valid_run_directory "$candidate"; then
+      if ! cleanup_stale_workspace "$candidate"; then
+        rm -f -- "$candidates_file"
+        return 1
+      fi
+    fi
+  done < "$candidates_file"
+  rm -f -- "$candidates_file"
+}
+
+require_repository() {
+  local probe_status=0
+
+  run_restic cat config > /dev/null || probe_status=$?
+  case "$probe_status" in
+    0)
+      return 0
+      ;;
+    10)
+      fail "Configured Restic repository is not initialized."
+      ;;
+    12)
+      fail "Configured Restic repository rejected its password."
+      ;;
+    *)
+      fail "Configured Restic repository/backend access failed with exit code $probe_status."
+      ;;
+  esac
+}
+
+select_snapshot() {
+  local snapshots_file="$1"
+  local selected_file="$2"
+
+  "$PYTHON_BIN" - \
+    "$snapshots_file" \
+    "$SNAPSHOT_HOST" \
+    "$CLUSTER_SCOPE" \
+    "$BACKUP_ROOT" > "$selected_file" <<'PYTHON'
+import datetime
+import json
+import pathlib
+import re
+import sys
+
+
+def reject(message):
+    print(f"Snapshot metadata validation failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+snapshot_file = pathlib.Path(sys.argv[1])
+expected_host = sys.argv[2]
+expected_cluster_tag = f"cluster={sys.argv[3]}"
+backup_root = sys.argv[4]
+try:
+    snapshots = json.loads(snapshot_file.read_text())
+except (OSError, UnicodeError, json.JSONDecodeError) as error:
+    reject(f"invalid snapshots JSON ({error})")
+if not isinstance(snapshots, list):
+    reject("snapshots JSON is not an array")
+
+candidates = []
+for snapshot in snapshots:
+    if not isinstance(snapshot, dict):
+        continue
+    if snapshot.get("hostname") != expected_host:
+        continue
+    tags = snapshot.get("tags")
+    if not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags):
+        reject("matching-host snapshot has malformed tags")
+    if "postgres-logical-backup" not in tags or expected_cluster_tag not in tags:
+        continue
+    if tags.count("postgres-logical-backup") != 1 or tags.count(expected_cluster_tag) != 1:
+        reject("logical-backup snapshot has duplicate stream tags")
+
+    snapshot_id = snapshot.get("id")
+    if not isinstance(snapshot_id, str) or not re.fullmatch(r"[0-9a-f]{64}", snapshot_id):
+        reject("logical-backup snapshot has an unsafe ID")
+    backup_tags = [tag.removeprefix("backup-id=") for tag in tags if tag.startswith("backup-id=")]
+    if len(backup_tags) != 1:
+        reject("logical-backup snapshot must have exactly one backup-id tag")
+    backup_id = backup_tags[0]
+    if not re.fullmatch(r"[0-9]{8}T[0-9]{6}Z", backup_id):
+        reject("logical-backup snapshot has an invalid backup ID")
+
+    expected_path = f"{backup_root}/{backup_id}"
+    paths = snapshot.get("paths")
+    if paths != [expected_path]:
+        reject("logical-backup snapshot has an unexpected source path")
+
+    snapshot_time = snapshot.get("time")
+    if not isinstance(snapshot_time, str):
+        reject("logical-backup snapshot has no timestamp")
+    try:
+        parsed_time = datetime.datetime.fromisoformat(snapshot_time.replace("Z", "+00:00"))
+    except ValueError:
+        reject("logical-backup snapshot timestamp is invalid")
+    if parsed_time.tzinfo is None:
+        reject("logical-backup snapshot timestamp has no timezone")
+    candidates.append((parsed_time, snapshot_id, backup_id, expected_path))
+
+if not candidates:
+    reject("no matching PostgreSQL logical-backup snapshots found")
+
+snapshot_time, snapshot_id, backup_id, backup_path = max(candidates)
+print(snapshot_id)
+print(backup_id)
+print(int(snapshot_time.timestamp()))
+print(backup_path)
+PYTHON
+}
+
+validate_restored_artifact() {
+  local artifact_dir="$1"
+  local database_list_file="$2"
+
+  "$PYTHON_BIN" - "$artifact_dir" > "$database_list_file" <<'PYTHON'
+import pathlib
+import re
+import stat
+import sys
+
+
+def reject(message):
+    print(f"Restored artifact validation failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+artifact = pathlib.Path(sys.argv[1])
+
+
+def require_regular(relative_path, nonempty=False):
+    path = artifact / relative_path
+    try:
+        mode = path.lstat().st_mode
+    except OSError:
+        reject(f"missing {relative_path}")
+    if not stat.S_ISREG(mode):
+        reject(f"{relative_path} is not a regular file")
+    if nonempty and path.stat().st_size == 0:
+        reject(f"{relative_path} is empty")
+    return path
+
+
+require_regular("SUCCESS")
+checksum_path = require_regular("SHA256SUMS", nonempty=True)
+manifest_path = require_regular("manifest.txt", nonempty=True)
+require_regular("globals.sql", nonempty=True)
+databases_dir = artifact / "databases"
+try:
+    databases_mode = databases_dir.lstat().st_mode
+except OSError:
+    reject("missing databases directory")
+if not stat.S_ISDIR(databases_mode):
+    reject("databases is not a real directory")
+
+try:
+    manifest_lines = manifest_path.read_text().splitlines()
+except (OSError, UnicodeError) as error:
+    reject(f"manifest cannot be read ({error})")
+count_values = [line.removeprefix("database_count=") for line in manifest_lines if line.startswith("database_count=")]
+if len(count_values) != 1 or not re.fullmatch(r"[1-9][0-9]*", count_values[0]):
+    reject("manifest database_count is missing or invalid")
+declared_count = int(count_values[0])
+
+databases = []
+dump_paths = []
+for line in manifest_lines:
+    if not line.startswith("database="):
+        continue
+    match = re.fullmatch(r"database=([A-Za-z0-9_.-]+)\tdump=databases/([A-Za-z0-9_.-]+)\.dump", line)
+    if match is None or match.group(1) != match.group(2):
+        reject("manifest contains an unsafe database mapping")
+    database = match.group(1)
+    relative_dump = f"databases/{database}.dump"
+    if database in databases or relative_dump in dump_paths:
+        reject("manifest contains a duplicate database")
+    require_regular(relative_dump, nonempty=True)
+    databases.append(database)
+    dump_paths.append(relative_dump)
+
+if len(databases) != declared_count:
+    reject("manifest database count does not match its database entries")
+
+actual_dumps = set()
+for dump in artifact.rglob("*.dump"):
+    relative_dump = dump.relative_to(artifact).as_posix()
+    if not stat.S_ISREG(dump.lstat().st_mode):
+        reject(f"{relative_dump} is not a regular file")
+    actual_dumps.add(relative_dump)
+if actual_dumps != set(dump_paths):
+    reject("restored dump files do not exactly match the manifest")
+
+expected_checksums = {"globals.sql", "manifest.txt", *dump_paths}
+checksum_entries = []
+try:
+    checksum_lines = checksum_path.read_text().splitlines()
+except (OSError, UnicodeError) as error:
+    reject(f"SHA256SUMS cannot be read ({error})")
+for line in checksum_lines:
+    match = re.fullmatch(r"([0-9a-f]{64})(?:  | \*)(.+)", line)
+    if match is None:
+        reject("SHA256SUMS contains a malformed entry")
+    relative_path = match.group(2)
+    if relative_path.startswith("/") or ".." in pathlib.PurePosixPath(relative_path).parts:
+        reject("SHA256SUMS contains an unsafe path")
+    if relative_path in checksum_entries:
+        reject("SHA256SUMS contains a duplicate path")
+    checksum_entries.append(relative_path)
+if set(checksum_entries) != expected_checksums:
+    reject("SHA256SUMS does not exactly cover the manifest, globals, and dumps")
+
+for database in databases:
+    print(database)
+PYTHON
+}
+
+psql_value() {
+  local database="$1"
+  local query="$2"
+
+  "$PSQL" \
+    --host="$SOCKET_DIR" \
+    --port="$VALIDATION_PORT" \
+    --username=postgres \
+    --dbname="$database" \
+    --no-psqlrc \
+    --tuples-only \
+    --no-align \
+    --set=ON_ERROR_STOP=1 \
+    --command="$query"
+}
+
+trap on_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+[[ "$WORK_ROOT" == /* && "$WORK_ROOT" != "/" && "$WORK_ROOT" != */ ]] ||
+  fail "Restore-validation work root must be a specific absolute path."
+[[ "$WORK_ROOT" != *"//"* && "$WORK_ROOT/" != *"/../"* && "$WORK_ROOT/" != *"/./"* ]] ||
+  fail "Restore-validation work root contains unsafe path components."
+[[ "$BACKUP_ROOT" == /* && "$BACKUP_ROOT" != "/" && "$BACKUP_ROOT" != */ ]] ||
+  fail "PostgreSQL backup root must be a specific absolute path."
+[[ "$BACKUP_ROOT" != *"//"* && "$BACKUP_ROOT/" != *"/../"* && "$BACKUP_ROOT/" != *"/./"* ]] ||
+  fail "PostgreSQL backup root contains unsafe path components."
+[[ "$WORK_ROOT/" != "$BACKUP_ROOT/"* && "$BACKUP_ROOT/" != "$WORK_ROOT/"* ]] ||
+  fail "Restore-validation work root and PostgreSQL backup root must not overlap."
+[[ "$PROC_ROOT" == /* && "$PROC_ROOT" != "/" && "$PROC_ROOT" != */ ]] ||
+  fail "Process inspection root must be a specific absolute path."
+[[ "$PROC_ROOT" =~ ^/[A-Za-z0-9_./-]+$ ]] ||
+  fail "Process inspection root contains unsupported characters."
+[[ "$PROC_ROOT" != *"//"* && "$PROC_ROOT/" != *"/../"* && "$PROC_ROOT/" != *"/./"* ]] ||
+  fail "Process inspection root contains unsafe path components."
+[[ -d "$PROC_ROOT" && ! -L "$PROC_ROOT" ]] ||
+  fail "Process inspection root is missing or unsafe."
+[[ "$VALIDATION_PORT" =~ ^[0-9]+$ ]] &&
+  (( VALIDATION_PORT >= 1 && VALIDATION_PORT <= 65535 )) ||
+  fail "Restore-validation port must be between 1 and 65535."
+[[ "$MAX_SNAPSHOT_AGE_HOURS" =~ ^[0-9]+$ ]] && (( MAX_SNAPSHOT_AGE_HOURS >= 1 )) ||
+  fail "Maximum snapshot age must be a positive integer."
+[[ "$MIN_FREE_BYTES" =~ ^[0-9]+$ ]] ||
+  fail "Minimum free bytes must be a non-negative integer."
+[[ -d "$WORK_ROOT" ]] || fail "Restore-validation work root is missing."
+
+exec 9> "$LOCK_FILE"
+if ! flock --nonblock 9; then
+  trap - EXIT INT TERM
+  log "Another PostgreSQL backup restore validation is already running; skipping."
+  log "POSTGRES_BACKUP_RESTORE_VALIDATION_RESULT=SKIPPED_OVERLAP"
+  exit 0
+fi
+
+ATTEMPT_EPOCH="$(date +%s)"
+RUN_START_EPOCH="$ATTEMPT_EPOCH"
+LAST_SUCCESS_EPOCH="$(
+  existing_metric postgres_backup_restore_validation_last_success_timestamp_seconds 0
+)"
+LAST_SUCCESS_DATABASE_COUNT="$(
+  existing_metric postgres_backup_restore_validation_last_database_count 0
+)"
+LAST_SUCCESS_SNAPSHOT_EPOCH="$(
+  existing_metric postgres_backup_restore_validation_last_snapshot_timestamp_seconds 0
+)"
+REPORT_FAILURE_METRICS=1
+write_metrics \
+  "$ATTEMPT_EPOCH" \
+  "$LAST_SUCCESS_EPOCH" \
+  0 \
+  0 \
+  "$LAST_SUCCESS_DATABASE_COUNT" \
+  "$LAST_SUCCESS_SNAPSHOT_EPOCH"
+
+for required_binary in \
+  "$RESTIC_BIN" \
+  "$PYTHON_BIN" \
+  "$RUNUSER_BIN" \
+  "$INITDB" \
+  "$PG_CTL" \
+  "$CREATEDB" \
+  "$DROPDB" \
+  "$PG_RESTORE" \
+  "$PSQL"; do
+  [[ -x "$required_binary" ]] || fail "Required executable is missing: $required_binary"
+done
+POSTGRES_UID="$(id -u postgres)" || fail "Unable to resolve the PostgreSQL OS user."
+[[ "$POSTGRES_UID" =~ ^[1-9][0-9]*$ ]] ||
+  fail "PostgreSQL OS user must resolve to a non-root numeric UID."
+[[ -s "$REPOSITORY_FILE" ]] || fail "Restic repository file is missing or empty."
+[[ -s "$PASSWORD_FILE" ]] || fail "Restic password file is missing or empty."
+
+if [[ -s "$BACKEND_ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$BACKEND_ENV_FILE"
+  set +a
+fi
+export RESTIC_REPOSITORY_FILE="$REPOSITORY_FILE"
+export RESTIC_PASSWORD_FILE="$PASSWORD_FILE"
+
+remove_stale_run_directories
+require_repository
+
+run_timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="$(mktemp -d "$WORK_ROOT/run-$run_timestamp-$$-XXXXXX")"
+chown root:postgres "$RUN_DIR"
+chmod 0710 "$RUN_DIR"
+
+snapshots_file="$RUN_DIR/snapshots.json"
+selected_file="$RUN_DIR/selected-snapshot"
+run_restic snapshots \
+  --json \
+  --host "$SNAPSHOT_HOST" \
+  --tag "postgres-logical-backup,cluster=$CLUSTER_SCOPE" > "$snapshots_file"
+select_snapshot "$snapshots_file" "$selected_file"
+mapfile -t SELECTED_SNAPSHOT < "$selected_file"
+(( ${{ '{' }}#SELECTED_SNAPSHOT[@]} == 4 )) ||
+  fail "Snapshot selection did not return the required metadata."
+snapshot_id="${SELECTED_SNAPSHOT[0]}"
+backup_id="${SELECTED_SNAPSHOT[1]}"
+snapshot_epoch="${SELECTED_SNAPSHOT[2]}"
+backup_path="${SELECTED_SNAPSHOT[3]}"
+[[ "$snapshot_id" =~ ^[0-9a-f]{64}$ ]] || fail "Selected snapshot ID is unsafe."
+[[ "$backup_id" =~ ^[0-9]{8}T[0-9]{6}Z$ ]] || fail "Selected backup ID is unsafe."
+[[ "$snapshot_epoch" =~ ^[0-9]+$ ]] || fail "Selected snapshot timestamp is invalid."
+[[ "$backup_path" == "$BACKUP_ROOT/$backup_id" ]] ||
+  fail "Selected snapshot path is outside the expected backup root."
+
+maximum_age_seconds=$((MAX_SNAPSHOT_AGE_HOURS * 3600))
+snapshot_age_seconds=$((ATTEMPT_EPOCH - snapshot_epoch))
+(( snapshot_age_seconds >= -300 )) ||
+  fail "Selected Restic snapshot timestamp is unexpectedly in the future."
+(( snapshot_age_seconds <= maximum_age_seconds )) ||
+  fail "Newest valid PostgreSQL Restic snapshot is older than $MAX_SNAPSHOT_AGE_HOURS hours."
+
+available_bytes="$(df --output=avail -B1 "$WORK_ROOT" | awk 'NR == 2 { print $1 }')"
+[[ "$available_bytes" =~ ^[0-9]+$ ]] ||
+  fail "Unable to determine free space for restore validation."
+(( available_bytes >= MIN_FREE_BYTES )) ||
+  fail "Restore-validation filesystem is below the configured free-space floor."
+
+artifact_dir="$RUN_DIR/artifact"
+mkdir -m 0700 -- "$artifact_dir"
+log "Restoring PostgreSQL logical backup $backup_id from exact Restic snapshot $snapshot_id."
+run_restic restore "$snapshot_id:$backup_path" --target "$artifact_dir"
+
+database_list_file="$RUN_DIR/databases"
+validate_restored_artifact "$artifact_dir" "$database_list_file"
+(
+  cd "$artifact_dir"
+  sha256sum --check --strict SHA256SUMS
+)
+mapfile -t DATABASES < "$database_list_file"
+(( ${{ '{' }}#DATABASES[@]} > 0 )) || fail "Validated manifest contains no databases."
+
+CLUSTER_DIR="$RUN_DIR/cluster"
+PGDATA="$CLUSTER_DIR/data"
+SOCKET_DIR="$CLUSTER_DIR/socket"
+install -d -o postgres -g postgres -m 0700 "$CLUSTER_DIR" "$PGDATA" "$SOCKET_DIR"
+
+"$RUNUSER_BIN" -u postgres -- \
+  "$INITDB" \
+  -D "$PGDATA" \
+  --username=postgres \
+  --auth-local=trust \
+  --auth-host=reject \
+  --no-instructions
+{
+  printf "\nlisten_addresses = ''\n"
+  printf "unix_socket_directories = '%s'\n" "$SOCKET_DIR"
+  printf "unix_socket_permissions = 0700\n"
+  printf "port = %s\n" "$VALIDATION_PORT"
+} >> "$PGDATA/postgresql.conf"
+chown postgres:postgres "$PGDATA/postgresql.conf"
+
+CLUSTER_START_ATTEMPTED=1
+"$RUNUSER_BIN" -u postgres -- \
+  "$PG_CTL" \
+  -D "$PGDATA" \
+  -l "$CLUSTER_DIR/postgresql.log" \
+  -w \
+  -t 60 \
+  start
+
+actual_data_directory="$(psql_value postgres 'SHOW data_directory;')"
+actual_listen_addresses="$(psql_value postgres 'SHOW listen_addresses;')"
+actual_socket_directory="$(psql_value postgres 'SHOW unix_socket_directories;')"
+actual_port="$(psql_value postgres 'SHOW port;')"
+[[ "$actual_data_directory" == "$PGDATA" ]] ||
+  fail "Temporary PostgreSQL safety check found an unexpected data directory."
+[[ -z "$actual_listen_addresses" ]] ||
+  fail "Temporary PostgreSQL safety check found TCP listening enabled."
+[[ "$actual_socket_directory" == "$SOCKET_DIR" ]] ||
+  fail "Temporary PostgreSQL safety check found an unexpected socket directory."
+[[ "$actual_port" == "$VALIDATION_PORT" ]] ||
+  fail "Temporary PostgreSQL safety check found an unexpected port."
+
+validated_database_count=0
+for source_database in "${DATABASES[@]}"; do
+  [[ "$source_database" =~ ^[A-Za-z0-9_.-]+$ ]] ||
+    fail "Manifest database name is unsafe."
+  dump_path="$artifact_dir/databases/$source_database.dump"
+  log "Validating restore of source database $source_database."
+  "$CREATEDB" \
+    --host="$SOCKET_DIR" \
+    --port="$VALIDATION_PORT" \
+    --username=postgres \
+    --template=template0 \
+    "$VALIDATION_DATABASE"
+  "$PG_RESTORE" \
+    --host="$SOCKET_DIR" \
+    --port="$VALIDATION_PORT" \
+    --username=postgres \
+    --dbname="$VALIDATION_DATABASE" \
+    --exit-on-error \
+    --no-owner \
+    --no-acl \
+    --no-tablespaces \
+    "$dump_path"
+  psql_value \
+    "$VALIDATION_DATABASE" \
+    'SELECT 1; SELECT count(*) FROM pg_catalog.pg_class WHERE relkind IN ('"'"'r'"'"', '"'"'p'"'"', '"'"'v'"'"', '"'"'m'"'"');' \
+    > /dev/null
+  "$DROPDB" \
+    --host="$SOCKET_DIR" \
+    --port="$VALIDATION_PORT" \
+    --username=postgres \
+    "$VALIDATION_DATABASE"
+  validated_database_count=$((validated_database_count + 1))
+done
+(( validated_database_count == ${{ '{' }}#DATABASES[@]} )) ||
+  fail "Not every manifest database was restored."
+
+cleanup_current_run
+success_epoch="$(date +%s)"
+duration_seconds=$((success_epoch - RUN_START_EPOCH))
+write_metrics \
+  "$ATTEMPT_EPOCH" \
+  "$success_epoch" \
+  1 \
+  "$duration_seconds" \
+  "$validated_database_count" \
+  "$snapshot_epoch"
+REPORT_FAILURE_METRICS=0
+log "PostgreSQL backup restore validation completed for $validated_database_count database(s)."
+log "POSTGRES_BACKUP_RESTORE_VALIDATION_RESULT=VALIDATED"

--- a/ansible/roles/postgres/templates/postgres-logical-backup-restore-validate.sh.j2
+++ b/ansible/roles/postgres/templates/postgres-logical-backup-restore-validate.sh.j2
@@ -16,6 +16,8 @@ readonly RETRY_LOCK='{{ postgres_backup_remote_retry_lock | string | replace("'"
 readonly VALIDATION_PORT={{ postgres_backup_restore_validation_port }}
 readonly MAX_SNAPSHOT_AGE_HOURS={{ postgres_backup_restore_validation_max_snapshot_age_hours }}
 readonly MIN_FREE_BYTES={{ postgres_backup_restore_validation_min_free_bytes }}
+readonly VALIDATION_ENCODING='{{ postgres_backup_restore_validation_encoding | string | replace("'", "'\"'\"'") }}'
+readonly VALIDATION_LOCALE='{{ postgres_backup_restore_validation_locale | string | replace("'", "'\"'\"'") }}'
 readonly VALIDATION_DATABASE="postgres_restore_validation"
 readonly PYTHON_BIN="/usr/bin/python3"
 readonly RUNUSER_BIN='{{ postgres_backup_restore_validation_runuser_path | string | replace("'", "'\"'\"'") }}'
@@ -221,7 +223,6 @@ process_belongs_to_validator_pgdata() {
   local process_executable=""
   local status_key=""
   local status_value=""
-  local status_remainder=""
   local argument_index
   local data_argument_count=0
   local -a process_arguments=()
@@ -232,7 +233,7 @@ process_belongs_to_validator_pgdata() {
     process_is_alive "$pid" || return 1
     return 2
   fi
-  while IFS=$' \t' read -r status_key status_value status_remainder; do
+  while IFS=$' \t' read -r status_key status_value _; do
     if [[ "$status_key" == "Uid:" ]]; then
       process_uid="$status_value"
       break
@@ -363,6 +364,7 @@ cleanup_stale_workspace() {
 remove_stale_run_directories() {
   local candidates_file
   local candidate
+  local cleanup_status=0
 
   candidates_file="$(mktemp "$WORK_ROOT/.stale-runs.XXXXXX")"
   if ! find "$WORK_ROOT" -mindepth 1 -maxdepth 1 -type d -name 'run-*' -print0 \
@@ -375,12 +377,13 @@ remove_stale_run_directories() {
   while IFS= read -r -d '' candidate; do
     if valid_run_directory "$candidate"; then
       if ! cleanup_stale_workspace "$candidate"; then
-        rm -f -- "$candidates_file"
-        return 1
+        cleanup_status=1
+        break
       fi
     fi
   done < "$candidates_file"
   rm -f -- "$candidates_file"
+  return "$cleanup_status"
 }
 
 require_repository() {
@@ -467,8 +470,13 @@ for snapshot in snapshots:
     snapshot_time = snapshot.get("time")
     if not isinstance(snapshot_time, str):
         reject("logical-backup snapshot has no timestamp")
+    normalized_time = re.sub(
+        r"(\.\d{6})\d+(Z|[+-]\d{2}:\d{2})$",
+        r"\1\2",
+        snapshot_time,
+    )
     try:
-        parsed_time = datetime.datetime.fromisoformat(snapshot_time.replace("Z", "+00:00"))
+        parsed_time = datetime.datetime.fromisoformat(normalized_time.replace("Z", "+00:00"))
     except ValueError:
         reject("logical-backup snapshot timestamp is invalid")
     if parsed_time.tzinfo is None:
@@ -629,11 +637,18 @@ trap 'exit 143' TERM
   fail "Process inspection root contains unsafe path components."
 [[ -d "$PROC_ROOT" && ! -L "$PROC_ROOT" ]] ||
   fail "Process inspection root is missing or unsafe."
-[[ "$VALIDATION_PORT" =~ ^[0-9]+$ ]] &&
-  (( VALIDATION_PORT >= 1 && VALIDATION_PORT <= 65535 )) ||
+if ! [[ "$VALIDATION_PORT" =~ ^[0-9]+$ ]]; then
   fail "Restore-validation port must be between 1 and 65535."
-[[ "$MAX_SNAPSHOT_AGE_HOURS" =~ ^[0-9]+$ ]] && (( MAX_SNAPSHOT_AGE_HOURS >= 1 )) ||
+fi
+if (( VALIDATION_PORT < 1 || VALIDATION_PORT > 65535 )); then
+  fail "Restore-validation port must be between 1 and 65535."
+fi
+if ! [[ "$MAX_SNAPSHOT_AGE_HOURS" =~ ^[0-9]+$ ]]; then
   fail "Maximum snapshot age must be a positive integer."
+fi
+if (( MAX_SNAPSHOT_AGE_HOURS < 1 )); then
+  fail "Maximum snapshot age must be a positive integer."
+fi
 [[ "$MIN_FREE_BYTES" =~ ^[0-9]+$ ]] ||
   fail "Minimum free bytes must be a non-negative integer."
 [[ -d "$WORK_ROOT" ]] || fail "Restore-validation work root is missing."
@@ -757,6 +772,8 @@ install -d -o postgres -g postgres -m 0700 "$CLUSTER_DIR" "$PGDATA" "$SOCKET_DIR
   "$INITDB" \
   -D "$PGDATA" \
   --username=postgres \
+  --encoding="$VALIDATION_ENCODING" \
+  --locale="$VALIDATION_LOCALE" \
   --auth-local=trust \
   --auth-host=reject \
   --no-instructions

--- a/ansible/roles/ubuntu/templates/skynet.j2
+++ b/ansible/roles/ubuntu/templates/skynet.j2
@@ -372,6 +372,8 @@ role_tag() {
     postgres:backup-remote-init)    echo "postgres_backup_remote_init" ;;
     postgres:backup-remote-run)     echo "postgres_backup_remote_run" ;;
     postgres:backup-remote-maintenance) echo "postgres_backup_remote_maintenance" ;;
+    postgres:backup-restore-validation-setup) echo "postgres_backup_restore_validation_setup" ;;
+    postgres:backup-restore-validation-run) echo "postgres_backup_restore_validation_run" ;;
     postgres:restore)               echo "postgres_restore" ;;
     postgres:admin)                 echo "postgres_admin" ;;
     postgres:admin-uptime-kuma)     echo "postgres_admin_uptime_kuma" ;;
@@ -539,6 +541,8 @@ Role/action targets:
     backup-remote-init  -> postgres_backup_remote_init
     backup-remote-run   -> postgres_backup_remote_run
     backup-remote-maintenance -> postgres_backup_remote_maintenance
+    backup-restore-validation-setup -> postgres_backup_restore_validation_setup
+    backup-restore-validation-run -> postgres_backup_restore_validation_run
     restore             -> postgres_restore
     admin               -> postgres_admin
     admin-uptime-kuma   -> postgres_admin_uptime_kuma

--- a/ansible/roles/ubuntu/templates/skynet.j2
+++ b/ansible/roles/ubuntu/templates/skynet.j2
@@ -368,6 +368,10 @@ role_tag() {
     postgres:backup)                echo "postgres_backup" ;;
     postgres:backup-setup)          echo "postgres_backup_setup" ;;
     postgres:backup-run)            echo "postgres_backup_run" ;;
+    postgres:backup-remote-setup)   echo "postgres_backup_remote_setup" ;;
+    postgres:backup-remote-init)    echo "postgres_backup_remote_init" ;;
+    postgres:backup-remote-run)     echo "postgres_backup_remote_run" ;;
+    postgres:backup-remote-maintenance) echo "postgres_backup_remote_maintenance" ;;
     postgres:restore)               echo "postgres_restore" ;;
     postgres:admin)                 echo "postgres_admin" ;;
     postgres:admin-uptime-kuma)     echo "postgres_admin_uptime_kuma" ;;
@@ -531,6 +535,10 @@ Role/action targets:
     backup              -> postgres_backup
     backup-setup        -> postgres_backup_setup
     backup-run          -> postgres_backup_run
+    backup-remote-setup -> postgres_backup_remote_setup
+    backup-remote-init  -> postgres_backup_remote_init
+    backup-remote-run   -> postgres_backup_remote_run
+    backup-remote-maintenance -> postgres_backup_remote_maintenance
     restore             -> postgres_restore
     admin               -> postgres_admin
     admin-uptime-kuma   -> postgres_admin_uptime_kuma

--- a/docs/cheat_sheets/skynet.md
+++ b/docs/cheat_sheets/skynet.md
@@ -386,6 +386,8 @@ Role/action targets are manually mapped inside the wrapper’s `role_tag()` func
 | `skynet run postgres backup-remote-init`  | `postgres_backup_remote_init`  |
 | `skynet run postgres backup-remote-run`   | `postgres_backup_remote_run`   |
 | `skynet run postgres backup-remote-maintenance` | `postgres_backup_remote_maintenance` |
+| `skynet run postgres backup-restore-validation-setup` | `postgres_backup_restore_validation_setup` |
+| `skynet run postgres backup-restore-validation-run` | `postgres_backup_restore_validation_run` |
 | `skynet run postgres restore`             | `postgres_restore`             |
 | `skynet run postgres admin`               | `postgres_admin`               |
 | `skynet run postgres admin-uptime-kuma`   | `postgres_admin_uptime_kuma`   |

--- a/docs/cheat_sheets/skynet.md
+++ b/docs/cheat_sheets/skynet.md
@@ -382,6 +382,10 @@ Role/action targets are manually mapped inside the wrapper’s `role_tag()` func
 | `skynet run postgres backup`              | `postgres_backup`              |
 | `skynet run postgres backup-setup`        | `postgres_backup_setup`        |
 | `skynet run postgres backup-run`          | `postgres_backup_run`          |
+| `skynet run postgres backup-remote-setup` | `postgres_backup_remote_setup` |
+| `skynet run postgres backup-remote-init`  | `postgres_backup_remote_init`  |
+| `skynet run postgres backup-remote-run`   | `postgres_backup_remote_run`   |
+| `skynet run postgres backup-remote-maintenance` | `postgres_backup_remote_maintenance` |
 | `skynet run postgres restore`             | `postgres_restore`             |
 | `skynet run postgres admin`               | `postgres_admin`               |
 | `skynet run postgres admin-uptime-kuma`   | `postgres_admin_uptime_kuma`   |
@@ -700,6 +704,7 @@ docker_swarm
 opentofu_pve_user
 infisical_podman_recreate
 postgres_backup
+postgres_backup_remote_run
 ```
 
 These are better exposed as:
@@ -710,6 +715,7 @@ skynet run docker swarm
 skynet run opentofu pve-user
 skynet run infisical-podman recreate
 skynet run postgres backup
+skynet run postgres backup-remote-run
 ```
 
 Do **not** add normal catalog service names here. Services should continue to use the service/tag flow from their service variable files:

--- a/docs/postgresql-logical-backups.md
+++ b/docs/postgresql-logical-backups.md
@@ -11,9 +11,10 @@ Patroni replicas provide high availability, not backups.
 
 The optional remote layer copies only completed, checksum-verified backup trees
 to a provider-neutral encrypted Restic repository. It is intentionally
-disabled until a repository and its backend are selected. WAL archiving,
-point-in-time recovery, physical base backups, and automated disposable restore
-tests are deliberately deferred.
+disabled until a repository and its backend are selected. An optional restore
+validation capability restores recent snapshots into an isolated throwaway
+PostgreSQL cluster. WAL archiving, point-in-time recovery, and physical base
+backups are deliberately deferred.
 
 These local logical backups only become off-host protection when the separate
 uploader copies them into the configured encrypted off-host backup repository.
@@ -182,6 +183,8 @@ All remote actions first probe `restic cat config`. Explicit initialization
 runs `restic init` only when that probe returns the precise missing-repository
 exit code `10`. An existing repository returns success; wrong-password exit
 `12` and every connectivity/backend failure fail without initialization.
+Minimum supported Restic version is 0.17.1 because these workflows rely on
+the differentiated repository and password failure exit codes.
 Upload and maintenance use the same probe but never initialize. Check-mode
 variants render and validate configuration, substitute deterministic secret
 stand-ins, and print the planned action without contacting Infisical or Restic.
@@ -212,8 +215,10 @@ exactly match the dump files; missing, duplicate, unsafe, or unexpected dumps
 fail before PostgreSQL starts.
 
 The throwaway PostgreSQL 18 cluster runs as OS user `postgres`, with TCP
-disabled, a private workspace socket, its own PGDATA, and a non-production
-port. Before any database is created, the validator queries
+disabled, a private workspace socket, its own PGDATA, a non-production port,
+and configurable deterministic `UTF8` / `C.UTF-8` encoding and locale defaults.
+These defaults do not claim to reproduce the source cluster locale. Before any
+database is created, the validator queries
 `data_directory`, `listen_addresses`, `unix_socket_directories`, and
 `port` through explicit socket, port, and user arguments and requires exact
 agreement with the temporary configuration. Every dump is then restored

--- a/docs/postgresql-logical-backups.md
+++ b/docs/postgresql-logical-backups.md
@@ -186,6 +186,70 @@ Upload and maintenance use the same probe but never initialize. Check-mode
 variants render and validate configuration, substitute deterministic secret
 stand-ins, and print the planned action without contacting Infisical or Restic.
 
+### Automated restore validation
+
+Restore validation is a separate, opt-in capability. It runs only on
+`postgres_backup_restore_validation_host`, which defaults to the single Restic
+maintenance host, and reuses the protected repository, password, backend
+environment, provider files, Restic options, and retry-lock configuration.
+Both `postgres_backup_restore_validation_manage` and
+`postgres_backup_restore_validation_enabled` default to `false`; the latter
+controls a Sunday 07:00 timer with up to 30 minutes of randomized delay, after
+the normal Sunday 05:00 maintenance window without a hard dependency.
+
+Each run uses `restic snapshots --json` and selects the newest timestamped
+snapshot whose host is the stable Patroni scope, whose tags identify the
+PostgreSQL logical-backup stream and cluster, and whose single
+`backup-id=<timestamp>` matches its path beneath `postgres_backup_root`.
+The snapshot must be no older than
+`postgres_backup_restore_validation_max_snapshot_age_hours` (48 by default).
+The validator restores that exact snapshot subdirectory beneath a unique,
+root-bounded workspace only after checking the configured free-space floor.
+
+The restored `SUCCESS`, `SHA256SUMS`, manifest, non-empty `globals.sql`,
+and every declared custom-format dump are revalidated. The manifest must
+exactly match the dump files; missing, duplicate, unsafe, or unexpected dumps
+fail before PostgreSQL starts.
+
+The throwaway PostgreSQL 18 cluster runs as OS user `postgres`, with TCP
+disabled, a private workspace socket, its own PGDATA, and a non-production
+port. Before any database is created, the validator queries
+`data_directory`, `listen_addresses`, `unix_socket_directories`, and
+`port` through explicit socket, port, and user arguments and requires exact
+agreement with the temporary configuration. Every dump is then restored
+sequentially into one clean `template0`-based validation database using
+`--exit-on-error --no-owner --no-acl --no-tablespaces`, followed by generic
+connectivity and catalog queries. The database is dropped before the next
+dump, bounding active expanded storage to one source database.
+
+`globals.sql` remains checksummed, required, remotely protected, and available
+for deliberate disaster recovery, but the automated validator never executes
+it. Cluster-global SQL can contain roles and tablespace paths with host-level
+effects, so automated validation intentionally proves database archive
+restorability independently from production ownership, ACL, and tablespace
+state.
+
+The validation root is `root:postgres` mode `0710`: PostgreSQL can traverse to
+its private runtime directories without gaining directory listing or write
+access. The validator always stops the temporary cluster and removes only its
+strictly named run workspace. Before stopping PostgreSQL recorded in an old
+workspace, cleanup proves through `/proc` that the live process belongs to the
+`postgres` user, is PostgreSQL, and uses that exact validation PGDATA. Ambiguous
+or reused PIDs fail closed, so stale state cannot stop production or unrelated
+processes. An overlap exits successfully without overwriting health metrics.
+Real attempts atomically publish:
+
+- `postgres_backup_restore_validation_last_attempt_timestamp_seconds`
+- `postgres_backup_restore_validation_last_success_timestamp_seconds`
+- `postgres_backup_restore_validation_last_run_success`
+- `postgres_backup_restore_validation_last_duration_seconds`
+- `postgres_backup_restore_validation_last_database_count`
+- `postgres_backup_restore_validation_last_snapshot_timestamp_seconds`
+
+The success timestamp, database count, and snapshot timestamp describe the
+latest fully successful validation and are preserved on failure. Metrics have
+no database, snapshot, repository, provider, or host labels.
+
 ### Conceptual backend examples
 
 These examples use placeholders and do not recommend a provider.
@@ -345,16 +409,25 @@ skynet run postgres backup-remote-setup
 skynet run postgres backup-remote-init
 skynet run postgres backup-remote-run
 skynet run postgres backup-remote-maintenance
+skynet run postgres backup-restore-validation-setup
+skynet run postgres backup-restore-validation-run
 ```
 
 The corresponding raw tags are `postgres_backup_remote_setup`,
 `postgres_backup_remote_init`, `postgres_backup_remote_run`, and
 `postgres_backup_remote_maintenance`. Manual upload runs on all PostgreSQL
 nodes; init and maintenance run only on the deterministic maintenance host.
+Restore-validation setup and manual execution use
+`postgres_backup_restore_validation_setup` and
+`postgres_backup_restore_validation_run`, and run only on the designated
+validation host.
 
 In check mode, `skynet check postgres backup-run` configures and validates the
 backup resources, then reports that it would discover the leader and invoke
 the runner. It does not query Patroni or run a backup.
+`skynet check postgres backup-restore-validation-run` reports the isolated
+restore plan without contacting Restic, restoring data, starting PostgreSQL, or
+cleaning real workspaces.
 
 The runner repeats the local leader check even after Ansible selected a leader,
 so a failover between discovery and execution cannot produce a backup on a
@@ -377,7 +450,13 @@ postgres_restore_dbs_map:
     file: /var/backups/postgresql/20260811T013000Z/databases/gotify.dump
 ```
 
-Phase 3b.2 remains responsible for automated restore validation: disposable
-PostgreSQL environments, restoring globals and databases, application-level
-queries, periodic restore tests, and restore-success metrics are not included
-here. WAL/PITR and physical backup mechanisms also remain separate future work.
+Inspect restore-validation scheduling and logs on its designated host with:
+
+```bash
+systemctl status postgres-logical-backup-restore-validation.timer
+systemctl status postgres-logical-backup-restore-validation.service
+journalctl -u postgres-logical-backup-restore-validation.service
+```
+
+WAL/PITR, physical backups, automatic execution of cluster globals, and
+application-specific semantic queries remain separate recovery decisions.

--- a/docs/postgresql-logical-backups.md
+++ b/docs/postgresql-logical-backups.md
@@ -9,10 +9,14 @@ not move during failover.
 
 Patroni replicas provide high availability, not backups.
 
-These are local logical backups only. An encrypted off-host backup repository
-is still required to protect against host, cluster, site, and administrative
-failure. WAL archiving, point-in-time recovery, physical base backups, and
-automated disposable restore tests are deliberately deferred.
+The optional remote layer copies only completed, checksum-verified backup trees
+to a provider-neutral encrypted Restic repository. It is intentionally
+disabled until a repository and its backend are selected. WAL archiving,
+point-in-time recovery, physical base backups, and automated disposable restore
+tests are deliberately deferred.
+
+These local logical backups only become off-host protection when the separate
+uploader copies them into the configured encrypted off-host backup repository.
 
 ## Configuration
 
@@ -40,6 +44,196 @@ installs the runner as `root:root` with mode `0755`, and runs the oneshot
 service as OS user and group `postgres`. PostgreSQL commands omit `-h` and
 use the local Unix socket with peer authentication. No PostgreSQL password is
 stored in the script or systemd unit.
+
+## Provider-neutral encrypted remote backups
+
+Local production and remote transfer are separate operations:
+
+```text
+local verified logical backup
+          |
+          v
+completed backup + SUCCESS
+          |
+          v
+checksum verification
+          |
+          v
+Restic encrypted remote snapshot
+          |
+          v
+remote retention
+```
+
+`postgres-logical-backup` remains PostgreSQL-specific and performs no network
+operations. When remote management is enabled, the role installs Restic and a
+separate root-run `postgres-logical-backup-remote` runner on every
+`tags_postgres` host. Every node needs the uploader because a completed local
+backup stays on whichever Patroni member was leader when it was created.
+
+The remote capability is intentionally disabled until a repository/provider is
+configured. Its main variables are:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `postgres_backup_remote_manage` | `false` | Install and configure the capability |
+| `postgres_backup_remote_enabled` | `false` | Enable upload and maintenance timers |
+| `postgres_backup_remote_repository` | empty | Provider-neutral Restic repository URL |
+| `postgres_backup_remote_password_secret` | `/Restic/Postgres` / `PASSWORD` | Infisical repository-password declaration |
+| `postgres_backup_remote_backend_environment` | `{}` | Non-secret backend environment |
+| `postgres_backup_remote_backend_secrets` | `[]` | Infisical-backed environment declarations |
+| `postgres_backup_remote_secret_files` | `[]` | Root-only Infisical-backed files |
+| `postgres_backup_remote_options` | `[]` | Additional non-secret Restic argv elements |
+| `postgres_backup_remote_retry_lock` | `10m` | Restic repository-lock retry duration |
+| `postgres_backup_remote_maintenance_host` | first sorted PostgreSQL host | Sole maintenance scheduler |
+| `postgres_backup_remote_snapshot_host` | `postgres_patroni_scope` | Cluster-stable snapshot host identity |
+| `postgres_backup_remote_keep_daily` | `14` | Daily snapshots retained remotely |
+| `postgres_backup_remote_keep_weekly` | `8` | Weekly snapshots retained remotely |
+| `postgres_backup_remote_keep_monthly` | `12` | Monthly snapshots retained remotely |
+
+`manage` controls package, configuration, runner, state, and unit management.
+`enabled` controls scheduled network activity. A repository is not required
+while both remain false, and this repository does not enable either variable in
+`tags_postgres.yml`.
+
+The role writes `/etc/restic/postgres-logical-backup` as `root:root 0700`.
+The repository, password, backend environment, and optional backend secret
+files are `root:root 0600`. The repository password and backend secrets are
+looked up through
+`hostvars[services_controller_host].infisical_lookup_default_params` on the
+controller. They are never placed in the runner, a systemd unit, or command
+arguments. The runner exports `RESTIC_REPOSITORY_FILE` and
+`RESTIC_PASSWORD_FILE` and safely sources the protected backend environment.
+
+Backend environment keys must be shell identifiers. Secret files must be
+direct children of the protected Restic config directory and use mode `0600`.
+Additional Restic options are individual array arguments, never a shell command
+and never evaluated with `eval`; keep credentials in Infisical-backed
+environment or files instead. Do not embed provider credentials in the
+repository URL.
+
+The role records only its declared provider secret-file paths in the root-only
+`.managed-secret-files` manifest. When a provider configuration changes, files
+that were previously recorded but are no longer declared are removed. Other
+administrator-created files in the protected configuration directory are not
+scanned or deleted.
+
+### Upload eligibility and snapshot identity
+
+The uploader considers only direct children of `postgres_backup_root` whose
+names exactly match `YYYYMMDDTHHMMSSZ` and contain `SUCCESS`. It ignores
+staging directories, lock/retention files, arbitrary names, and incomplete
+backups. Before upload it runs `sha256sum --check SHA256SUMS` inside the
+candidate. A checksum or Restic failure leaves the local backup untouched and
+does not create an uploaded-state marker.
+
+Each successful `restic backup` creates one snapshot and then atomically writes
+a root-only marker under
+`/var/lib/postgres-logical-backup-remote/uploaded/<repository-id>/<backup-id>`.
+The namespace is Restic's unique repository ID from `restic cat config`, so
+switching providers or recreating a repository at the same URL automatically
+makes locally retained backups eligible for the new repository. Marker
+directories for prior repositories are preserved. Missing markers retry on
+later runs; existing markers skip duplicates for that repository. A separate
+local flock prevents overlapping upload processes without changing metrics on
+a clean overlap skip. Restic operations also use
+`postgres_backup_remote_retry_lock: 10m` by default so short-lived shared
+repository lock contention is retried by Restic itself.
+
+Snapshots use the Patroni scope as their stable Restic host and carry these
+tags:
+
+- `postgres-logical-backup`
+- `cluster=<patroni-scope>`
+- `backup-id=<timestamp>`
+- `source-member=<inventory-host>`
+
+The source member is diagnostic only. Retention scopes to the stable host and
+`postgres-logical-backup` tag, then groups by host so changing source paths and
+leaders remain one logical cluster stream. This prevents maintenance from
+touching unrelated snapshots if the repository is shared.
+
+Upload timers are rendered on all PostgreSQL nodes. A separate Sunday
+maintenance timer is rendered only on
+`postgres_backup_remote_maintenance_host`; it applies 14 daily, 8 weekly, and
+12 monthly retention by default and performs the repository prune. Upload runs
+never call `forget` or `prune`.
+
+### Activation workflow
+
+The future administrator must provide the repository URL/server, create a
+strong random Restic repository password in Infisical, add any provider
+credentials to Infisical, and provide any safe provider options. Then:
+
+1. Set `postgres_backup_remote_repository`.
+2. Configure `postgres_backup_remote_backend_environment`, secret environment
+   declarations, secret files, or non-secret options required by the backend.
+3. Set `postgres_backup_remote_manage: true`.
+4. Run `skynet run postgres backup-remote-setup`.
+5. After independently confirming the destination, explicitly run
+   `skynet run postgres backup-remote-init` once.
+6. Run `skynet run postgres backup-remote-run` and inspect snapshots and
+   metrics.
+7. Set `postgres_backup_remote_enabled: true`, rerun setup, and verify both
+   timers.
+
+Normal role execution and setup never initialize, upload, forget, or prune.
+All remote actions first probe `restic cat config`. Explicit initialization
+runs `restic init` only when that probe returns the precise missing-repository
+exit code `10`. An existing repository returns success; wrong-password exit
+`12` and every connectivity/backend failure fail without initialization.
+Upload and maintenance use the same probe but never initialize. Check-mode
+variants render and validate configuration, substitute deterministic secret
+stand-ins, and print the planned action without contacting Infisical or Restic.
+
+### Conceptual backend examples
+
+These examples use placeholders and do not recommend a provider.
+
+Unconfigured safe state:
+
+```yaml
+postgres_backup_remote_manage: false
+postgres_backup_remote_enabled: false
+postgres_backup_remote_repository: ""
+```
+
+Conceptual SFTP state:
+
+```yaml
+postgres_backup_remote_repository: sftp:backup@example.invalid:/srv/restic/postgres
+postgres_backup_remote_secret_files:
+  - path: /etc/restic/postgres-logical-backup/backend-key
+    infisical:
+      path: /Restic/Postgres
+      name: SFTP_PRIVATE_KEY
+    mode: "0600"
+postgres_backup_remote_options:
+  - --option
+  - sftp.command=ssh -i /etc/restic/postgres-logical-backup/backend-key
+```
+
+Before using SFTP, independently verify the server host key and install it in a
+root-readable known-hosts file. Do not disable strict host-key checking and do
+not automatically trust the first presented key.
+
+Conceptual S3-compatible state:
+
+```yaml
+postgres_backup_remote_repository: s3:https://objects.example.invalid/backups/postgres
+postgres_backup_remote_backend_environment:
+  AWS_DEFAULT_REGION: example-region-1
+postgres_backup_remote_backend_secrets:
+  - env: AWS_ACCESS_KEY_ID
+    path: /Restic/Postgres
+    name: S3_ACCESS_KEY_ID
+  - env: AWS_SECRET_ACCESS_KEY
+    path: /Restic/Postgres
+    name: S3_SECRET_ACCESS_KEY
+```
+
+No provider URL, account, credentials, or SSH host key is committed by this
+phase.
 
 ## Backup contents and completion contract
 
@@ -110,6 +304,22 @@ A normal replica skip and a local overlap skip do not overwrite genuine backup
 health. A failed metrics write is visible as a failed systemd invocation; it
 cannot turn a failed database backup into a success.
 
+The remote uploader atomically publishes a separate metrics file containing:
+
+- `postgres_backup_remote_last_attempt_timestamp_seconds`: the latest
+  non-overlap upload attempt.
+- `postgres_backup_remote_last_success_timestamp_seconds`: the latest actual
+  successful upload; a successful no-work run preserves it.
+- `postgres_backup_remote_last_run_success`: whether the whole uploader run
+  completed, including successful no-work runs.
+- `postgres_backup_remote_last_duration_seconds`: duration of the latest run.
+- `postgres_backup_remote_last_uploaded_count`: backups uploaded by that run.
+- `postgres_backup_remote_pending_count`: eligible unmarked backups remaining
+  after discovery at completion or failure. It is `0` if a preflight failure
+  occurs before local eligibility can be counted.
+
+Repository URLs, hostnames, backup IDs, and credentials are not metric labels.
+
 ## Setup, manual runs, and inspection
 
 A normal full play configures the runner and timer but does not run an
@@ -127,6 +337,20 @@ skynet run postgres backup-setup
 skynet run postgres backup-run
 skynet run postgres backup
 ```
+
+Remote Restic operations use distinct tags and commands:
+
+```bash
+skynet run postgres backup-remote-setup
+skynet run postgres backup-remote-init
+skynet run postgres backup-remote-run
+skynet run postgres backup-remote-maintenance
+```
+
+The corresponding raw tags are `postgres_backup_remote_setup`,
+`postgres_backup_remote_init`, `postgres_backup_remote_run`, and
+`postgres_backup_remote_maintenance`. Manual upload runs on all PostgreSQL
+nodes; init and maintenance run only on the deterministic maintenance host.
 
 In check mode, `skynet check postgres backup-run` configures and validates the
 backup resources, then reports that it would discover the leader and invoke
@@ -153,5 +377,7 @@ postgres_restore_dbs_map:
     file: /var/backups/postgresql/20260811T013000Z/databases/gotify.dump
 ```
 
-Selecting the latest backup automatically and proving full recovery in a
-disposable restore environment remain follow-up work.
+Phase 3b.2 remains responsible for automated restore validation: disposable
+PostgreSQL environments, restoring globals and databases, application-level
+queries, periodic restore tests, and restore-success metrics are not included
+here. WAL/PITR and physical backup mechanisms also remain separate future work.

--- a/tests/unit/test_postgres_remote_backup.py
+++ b/tests/unit/test_postgres_remote_backup.py
@@ -1,0 +1,1138 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import pwd
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+from jinja2 import Environment, StrictUndefined
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROLE_PATH = REPO_ROOT / "ansible/roles/postgres"
+DEFAULTS_PATH = ROLE_PATH / "defaults/main.yml"
+MAIN_TASKS_PATH = ROLE_PATH / "tasks/main.yml"
+REMOTE_SETUP_TASKS_PATH = ROLE_PATH / "tasks/sub_tasks/backup_remote_setup.yml"
+REMOTE_ACTION_TASKS_PATH = ROLE_PATH / "tasks/sub_tasks/backup_remote_action.yml"
+REMOTE_SECRET_RECONCILE_TASKS_PATH = ROLE_PATH / "tasks/sub_tasks/backup_remote_secret_reconcile.yml"
+LOCAL_RUNNER_TEMPLATE_PATH = ROLE_PATH / "templates/postgres-logical-backup.sh.j2"
+REMOTE_RUNNER_TEMPLATE_PATH = ROLE_PATH / "templates/postgres-logical-backup-remote.sh.j2"
+REMOTE_ENV_TEMPLATE_PATH = ROLE_PATH / "templates/postgres-logical-backup-remote.env.j2"
+GROUP_VARS_PATH = REPO_ROOT / "ansible/group_vars/tags_postgres.yml"
+PLAYBOOK_PATH = REPO_ROOT / "ansible/playbook.yml"
+SKYNET_TEMPLATE_PATH = REPO_ROOT / "ansible/roles/ubuntu/templates/skynet.j2"
+SKYNET_DOC_PATH = REPO_ROOT / "docs/cheat_sheets/skynet.md"
+BACKUP_DOC_PATH = REPO_ROOT / "docs/postgresql-logical-backups.md"
+SYSTEMD_SERVICE_TEMPLATE = REPO_ROOT / "ansible/roles/systemd_jobs/templates/systemd-job.service.j2"
+SYSTEMD_TIMER_TEMPLATE = REPO_ROOT / "ansible/roles/systemd_jobs/templates/systemd-job.timer.j2"
+ANSIBLE_PLAYBOOK = shutil.which(
+    "ansible-playbook",
+    path=os.pathsep.join((str(Path(sys.executable).parent), os.environ.get("PATH", ""))),
+)
+try:
+    pwd.getpwnam("postgres")
+except KeyError:
+    POSTGRES_USER_AVAILABLE = False
+else:
+    POSTGRES_USER_AVAILABLE = True
+
+REPOSITORY_ID_A = "a" * 64
+REPOSITORY_ID_B = "b" * 64
+
+
+def task_named(tasks: list[dict], name: str) -> dict:
+    return next(task for task in tasks if task.get("name") == name)
+
+
+def render_jinja(path: Path, **variables) -> str:
+    environment = Environment(
+        trim_blocks=True,
+        lstrip_blocks=True,
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+    environment.filters["quote"] = lambda value: shlex.quote(str(value))
+    return environment.from_string(path.read_text()).render(**variables)
+
+
+def render_remote_runner(
+    tmp_path: Path,
+    *,
+    options: list[str] | None = None,
+    retry_lock: str = "10m",
+) -> Path:
+    backup_root = tmp_path / "backups"
+    state_dir = tmp_path / "state"
+    config_dir = tmp_path / "config"
+    metrics_file = tmp_path / "textfile" / "postgres_logical_backup_remote.prom"
+    for directory in (backup_root, state_dir / "uploaded", config_dir, metrics_file.parent):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    repository_file = config_dir / "repository"
+    password_file = config_dir / "password"
+    environment_file = config_dir / "backend.env"
+    repository_file.write_text("local:test-repository\n")
+    password_file.write_text("CHECK_MODE_TEST_PASSWORD\n")
+    environment_file.write_text("")
+    metrics_file.write_text("")
+
+    fake_restic = tmp_path / "fake-restic"
+    fake_restic.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'CALL' >> "$FAKE_RESTIC_LOG"
+printf '\t%s' "$@" >> "$FAKE_RESTIC_LOG"
+printf '\n' >> "$FAKE_RESTIC_LOG"
+
+[[ -n "${RESTIC_REPOSITORY_FILE:-}" ]]
+[[ -n "${RESTIC_PASSWORD_FILE:-}" ]]
+
+command=''
+previous_argument=''
+for argument in "$@"; do
+  if [[ "$previous_argument" == cat && "$argument" == config ]]; then
+    command='cat-config'
+    break
+  fi
+  case "$argument" in
+    init|backup|forget) command="$argument"; break ;;
+  esac
+  previous_argument="$argument"
+done
+
+case "$command:${FAKE_RESTIC_MODE:-available}" in
+  cat-config:missing|cat-config:missing-init-fail) exit 10 ;;
+  cat-config:wrong-password) exit 12 ;;
+  cat-config:backend-fail) exit 20 ;;
+  cat-config:invalid-json) printf '{invalid json\n' ;;
+  cat-config:missing-id) printf '{"version":2}\n' ;;
+  cat-config:empty-id) printf '{"version":2,"id":""}\n' ;;
+  cat-config:unsafe-id) printf '{"version":2,"id":"../../unsafe"}\n' ;;
+  cat-config:*) printf '{"version":2,"id":"%s","chunker_polynomial":"3da3358b4dc173"}\n' "${FAKE_RESTIC_REPOSITORY_ID:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}" ;;
+  init:missing-init-fail|init:init-fail) exit 21 ;;
+  backup:backup-fail) exit 22 ;;
+  backup:sleep) sleep 1 ;;
+  forget:maintenance-fail) exit 23 ;;
+esac
+"""
+    )
+    fake_restic.chmod(0o755)
+
+    script = render_jinja(
+        REMOTE_RUNNER_TEMPLATE_PATH,
+        postgres_backup_root=str(backup_root),
+        postgres_backup_remote_state_dir=str(state_dir),
+        postgres_backup_remote_metrics_file=str(metrics_file),
+        postgres_backup_remote_restic_path=str(fake_restic),
+        postgres_backup_remote_repository_file=str(repository_file),
+        postgres_backup_remote_password_file=str(password_file),
+        postgres_backup_remote_environment_file=str(environment_file),
+        postgres_backup_remote_snapshot_host="pg-cluster",
+        postgres_patroni_scope="pg-cluster",
+        inventory_hostname="pg95",
+        postgres_backup_remote_keep_daily=14,
+        postgres_backup_remote_keep_weekly=8,
+        postgres_backup_remote_keep_monthly=12,
+        postgres_backup_remote_retry_lock=retry_lock,
+        postgres_backup_remote_options=options or [],
+    )
+    script_path = tmp_path / "postgres-logical-backup-remote"
+    script_path.write_text(script)
+    script_path.chmod(0o755)
+    return script_path
+
+
+def make_completed_backup(
+    tmp_path: Path,
+    backup_id: str,
+    *,
+    success: bool = True,
+    valid_checksum: bool = True,
+) -> Path:
+    backup = tmp_path / "backups" / backup_id
+    backup.mkdir()
+    payload = backup / "payload.txt"
+    payload.write_text(f"payload for {backup_id}\n")
+    digest = hashlib.sha256(payload.read_bytes()).hexdigest()
+    (backup / "SHA256SUMS").write_text(f"{digest}  payload.txt\n")
+    if not valid_checksum:
+        payload.write_text("corrupted after checksum\n")
+    if success:
+        (backup / "SUCCESS").touch()
+    return backup
+
+
+def run_remote(
+    script: Path,
+    action: str,
+    *,
+    restic_mode: str = "available",
+    repository_id: str = REPOSITORY_ID_A,
+) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "FAKE_RESTIC_LOG": str(script.parent / "restic.log"),
+            "FAKE_RESTIC_MODE": restic_mode,
+            "FAKE_RESTIC_REPOSITORY_ID": repository_id,
+        }
+    )
+    return subprocess.run(
+        [str(script), action],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+
+def restic_log(tmp_path: Path) -> str:
+    path = tmp_path / "restic.log"
+    return path.read_text() if path.exists() else ""
+
+
+def run_setup_check(
+    tmp_path: Path,
+    *,
+    remote_manage: bool = False,
+    remote_enabled: bool = False,
+    repository: str = "",
+    backend_environment: dict[str, str] | None = None,
+    backend_secrets: list[dict[str, str]] | None = None,
+    secret_files: list[dict] | None = None,
+    config_dir: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    inventory = tmp_path / "inventory.yml"
+    playbook = tmp_path / "remote-backup.yml"
+    play_vars = {
+        "services_controller_host": "localhost",
+        "ansible_facts": {"service_mgr": "systemd"},
+        "postgres_backup_remote_manage": remote_manage,
+        "postgres_backup_remote_enabled": remote_enabled,
+        "postgres_backup_remote_repository": repository,
+    }
+    if config_dir is not None:
+        play_vars.update(
+            {
+                "postgres_backup_remote_config_dir": str(config_dir),
+                "postgres_backup_remote_repository_file": str(config_dir / "repository"),
+                "postgres_backup_remote_password_file": str(config_dir / "password"),
+                "postgres_backup_remote_environment_file": str(config_dir / "backend.env"),
+                "postgres_backup_remote_managed_secret_files_manifest": str(config_dir / ".managed-secret-files"),
+            }
+        )
+    if repository:
+        play_vars.update(
+            {
+                "postgres_backup_remote_backend_environment": (
+                    {"SAFE_REGION": "example-region-1"} if backend_environment is None else backend_environment
+                ),
+                "postgres_backup_remote_backend_secrets": (
+                    [{"env": "BACKEND_TOKEN", "path": "/Restic/Postgres", "name": "BACKEND_TOKEN"}]
+                    if backend_secrets is None
+                    else backend_secrets
+                ),
+                "postgres_backup_remote_secret_files": (
+                    [
+                        {
+                            "path": str((config_dir or Path("/etc/restic/postgres-logical-backup")) / "backend-key"),
+                            "infisical": {"path": "/Restic/Postgres", "name": "BACKEND_KEY"},
+                            "mode": "0600",
+                        }
+                    ]
+                    if secret_files is None
+                    else secret_files
+                ),
+                "postgres_backup_remote_options": ["--option", "sftp.command=ssh -i /protected/key"],
+            }
+        )
+    inventory.write_text(
+        yaml.safe_dump(
+            {
+                "all": {
+                    "children": {"tags_postgres": {"hosts": {"localhost": {}}}},
+                    "hosts": {"localhost": {"ansible_connection": "local"}},
+                }
+            },
+            sort_keys=False,
+        )
+    )
+    playbook.write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "name": "Validate disabled PostgreSQL remote backup setup",
+                    "hosts": "tags_postgres",
+                    "gather_facts": False,
+                    "vars": play_vars,
+                    "roles": ["postgres"],
+                }
+            ],
+            sort_keys=False,
+        )
+    )
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "ANSIBLE_CONFIG": str(REPO_ROOT / "ansible/ansible.cfg"),
+            "ANSIBLE_LOCAL_TEMP": str(tmp_path / "ansible-local"),
+            "ANSIBLE_REMOTE_TEMP": str(tmp_path / "ansible-remote"),
+        }
+    )
+    return subprocess.run(
+        [
+            ANSIBLE_PLAYBOOK,
+            "-i",
+            str(inventory),
+            str(playbook),
+            "--check",
+            "--tags",
+            "postgres_backup_remote_setup",
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_remote_capability_defaults_are_provider_neutral_and_disabled():
+    defaults = yaml.safe_load(DEFAULTS_PATH.read_text())
+    group_vars = yaml.safe_load(GROUP_VARS_PATH.read_text())
+
+    assert defaults["postgres_backup_remote_manage"] is False
+    assert defaults["postgres_backup_remote_enabled"] is False
+    assert defaults["postgres_backup_remote_repository"] == ""
+    assert defaults["postgres_backup_remote_backend_environment"] == {}
+    assert defaults["postgres_backup_remote_backend_secrets"] == []
+    assert defaults["postgres_backup_remote_secret_files"] == []
+    assert defaults["postgres_backup_remote_retry_lock"] == "10m"
+    assert defaults["postgres_backup_remote_managed_secret_files_manifest"].endswith("/.managed-secret-files")
+    assert defaults["postgres_backup_remote_keep_daily"] == 14
+    assert defaults["postgres_backup_remote_keep_weekly"] == 8
+    assert defaults["postgres_backup_remote_keep_monthly"] == 12
+    assert not any(key.startswith("postgres_backup_remote_") for key in group_vars)
+
+
+@pytest.mark.skipif(ANSIBLE_PLAYBOOK is None, reason="ansible-playbook is unavailable")
+def test_disabled_remote_management_does_not_require_a_provider(tmp_path: Path):
+    result = run_setup_check(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Remote logical backup | Validate configuration" in result.stdout
+    assert "Remote logical backup | Install Restic package" in result.stdout
+    assert "skipping: [localhost]" in result.stdout
+
+
+def test_enabled_scheduling_requires_management_and_repository():
+    tasks = yaml.safe_load(REMOTE_SETUP_TASKS_PATH.read_text())
+    validation = task_named(tasks, "Remote logical backup | Validate configuration")
+    conditions = " ".join(validation["ansible.builtin.assert"]["that"])
+
+    assert "not postgres_backup_remote_enabled or postgres_backup_remote_manage" in conditions
+    assert "postgres_backup_remote_repository | trim | length > 0" in conditions
+
+
+@pytest.mark.skipif(ANSIBLE_PLAYBOOK is None, reason="ansible-playbook is unavailable")
+def test_enabled_scheduling_without_repository_is_rejected_before_mutation(tmp_path: Path):
+    result = run_setup_check(tmp_path, remote_manage=True, remote_enabled=True)
+
+    assert result.returncode != 0
+    assert "PostgreSQL remote logical backup configuration is invalid" in result.stdout
+    assert "Remote logical backup | Install Restic package" not in result.stdout
+
+
+@pytest.mark.skipif(ANSIBLE_PLAYBOOK is None, reason="ansible-playbook is unavailable")
+@pytest.mark.skipif(not POSTGRES_USER_AVAILABLE, reason="postgres OS user is unavailable")
+def test_configured_check_mode_uses_placeholders_without_live_restic_actions(tmp_path: Path):
+    result = run_setup_check(tmp_path, remote_manage=True, repository="local:check-mode-repository")
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 0, output
+    assert "Remote logical backup | Build deterministic check-mode credentials" in output
+    assert "Remote logical backup | Resolve repository password through controller Infisical parameters" in output
+    assert "Remote logical backup action | Invoke host-local runner" not in output
+    assert "Systemd jobs | Render service units" in output
+
+
+def test_restic_install_and_runner_are_scoped_to_managed_postgres_hosts():
+    main_tasks = yaml.safe_load(MAIN_TASKS_PATH.read_text())
+    setup_tasks = yaml.safe_load(REMOTE_SETUP_TASKS_PATH.read_text())
+    include = task_named(main_tasks, "Configure PostgreSQL remote logical backups")
+    install = task_named(setup_tasks, "Remote logical backup | Install Restic package")
+    runner = task_named(setup_tasks, "Remote logical backup | Install host-local runner")
+
+    assert include["when"] == "'tags_postgres' in group_names"
+    assert "postgres" in include["tags"]
+    assert install["when"] == "postgres_backup_remote_manage"
+    assert install["ansible.builtin.apt"] == {"name": "restic", "state": "present"}
+    assert runner["when"] == "postgres_backup_remote_manage"
+    assert runner["ansible.builtin.template"]["dest"] == "{{ postgres_backup_remote_script_path }}"
+    assert "restic" not in LOCAL_RUNNER_TEMPLATE_PATH.read_text().lower()
+
+
+def test_infisical_lookups_use_controller_contract_and_hide_secret_material():
+    tasks = yaml.safe_load(REMOTE_SETUP_TASKS_PATH.read_text())
+    lookup_names = (
+        "Remote logical backup | Resolve repository password through controller Infisical parameters",
+        "Remote logical backup | Resolve backend environment secrets through controller",
+        "Remote logical backup | Resolve backend secret files through controller",
+    )
+    write_names = (
+        "Remote logical backup | Write repository location",
+        "Remote logical backup | Write repository password",
+        "Remote logical backup | Write protected backend environment",
+        "Remote logical backup | Write protected backend secret files",
+    )
+
+    for name in lookup_names:
+        task = task_named(tasks, name)
+        source = str(task)
+        assert task["delegate_to"] == "{{ services_controller_host }}"
+        assert "hostvars[services_controller_host].infisical_lookup_default_params" in source
+        assert "infisical.vault.read_secrets" in source
+        assert "not ansible_check_mode" in task["when"]
+        assert task["no_log"] is True
+        assert task["diff"] is False
+
+    for name in write_names:
+        task = task_named(tasks, name)
+        assert task["no_log"] is True
+        assert task["diff"] is False
+
+
+def test_protected_config_state_and_secret_files_have_restrictive_permissions():
+    tasks = yaml.safe_load(REMOTE_SETUP_TASKS_PATH.read_text())
+    config_dir = task_named(tasks, "Remote logical backup | Create protected configuration directory")
+    state_dirs = task_named(tasks, "Remote logical backup | Create protected state directories")
+
+    assert config_dir["ansible.builtin.file"]["owner"] == "root"
+    assert config_dir["ansible.builtin.file"]["group"] == "root"
+    assert config_dir["ansible.builtin.file"]["mode"] == "0700"
+    assert state_dirs["ansible.builtin.file"]["mode"] == "0700"
+    for name in (
+        "Remote logical backup | Write repository location",
+        "Remote logical backup | Write repository password",
+        "Remote logical backup | Write protected backend environment",
+        "Remote logical backup | Write protected backend secret files",
+    ):
+        module = next(
+            value for key, value in task_named(tasks, name).items() if key in {"ansible.builtin.copy", "ansible.builtin.template"}
+        )
+        assert module["owner"] == "root"
+        assert module["group"] == "root"
+        assert module["mode"] == "0600"
+
+
+def test_managed_secret_manifest_reconciles_only_previously_owned_files(tmp_path: Path):
+    tasks = yaml.safe_load(REMOTE_SECRET_RECONCILE_TASKS_PATH.read_text())
+    remove = task_named(tasks, "Remote logical backup secret reconciliation | Remove obsolete managed secret files")
+    publish = task_named(tasks, "Remote logical backup secret reconciliation | Publish managed-file manifest atomically")
+    source = REMOTE_SECRET_RECONCILE_TASKS_PATH.read_text()
+
+    assert "postgres_backup_remote_previous_secret_file_paths" in remove["loop"]
+    assert "difference(postgres_backup_remote_desired_secret_file_paths)" in remove["loop"]
+    assert remove["ansible.builtin.file"]["state"] == "absent"
+    assert publish["ansible.builtin.copy"]["mode"] == "0600"
+    assert publish["ansible.builtin.copy"]["unsafe_writes"] is False
+    assert "find:" not in source
+    assert "rm -rf" not in source
+
+    old_key = tmp_path / "old-key"
+    still_desired = tmp_path / "still-desired"
+    unrelated = tmp_path / "operator-notes"
+    for path in (old_key, still_desired, unrelated):
+        path.write_text(path.name)
+
+    previous_managed = {old_key, still_desired}
+    desired_managed = {still_desired}
+    for obsolete in previous_managed.difference(desired_managed):
+        obsolete.unlink()
+
+    assert not old_key.exists()
+    assert still_desired.exists()
+    assert unrelated.exists()
+
+    new_provider_credentials = tmp_path / "new-provider-credentials"
+    new_provider_credentials.write_text("new")
+    previous_managed = desired_managed
+    desired_managed = {new_provider_credentials}
+    for obsolete in previous_managed.difference(desired_managed):
+        obsolete.unlink()
+
+    assert not still_desired.exists()
+    assert new_provider_credentials.exists()
+    assert unrelated.exists()
+
+
+@pytest.mark.skipif(ANSIBLE_PLAYBOOK is None, reason="ansible-playbook is unavailable")
+@pytest.mark.skipif(not POSTGRES_USER_AVAILABLE, reason="postgres OS user is unavailable")
+def test_secret_reconciliation_check_mode_plans_without_mutating_files(tmp_path: Path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    old_key = config_dir / "old-key"
+    unrelated = config_dir / "operator-notes"
+    manifest = config_dir / ".managed-secret-files"
+    old_key.write_text("old")
+    unrelated.write_text("operator")
+    manifest.write_text(f"{old_key}\n")
+
+    result = run_setup_check(
+        tmp_path,
+        remote_manage=True,
+        repository="local:check-mode-repository",
+        backend_environment={},
+        backend_secrets=[],
+        secret_files=[],
+        config_dir=config_dir,
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 0, output
+    assert "Remove obsolete managed secret files" in output
+    assert "Publish managed-file manifest atomically" in output
+    assert old_key.read_text() == "old"
+    assert unrelated.read_text() == "operator"
+    assert manifest.read_text() == f"{old_key}\n"
+
+
+def test_backend_schema_is_shell_safe_and_secret_files_stay_under_config_dir():
+    source = REMOTE_SETUP_TASKS_PATH.read_text()
+    environment_template = REMOTE_ENV_TEMPLATE_PATH.read_text()
+
+    assert "^[A-Za-z_][A-Za-z0-9_]*$" in source
+    assert "dirname == postgres_backup_remote_config_dir" in source
+    assert "postgres_backup_remote_secret_file.mode | default('0600') == '0600'" in source
+    assert "RESTIC_PASSWORD_FILE" in source
+    assert "RESTIC_REPOSITORY_FILE" in source
+    assert "| replace" in environment_template
+
+
+def test_reserved_backend_environment_names_cover_shell_startup_and_loader_controls():
+    source = REMOTE_SETUP_TASKS_PATH.read_text()
+    for name in (
+        "IFS",
+        "BASH_ENV",
+        "ENV",
+        "PATH",
+        "SHELLOPTS",
+        "BASHOPTS",
+        "BASH_XTRACEFD",
+        "POSIXLY_CORRECT",
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+    ):
+        assert source.count(f"- {name}") == 2
+
+
+@pytest.mark.parametrize(
+    ("backend_environment", "backend_secrets"),
+    [
+        ({"IFS": "unsafe"}, []),
+        ({}, [{"env": "BASH_XTRACEFD", "path": "/Restic/Postgres", "name": "TRACE_FD"}]),
+        ({"POSIXLY_CORRECT": "1"}, []),
+    ],
+)
+@pytest.mark.skipif(ANSIBLE_PLAYBOOK is None, reason="ansible-playbook is unavailable")
+def test_reserved_backend_environment_names_are_rejected(
+    tmp_path: Path,
+    backend_environment: dict[str, str],
+    backend_secrets: list[dict[str, str]],
+):
+    result = run_setup_check(
+        tmp_path,
+        remote_manage=True,
+        repository="local:check-mode-repository",
+        backend_environment=backend_environment,
+        backend_secrets=backend_secrets,
+        secret_files=[],
+    )
+
+    assert result.returncode != 0
+    assert "must be safe string assignments" in result.stdout or "declarations are invalid" in result.stdout
+
+
+@pytest.mark.skipif(ANSIBLE_PLAYBOOK is None, reason="ansible-playbook is unavailable")
+@pytest.mark.skipif(not POSTGRES_USER_AVAILABLE, reason="postgres OS user is unavailable")
+def test_normal_provider_environment_names_remain_allowed(tmp_path: Path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    result = run_setup_check(
+        tmp_path,
+        remote_manage=True,
+        repository="local:check-mode-repository",
+        backend_environment={
+            "AWS_DEFAULT_REGION": "example-region-1",
+            "B2_ACCOUNT_ID": "example-account",
+            "RESTIC_FEATURES": "example-feature",
+        },
+        backend_secrets=[
+            {"env": "AWS_ACCESS_KEY_ID", "path": "/Restic/Postgres", "name": "ACCESS_KEY"},
+            {"env": "AWS_SECRET_ACCESS_KEY", "path": "/Restic/Postgres", "name": "SECRET_KEY"},
+            {"env": "B2_ACCOUNT_KEY", "path": "/Restic/Postgres", "name": "ACCOUNT_KEY"},
+        ],
+        secret_files=[],
+        config_dir=config_dir,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("unsafe_name", [".", "..", "sub/../escaped", "sub//escaped"])
+@pytest.mark.skipif(ANSIBLE_PLAYBOOK is None, reason="ansible-playbook is unavailable")
+def test_unsafe_secret_file_paths_are_rejected(tmp_path: Path, unsafe_name: str):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    result = run_setup_check(
+        tmp_path,
+        remote_manage=True,
+        repository="local:check-mode-repository",
+        backend_environment={},
+        backend_secrets=[],
+        secret_files=[
+            {
+                "path": f"{config_dir}/{unsafe_name}",
+                "infisical": {"path": "/Restic/Postgres", "name": "UNSAFE"},
+                "mode": "0600",
+            }
+        ],
+        config_dir=config_dir,
+    )
+
+    assert result.returncode != 0
+    assert "secret-file declarations are invalid" in result.stdout
+
+
+def test_backend_environment_template_quotes_values_as_literal_assignments(tmp_path: Path):
+    marker = tmp_path / "must-not-exist"
+    rendered = render_jinja(
+        REMOTE_ENV_TEMPLATE_PATH,
+        postgres_backup_remote_resolved_backend_environment={
+            "LITERAL_VALUE": f"$(touch {marker})",
+            "SAFE_SETTING": "value with spaces",
+        },
+    )
+    environment_file = tmp_path / "backend.env"
+    environment_file.write_text(rendered)
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'set -a; source "$1"; printf "%s\\n%s\\n" "$SAFE_SETTING" "$LITERAL_VALUE"',
+            "--",
+            str(environment_file),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.splitlines() == ["value with spaces", f"$(touch {marker})"]
+    assert not marker.exists()
+
+
+def test_systemd_jobs_run_as_root_on_all_nodes_and_maintenance_is_single_host():
+    tasks = yaml.safe_load(REMOTE_SETUP_TASKS_PATH.read_text())
+    uploader = task_named(tasks, "Remote logical backup | Manage uploader systemd job")
+    maintenance = task_named(tasks, "Remote logical backup | Manage maintenance systemd job")
+    uploader_job = uploader["vars"]["systemd_jobs"][0]
+    maintenance_job = maintenance["vars"]["systemd_jobs"][0]
+
+    assert uploader["ansible.builtin.include_role"]["name"] == "systemd_jobs"
+    assert uploader["when"] == "postgres_backup_remote_manage"
+    assert uploader_job["service"]["exec_start"] == "{{ postgres_backup_remote_script_path }} upload"
+    assert uploader_job["service"]["user"] == "root"
+    assert uploader_job["service"]["group"] == "root"
+    assert uploader_job["service"]["wants"] == ["network-online.target"]
+    assert uploader_job["service"]["after"] == ["network-online.target"]
+    assert uploader_job["enabled"] == "{{ postgres_backup_remote_enabled }}"
+    assert maintenance_job["service"]["exec_start"] == "{{ postgres_backup_remote_script_path }} maintenance"
+    assert "inventory_hostname == postgres_backup_remote_maintenance_host" in maintenance["when"]
+    assert maintenance_job["service"]["wants"] == ["network-online.target"]
+    assert maintenance_job["service"]["after"] == ["network-online.target"]
+    assert maintenance_job["enabled"] == "{{ postgres_backup_remote_enabled }}"
+    assert "repository" not in str(uploader_job).lower()
+    assert "password" not in str(uploader_job).lower()
+    assert "secret" not in str(uploader_job).lower()
+
+    for job in (uploader_job, maintenance_job):
+        rendered = render_jinja(SYSTEMD_SERVICE_TEMPLATE, systemd_jobs_job=job)
+        assert "Wants=network-online.target" in rendered
+        assert "After=network-online.target" in rendered
+
+
+def test_manual_actions_and_check_mode_plans_preserve_operation_boundaries():
+    tasks = yaml.safe_load(MAIN_TASKS_PATH.read_text())
+    init = task_named(tasks, "Initialize PostgreSQL remote backup repository explicitly")
+    upload = task_named(tasks, "Run PostgreSQL remote backup uploader manually")
+    maintenance = task_named(tasks, "Run PostgreSQL remote backup maintenance manually")
+    check_upload = task_named(tasks, "Report PostgreSQL remote backup upload check-mode plan")
+    source = MAIN_TASKS_PATH.read_text()
+
+    assert "postgres_backup_remote_init" in " ".join(init["when"])
+    assert "inventory_hostname == postgres_backup_remote_maintenance_host" in init["when"]
+    assert "postgres_backup_remote_run" in " ".join(upload["when"])
+    assert "inventory_hostname == postgres_backup_remote_maintenance_host" not in upload["when"]
+    assert "inventory_hostname == postgres_backup_remote_maintenance_host" in maintenance["when"]
+    assert "not ansible_check_mode" in init["when"]
+    assert "not ansible_check_mode" in upload["when"]
+    assert "not ansible_check_mode" in maintenance["when"]
+    assert "ansible_check_mode" in check_upload["when"]
+    assert "would upload eligible completed PostgreSQL logical backups" in check_upload["ansible.builtin.debug"]["msg"]
+    assert "ansible.builtin.command" not in source
+
+
+def test_remote_tags_are_wired_through_playbook_skynet_and_docs():
+    playbook = PLAYBOOK_PATH.read_text()
+    skynet = SKYNET_TEMPLATE_PATH.read_text()
+    skynet_docs = SKYNET_DOC_PATH.read_text()
+    backup_docs = BACKUP_DOC_PATH.read_text()
+
+    for action in ("setup", "init", "run", "maintenance"):
+        tag = f"postgres_backup_remote_{action}"
+        command = f"backup-remote-{action}"
+        assert tag in playbook
+        assert tag in skynet
+        assert tag in skynet_docs
+        assert tag in backup_docs
+        assert command in skynet
+        assert command in skynet_docs
+
+
+def test_only_completed_verified_backups_are_uploaded_with_stable_metadata(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+    eligible = make_completed_backup(tmp_path, "20260811T030412Z")
+    make_completed_backup(tmp_path, ".staging-20260811T030412Z-123")
+    make_completed_backup(tmp_path, "invalid-name")
+    make_completed_backup(tmp_path, "20260812T030412Z", success=False)
+
+    result = run_remote(script, "upload")
+    log = restic_log(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (tmp_path / f"state/uploaded/{REPOSITORY_ID_A}/20260811T030412Z").is_file()
+    assert "backup\t--host\tpg-cluster\t--group-by\thost" in log
+    assert "--tag\tpostgres-logical-backup" in log
+    assert "--tag\tcluster=pg-cluster" in log
+    assert "--tag\tbackup-id=20260811T030412Z" in log
+    assert "--tag\tsource-member=pg95" in log
+    assert str(eligible) in log
+    assert ".staging-" not in next(line for line in log.splitlines() if "\tbackup\t" in line)
+    assert "invalid-name" not in log
+    metrics = (tmp_path / "textfile/postgres_logical_backup_remote.prom").read_text()
+    assert "postgres_backup_remote_last_run_success 1" in metrics
+    assert "postgres_backup_remote_last_uploaded_count 1" in metrics
+    assert "postgres_backup_remote_pending_count 0" in metrics
+    assert not list((tmp_path / "textfile").glob("*.tmp.*"))
+
+
+def test_checksum_failure_prevents_upload_marker_and_emits_failure_metrics(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+    make_completed_backup(tmp_path, "20260811T030412Z", valid_checksum=False)
+
+    result = run_remote(script, "upload")
+
+    assert result.returncode != 0
+    assert "Checksum verification failed for backup 20260811T030412Z" in result.stderr
+    assert "\tbackup\t" not in restic_log(tmp_path)
+    assert not (tmp_path / f"state/uploaded/{REPOSITORY_ID_A}/20260811T030412Z").exists()
+    metrics = (tmp_path / "textfile/postgres_logical_backup_remote.prom").read_text()
+    assert "postgres_backup_remote_last_run_success 0" in metrics
+    assert "postgres_backup_remote_pending_count 1" in metrics
+
+
+def test_failed_upload_remains_pending_and_retries_successfully(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+    make_completed_backup(tmp_path, "20260811T030412Z")
+    marker = tmp_path / f"state/uploaded/{REPOSITORY_ID_A}/20260811T030412Z"
+
+    failed = run_remote(script, "upload", restic_mode="backup-fail")
+    assert failed.returncode != 0
+    assert not marker.exists()
+
+    retried = run_remote(script, "upload")
+    assert retried.returncode == 0, retried.stdout + retried.stderr
+    assert marker.is_file()
+    assert restic_log(tmp_path).count("\tbackup\t") == 2
+
+
+def test_uploaded_marker_skips_backup_and_preserves_last_upload_timestamp(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+    make_completed_backup(tmp_path, "20260811T030412Z")
+    marker = tmp_path / f"state/uploaded/{REPOSITORY_ID_A}/20260811T030412Z"
+    marker.parent.mkdir()
+    marker.touch()
+    metrics_file = tmp_path / "textfile/postgres_logical_backup_remote.prom"
+    metrics_file.write_text("postgres_backup_remote_last_success_timestamp_seconds 123\n")
+
+    result = run_remote(script, "upload")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "\tbackup\t" not in restic_log(tmp_path)
+    metrics = metrics_file.read_text()
+    assert "postgres_backup_remote_last_success_timestamp_seconds 123" in metrics
+    assert "postgres_backup_remote_last_uploaded_count 0" in metrics
+    assert "postgres_backup_remote_pending_count 0" in metrics
+
+
+def test_same_restic_repository_marker_prevents_duplicate_upload(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+    make_completed_backup(tmp_path, "20260811T030412Z")
+    marker = tmp_path / f"state/uploaded/{REPOSITORY_ID_A}/20260811T030412Z"
+
+    first = run_remote(script, "upload", repository_id=REPOSITORY_ID_A)
+    second = run_remote(script, "upload", repository_id=REPOSITORY_ID_A)
+
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert marker.is_file()
+    assert marker.parent.stat().st_mode & 0o777 == 0o700
+    assert restic_log(tmp_path).count("\tcat\tconfig") == 2
+    assert restic_log(tmp_path).count("\tbackup\t") == 1
+
+
+def test_changing_restic_repository_id_reuploads_retained_local_backup_at_same_url(
+    tmp_path: Path,
+):
+    script = render_remote_runner(tmp_path)
+    make_completed_backup(tmp_path, "20260811T030412Z")
+    repository_file = tmp_path / "config/repository"
+    repository_value = repository_file.read_text()
+    marker_a = tmp_path / f"state/uploaded/{REPOSITORY_ID_A}/20260811T030412Z"
+    marker_b = tmp_path / f"state/uploaded/{REPOSITORY_ID_B}/20260811T030412Z"
+
+    first = run_remote(script, "upload", repository_id=REPOSITORY_ID_A)
+    second = run_remote(script, "upload", repository_id=REPOSITORY_ID_B)
+
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert repository_file.read_text() == repository_value
+    assert marker_a.is_file()
+    assert marker_b.is_file()
+    assert restic_log(tmp_path).count("\tcat\tconfig") == 2
+    assert restic_log(tmp_path).count("\tbackup\t") == 2
+
+
+def test_failed_upload_to_new_repository_preserves_only_old_repository_marker(
+    tmp_path: Path,
+):
+    script = render_remote_runner(tmp_path)
+    make_completed_backup(tmp_path, "20260811T030412Z")
+    marker_a = tmp_path / f"state/uploaded/{REPOSITORY_ID_A}/20260811T030412Z"
+    marker_b = tmp_path / f"state/uploaded/{REPOSITORY_ID_B}/20260811T030412Z"
+
+    first = run_remote(script, "upload", repository_id=REPOSITORY_ID_A)
+    failed = run_remote(
+        script,
+        "upload",
+        restic_mode="backup-fail",
+        repository_id=REPOSITORY_ID_B,
+    )
+
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert failed.returncode != 0
+    assert marker_a.is_file()
+    assert not marker_b.exists()
+    assert restic_log(tmp_path).count("\tbackup\t") == 2
+
+
+@pytest.mark.parametrize(
+    "restic_mode",
+    ["invalid-json", "missing-id", "empty-id", "unsafe-id"],
+)
+def test_invalid_restic_repository_identity_fails_before_backup(
+    tmp_path: Path,
+    restic_mode: str,
+):
+    script = render_remote_runner(tmp_path)
+    make_completed_backup(tmp_path, "20260811T030412Z")
+
+    result = run_remote(script, "upload", restic_mode=restic_mode)
+
+    assert result.returncode != 0
+    assert "Restic repository config" in result.stderr
+    assert "\tbackup\t" not in restic_log(tmp_path)
+    assert not list((tmp_path / "state/uploaded").iterdir())
+
+
+def test_overlap_lock_skips_cleanly_without_overwriting_metrics(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+    make_completed_backup(tmp_path, "20260811T030412Z")
+    metrics_file = tmp_path / "textfile/postgres_logical_backup_remote.prom"
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "FAKE_RESTIC_LOG": str(tmp_path / "restic.log"),
+            "FAKE_RESTIC_MODE": "sleep",
+        }
+    )
+    first = subprocess.Popen(
+        [str(script), "upload"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=environment,
+    )
+    try:
+        for _ in range(100):
+            if "\tbackup\t" in restic_log(tmp_path):
+                break
+            if first.poll() is not None:
+                break
+            time.sleep(0.02)
+        metrics_before_overlap = metrics_file.read_text()
+        overlap = run_remote(script, "upload")
+        metrics_after_overlap = metrics_file.read_text()
+        first_stdout, first_stderr = first.communicate(timeout=10)
+    finally:
+        if first.poll() is None:
+            first.terminate()
+            first.wait(timeout=5)
+
+    assert first.returncode == 0, first_stdout + first_stderr
+    assert overlap.returncode == 0, overlap.stdout + overlap.stderr
+    assert "POSTGRES_BACKUP_REMOTE_RESULT=SKIPPED_OVERLAP" in overlap.stdout
+    assert metrics_after_overlap == metrics_before_overlap
+    assert restic_log(tmp_path).count("\tbackup\t") == 1
+
+
+@pytest.mark.parametrize(
+    ("restic_mode", "expected_message"),
+    [
+        ("missing", "is not initialized; run the explicit init action"),
+        ("wrong-password", "rejected its password"),
+        ("backend-fail", "repository/backend access failed with exit code 20"),
+    ],
+)
+def test_upload_probe_failures_never_initialize_or_upload(
+    tmp_path: Path,
+    restic_mode: str,
+    expected_message: str,
+):
+    script = render_remote_runner(tmp_path)
+    make_completed_backup(tmp_path, "20260811T030412Z")
+
+    result = run_remote(script, "upload", restic_mode=restic_mode)
+    log = restic_log(tmp_path)
+
+    assert result.returncode != 0
+    assert expected_message in result.stderr
+    assert "\tcat\tconfig" in log
+    assert "\tinit" not in log
+    assert "\tbackup" not in log
+
+
+def test_repository_initialization_only_initializes_precisely_missing_repository(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+
+    initialized = run_remote(script, "init", restic_mode="missing")
+    assert initialized.returncode == 0, initialized.stdout + initialized.stderr
+    assert "POSTGRES_BACKUP_REMOTE_RESULT=INITIALIZED" in initialized.stdout
+    assert "\tcat\tconfig" in restic_log(tmp_path)
+    assert "\tinit" in restic_log(tmp_path)
+
+    (tmp_path / "restic.log").write_text("")
+    existing = run_remote(script, "init")
+    assert existing.returncode == 0, existing.stdout + existing.stderr
+    assert "POSTGRES_BACKUP_REMOTE_RESULT=ALREADY_INITIALIZED" in existing.stdout
+    assert "\tcat\tconfig" in restic_log(tmp_path)
+    assert "\tinit" not in restic_log(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("restic_mode", "expected_message"),
+    [
+        ("wrong-password", "rejected its password; refusing initialization"),
+        ("backend-fail", "repository/backend access failed with exit code 20; refusing initialization"),
+    ],
+)
+def test_explicit_init_refuses_wrong_password_and_backend_failures(
+    tmp_path: Path,
+    restic_mode: str,
+    expected_message: str,
+):
+    script = render_remote_runner(tmp_path)
+
+    result = run_remote(script, "init", restic_mode=restic_mode)
+    log = restic_log(tmp_path)
+
+    assert result.returncode != 0
+    assert expected_message in result.stderr
+    assert "\tcat\tconfig" in log
+    assert "\tinit" not in log
+
+
+def test_explicit_init_failure_is_loud_after_missing_repository_probe(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+
+    result = run_remote(script, "init", restic_mode="missing-init-fail")
+    log = restic_log(tmp_path)
+
+    assert result.returncode != 0
+    assert "\tcat\tconfig" in log
+    assert "\tinit" in log
+
+
+@pytest.mark.parametrize(
+    ("restic_mode", "expected_message"),
+    [
+        ("missing", "is not initialized; run the explicit init action"),
+        ("wrong-password", "rejected its password"),
+        ("backend-fail", "repository/backend access failed with exit code 20"),
+    ],
+)
+def test_maintenance_probe_failures_never_initialize_or_forget(
+    tmp_path: Path,
+    restic_mode: str,
+    expected_message: str,
+):
+    script = render_remote_runner(tmp_path)
+
+    result = run_remote(script, "maintenance", restic_mode=restic_mode)
+    log = restic_log(tmp_path)
+
+    assert result.returncode != 0
+    assert expected_message in result.stderr
+    assert "\tcat\tconfig" in log
+    assert "\tinit" not in log
+    assert "\tforget" not in log
+
+
+def test_maintenance_is_scoped_and_uses_configured_retention_without_upload(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+
+    result = run_remote(script, "maintenance")
+    log = restic_log(tmp_path)
+    forget = next(line for line in log.splitlines() if "\tforget\t" in line)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "--prune" in forget
+    assert "--host\tpg-cluster" in forget
+    assert "--tag\tpostgres-logical-backup" in forget
+    assert "--group-by\thost" in forget
+    assert "--keep-daily\t14" in forget
+    assert "--keep-weekly\t8" in forget
+    assert "--keep-monthly\t12" in forget
+    assert "\tbackup\t" not in log
+    assert "\tinit" not in log
+
+
+def test_maintenance_failure_is_loud(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+
+    result = run_remote(script, "maintenance", restic_mode="maintenance-fail")
+
+    assert result.returncode != 0
+    assert "maintenance operation failed" in result.stderr
+
+
+def test_additional_restic_options_are_rendered_as_array_arguments(tmp_path: Path):
+    script = render_remote_runner(tmp_path, options=["--option", "sftp.command=ssh -i /protected/key"])
+
+    result = run_remote(script, "init")
+    first_call = restic_log(tmp_path).splitlines()[0]
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "--option\tsftp.command=ssh -i /protected/key\t--retry-lock\t10m\tcat\tconfig" in first_call
+    assert "eval" not in script.read_text()
+
+
+def test_retry_lock_reaches_probe_backup_and_maintenance(tmp_path: Path):
+    script = render_remote_runner(tmp_path, retry_lock="10m")
+    make_completed_backup(tmp_path, "20260811T030412Z")
+
+    upload = run_remote(script, "upload")
+    assert upload.returncode == 0, upload.stdout + upload.stderr
+    upload_calls = restic_log(tmp_path).splitlines()
+    assert any("--retry-lock\t10m\tcat\tconfig" in call for call in upload_calls)
+    assert any("--retry-lock\t10m\tbackup" in call for call in upload_calls)
+
+    (tmp_path / "restic.log").write_text("")
+    maintenance = run_remote(script, "maintenance")
+    assert maintenance.returncode == 0, maintenance.stdout + maintenance.stderr
+    maintenance_calls = restic_log(tmp_path).splitlines()
+    assert any("--retry-lock\t10m\tcat\tconfig" in call for call in maintenance_calls)
+    assert any("--retry-lock\t10m\tforget" in call for call in maintenance_calls)
+
+
+def test_remote_runner_uses_atomic_metrics_and_state_without_touching_local_backups():
+    source = REMOTE_RUNNER_TEMPLATE_PATH.read_text()
+    upload_function = source.split("upload_backups()", maxsplit=1)[1].split("maintain_repository()", maxsplit=1)[0]
+
+    assert 'mktemp "${METRICS_FILE}.tmp.XXXXXX"' in source
+    assert 'mv -f -- "$metrics_tmp" "$METRICS_FILE"' in source
+    assert 'mktemp "$REPOSITORY_UPLOADED_DIR/.${backup_id}.XXXXXX"' in source
+    assert 'mv -f -- "$MARKER_TMP" "$marker"' in source
+    assert "rm -rf" not in source
+    assert "run_restic init" not in upload_function
+
+
+def test_remote_systemd_units_pass_systemd_analyze_verify(tmp_path: Path):
+    if shutil.which("systemd-analyze") is None:
+        pytest.skip("systemd-analyze is unavailable")
+    runner = tmp_path / "postgres-logical-backup-remote"
+    runner.write_text("#!/bin/sh\nexit 0\n")
+    runner.chmod(0o755)
+    job = {
+        "name": "postgres-logical-backup-remote",
+        "description": "Upload completed PostgreSQL logical backups to Restic",
+        "service": {
+            "type": "oneshot",
+            "exec_start": f"{runner} upload",
+            "user": "root",
+            "group": "root",
+            "working_directory": str(tmp_path),
+            "wants": ["network-online.target"],
+            "after": ["network-online.target"],
+            "nice": 10,
+            "io_scheduling_class": "best-effort",
+            "io_scheduling_priority": 7,
+        },
+        "timer": {
+            "on_calendar": "*-*-* 04:00:00",
+            "randomized_delay_sec": "30m",
+            "persistent": True,
+        },
+        "enabled": False,
+    }
+    service_path = tmp_path / "postgres-logical-backup-remote.service"
+    timer_path = tmp_path / "postgres-logical-backup-remote.timer"
+    service_path.write_text(render_jinja(SYSTEMD_SERVICE_TEMPLATE, systemd_jobs_job=job))
+    timer_path.write_text(render_jinja(SYSTEMD_TIMER_TEMPLATE, systemd_jobs_job=job))
+
+    result = subprocess.run(
+        ["systemd-analyze", "verify", str(service_path), str(timer_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Wants=network-online.target" in service_path.read_text()
+    assert "After=network-online.target" in service_path.read_text()
+
+
+def test_rendered_remote_runner_passes_bash_syntax(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+
+    result = subprocess.run(["bash", "-n", str(script)], check=False, capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(shutil.which("shellcheck") is None, reason="shellcheck is unavailable")
+def test_rendered_remote_runner_passes_shellcheck(tmp_path: Path):
+    script = render_remote_runner(tmp_path)
+
+    result = subprocess.run(["shellcheck", str(script)], check=False, capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/unit/test_postgres_remote_backup.py
+++ b/tests/unit/test_postgres_remote_backup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 import pwd
+import re
 import shlex
 import shutil
 import subprocess
@@ -12,6 +13,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from ansible.plugins.test.core import version_compare
 from jinja2 import Environment, StrictUndefined
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -59,6 +61,16 @@ def render_jinja(path: Path, **variables) -> str:
     )
     environment.filters["quote"] = lambda value: shlex.quote(str(value))
     return environment.from_string(path.read_text()).render(**variables)
+
+
+def render_value(value: str, **variables):
+    environment = Environment(undefined=StrictUndefined)
+    return yaml.safe_load(environment.from_string(value).render(**variables))
+
+
+def restic_version_is_supported(output: str) -> bool:
+    match = re.match(r"^restic ([0-9]+\.[0-9]+\.[0-9]+)(?:[-+~][^ ]+)?(?: |$)", output)
+    return match is not None and version_compare(match.group(1), "0.17.1", ">=")
 
 
 def render_remote_runner(
@@ -378,6 +390,41 @@ def test_restic_install_and_runner_are_scoped_to_managed_postgres_hosts():
     assert "restic" not in LOCAL_RUNNER_TEMPLATE_PATH.read_text().lower()
 
 
+@pytest.mark.parametrize(
+    ("output", "supported"),
+    [
+        ("restic 0.16.5 compiled with go1.22", False),
+        ("restic 0.17.0 compiled with go1.23", False),
+        ("restic 0.17.1 compiled with go1.23", True),
+        ("restic 0.17.1+ds compiled with go1.23", True),
+        ("restic 0.18.2 compiled with go1.24", True),
+        ("restic 1.0.0 compiled with go1.25", True),
+    ],
+)
+def test_restic_minimum_version_contract(output: str, supported: bool):
+    assert restic_version_is_supported(output) is supported
+
+
+def test_restic_version_is_checked_after_install_and_before_configuration():
+    tasks = yaml.safe_load(REMOTE_SETUP_TASKS_PATH.read_text())
+    task_names = [task.get("name") for task in tasks]
+    install_name = "Remote logical backup | Install Restic package"
+    query_name = "Remote logical backup | Query installed Restic version"
+    require_name = "Remote logical backup | Require supported Restic version"
+    configure_name = "Remote logical backup | Create protected configuration directory"
+    query = task_named(tasks, query_name)
+    requirement = task_named(tasks, require_name)
+
+    assert task_names.index(install_name) < task_names.index(query_name) < task_names.index(require_name)
+    assert task_names.index(require_name) < task_names.index(configure_name)
+    assert query["ansible.builtin.command"]["argv"] == ["{{ postgres_backup_remote_restic_path }}", "version"]
+    assert query["changed_when"] is False
+    assert query["when"] == ["postgres_backup_remote_manage", "not ansible_check_mode"]
+    assert "version('0.17.1', '>=')" in " ".join(requirement["ansible.builtin.assert"]["that"])
+    assert "Restic 0.17.1 or newer" in requirement["ansible.builtin.assert"]["fail_msg"]
+    assert "Minimum supported Restic version is 0.17.1" in BACKUP_DOC_PATH.read_text()
+
+
 def test_infisical_lookups_use_controller_contract_and_hide_secret_material():
     tasks = yaml.safe_load(REMOTE_SETUP_TASKS_PATH.read_text())
     lookup_names = (
@@ -640,7 +687,7 @@ def test_backend_environment_template_quotes_values_as_literal_assignments(tmp_p
     assert not marker.exists()
 
 
-def test_systemd_jobs_run_as_root_on_all_nodes_and_maintenance_is_single_host():
+def test_systemd_jobs_converge_lifecycle_and_maintenance_host_transitions():
     tasks = yaml.safe_load(REMOTE_SETUP_TASKS_PATH.read_text())
     uploader = task_named(tasks, "Remote logical backup | Manage uploader systemd job")
     maintenance = task_named(tasks, "Remote logical backup | Manage maintenance systemd job")
@@ -648,18 +695,64 @@ def test_systemd_jobs_run_as_root_on_all_nodes_and_maintenance_is_single_host():
     maintenance_job = maintenance["vars"]["systemd_jobs"][0]
 
     assert uploader["ansible.builtin.include_role"]["name"] == "systemd_jobs"
-    assert uploader["when"] == "postgres_backup_remote_manage"
+    assert "when" not in uploader
     assert uploader_job["service"]["exec_start"] == "{{ postgres_backup_remote_script_path }} upload"
     assert uploader_job["service"]["user"] == "root"
     assert uploader_job["service"]["group"] == "root"
     assert uploader_job["service"]["wants"] == ["network-online.target"]
     assert uploader_job["service"]["after"] == ["network-online.target"]
-    assert uploader_job["enabled"] == "{{ postgres_backup_remote_enabled }}"
+    assert (
+        render_value(
+            uploader_job["enabled"],
+            postgres_backup_remote_manage=True,
+            postgres_backup_remote_enabled=True,
+        )
+        is True
+    )
+    assert (
+        render_value(
+            uploader_job["enabled"],
+            postgres_backup_remote_manage=False,
+            postgres_backup_remote_enabled=False,
+        )
+        is False
+    )
     assert maintenance_job["service"]["exec_start"] == "{{ postgres_backup_remote_script_path }} maintenance"
-    assert "inventory_hostname == postgres_backup_remote_maintenance_host" in maintenance["when"]
+    assert "when" not in maintenance
     assert maintenance_job["service"]["wants"] == ["network-online.target"]
     assert maintenance_job["service"]["after"] == ["network-online.target"]
-    assert maintenance_job["enabled"] == "{{ postgres_backup_remote_enabled }}"
+    first_designation = {
+        host: render_value(
+            maintenance_job["enabled"],
+            postgres_backup_remote_manage=True,
+            postgres_backup_remote_enabled=True,
+            inventory_hostname=host,
+            postgres_backup_remote_maintenance_host="pg95",
+        )
+        for host in ("pg95", "pg96")
+    }
+    migrated_designation = {
+        host: render_value(
+            maintenance_job["enabled"],
+            postgres_backup_remote_manage=True,
+            postgres_backup_remote_enabled=True,
+            inventory_hostname=host,
+            postgres_backup_remote_maintenance_host="pg96",
+        )
+        for host in ("pg95", "pg96")
+    }
+    assert first_designation == {"pg95": True, "pg96": False}
+    assert migrated_designation == {"pg95": False, "pg96": True}
+    assert (
+        render_value(
+            maintenance_job["enabled"],
+            postgres_backup_remote_manage=False,
+            postgres_backup_remote_enabled=False,
+            inventory_hostname="pg95",
+            postgres_backup_remote_maintenance_host="pg95",
+        )
+        is False
+    )
     assert "repository" not in str(uploader_job).lower()
     assert "password" not in str(uploader_job).lower()
     assert "secret" not in str(uploader_job).lower()

--- a/tests/unit/test_postgres_restore_validation.py
+++ b/tests/unit/test_postgres_restore_validation.py
@@ -49,6 +49,11 @@ def render_jinja(path: Path, **variables) -> str:
     return environment.from_string(path.read_text()).render(**variables)
 
 
+def render_value(value: str, **variables):
+    environment = Environment(undefined=StrictUndefined)
+    return yaml.safe_load(environment.from_string(value).render(**variables))
+
+
 def write_executable(path: Path, source: str) -> None:
     path.write_text(source)
     path.chmod(0o755)
@@ -133,6 +138,8 @@ def render_validator(
     artifact: Path | None = None,
     max_age_hours: int = 48,
     min_free_bytes: int = 0,
+    encoding: str = "UTF8",
+    locale: str = "C.UTF-8",
 ) -> Path:
     backup_root = tmp_path / "backups"
     work_root = tmp_path / "work"
@@ -278,7 +285,7 @@ set -euo pipefail
 printf 'PG_RESTORE' >> "$FAKE_COMMAND_LOG"
 printf '\t%s' "$@" >> "$FAKE_COMMAND_LOG"
 printf '\n' >> "$FAKE_COMMAND_LOG"
-if [[ -n "${FAKE_PG_RESTORE_SLEEP:-}" ]]; then sleep "$FAKE_PG_RESTORE_SLEEP"; fi
+if [[ -n "${FAKE_PG_RESTORE_SLEEP:-}" ]]; then /bin/sleep "$FAKE_PG_RESTORE_SLEEP"; fi
 [[ "${FAKE_PG_RESTORE_FAIL:-0}" != 1 ]]
 """,
     )
@@ -347,6 +354,8 @@ done
         postgres_backup_restore_validation_port=55432,
         postgres_backup_restore_validation_max_snapshot_age_hours=max_age_hours,
         postgres_backup_restore_validation_min_free_bytes=min_free_bytes,
+        postgres_backup_restore_validation_encoding=encoding,
+        postgres_backup_restore_validation_locale=locale,
         postgres_backup_restore_validation_runuser_path=str(fake_bin / "runuser"),
         postgres_backup_remote_options=[],
     )
@@ -431,6 +440,8 @@ def test_restore_validation_defaults_are_disabled_and_reuse_remote_contract():
     assert defaults["postgres_backup_restore_validation_timer_on_calendar"] == "Sun *-*-* 07:00:00"
     assert defaults["postgres_backup_restore_validation_max_snapshot_age_hours"] == 48
     assert defaults["postgres_backup_restore_validation_min_free_bytes"] == 5368709120
+    assert defaults["postgres_backup_restore_validation_encoding"] == "UTF8"
+    assert defaults["postgres_backup_restore_validation_locale"] == "C.UTF-8"
     assert not any(key.startswith("postgres_backup_restore_validation_") for key in group_vars)
 
 
@@ -462,19 +473,50 @@ def test_validation_host_and_remote_capability_are_required_before_mutation():
     assert 'install -d -o postgres -g postgres -m 0700 "$CLUSTER_DIR" "$PGDATA" "$SOCKET_DIR"' in runner
 
 
-def test_systemd_job_exists_only_on_designated_host_and_uses_network_online():
+def test_systemd_job_converges_validation_host_migration_and_uses_network_online():
     tasks = yaml.safe_load(SETUP_TASKS_PATH.read_text())
     include = task_named(tasks, "Backup restore validation | Manage systemd job")
     job = include["vars"]["systemd_jobs"][0]
 
     assert include["ansible.builtin.include_role"]["name"] == "systemd_jobs"
-    assert "inventory_hostname == postgres_backup_restore_validation_host" in include["when"]
+    assert "when" not in include
     assert job["service"]["user"] == "root"
     assert job["service"]["group"] == "root"
     assert job["service"]["wants"] == ["network-online.target"]
     assert job["service"]["after"] == ["network-online.target"]
     assert job["timer"]["on_calendar"] == "{{ postgres_backup_restore_validation_timer_on_calendar }}"
-    assert job["enabled"] == "{{ postgres_backup_restore_validation_enabled }}"
+    first_designation = {
+        host: render_value(
+            job["enabled"],
+            postgres_backup_restore_validation_manage=True,
+            postgres_backup_restore_validation_enabled=True,
+            inventory_hostname=host,
+            postgres_backup_restore_validation_host="pg95",
+        )
+        for host in ("pg95", "pg96")
+    }
+    migrated_designation = {
+        host: render_value(
+            job["enabled"],
+            postgres_backup_restore_validation_manage=True,
+            postgres_backup_restore_validation_enabled=True,
+            inventory_hostname=host,
+            postgres_backup_restore_validation_host="pg96",
+        )
+        for host in ("pg95", "pg96")
+    }
+    assert first_designation == {"pg95": True, "pg96": False}
+    assert migrated_designation == {"pg95": False, "pg96": True}
+    assert (
+        render_value(
+            job["enabled"],
+            postgres_backup_restore_validation_manage=False,
+            postgres_backup_restore_validation_enabled=False,
+            inventory_hostname="pg95",
+            postgres_backup_restore_validation_host="pg95",
+        )
+        is False
+    )
     rendered = render_jinja(SYSTEMD_SERVICE_TEMPLATE, systemd_jobs_job=job)
     assert "Wants=network-online.target" in rendered
     assert "After=network-online.target" in rendered
@@ -585,6 +627,8 @@ def test_successful_validation_restores_every_database_sequentially_and_emits_me
     assert "PG_CTL\t" in joined and "\tstart" in joined and "\tstop" in joined
     assert "--auth-local=trust" in joined
     assert "--auth-host=reject" in joined
+    assert "--encoding=UTF8" in joined
+    assert "--locale=C.UTF-8" in joined
     assert "--template=template0" in joined
     for line in [line for line in log if line.startswith(("CREATEDB\t", "DROPDB\t"))]:
         assert line.endswith("\tpostgres_restore_validation")
@@ -634,6 +678,45 @@ def test_newest_valid_matching_snapshot_is_selected_and_unrelated_snapshot_is_ig
     assert f"{SNAPSHOT_ID_B}:{backup_root}/{BACKUP_ID_B}" in restore
     assert SNAPSHOT_ID_A not in restore
     assert "d" * 64 not in restore
+
+
+def test_nanosecond_snapshot_timestamp_with_offset_is_parsed_and_ordered(tmp_path: Path):
+    backup_root = tmp_path / "backups"
+    earlier = snapshot(
+        backup_root,
+        snapshot_id=SNAPSHOT_ID_A,
+        backup_id=BACKUP_ID_A,
+    )
+    earlier["time"] = "2026-08-11T01:02:03.123456788Z"
+    newest = snapshot(
+        backup_root,
+        snapshot_id=SNAPSHOT_ID_B,
+        backup_id=BACKUP_ID_B,
+    )
+    newest["time"] = "2026-08-11T12:02:03.123456789+10:00"
+    script = render_validator(
+        tmp_path,
+        snapshots=[earlier, newest],
+        max_age_hours=10**6,
+    )
+
+    result = run_validator(script)
+    restore = next(line for line in command_log(tmp_path) if "\trestore\t" in line)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"{SNAPSHOT_ID_B}:{backup_root}/{BACKUP_ID_B}" in restore
+    assert "2026-08-11T12:02:03.123456789+10:00" in (tmp_path / "snapshots.json").read_text()
+
+
+def test_validation_encoding_and_locale_overrides_reach_initdb(tmp_path: Path):
+    script = render_validator(tmp_path, encoding="LATIN1", locale="C")
+
+    result = run_validator(script)
+    initdb_call = next(line for line in command_log(tmp_path) if line.startswith("INITDB\t"))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "\t--encoding=LATIN1" in initdb_call
+    assert "\t--locale=C" in initdb_call
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_postgres_restore_validation.py
+++ b/tests/unit/test_postgres_restore_validation.py
@@ -1,0 +1,1125 @@
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+from jinja2 import Environment, StrictUndefined
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROLE_PATH = REPO_ROOT / "ansible/roles/postgres"
+DEFAULTS_PATH = ROLE_PATH / "defaults/main.yml"
+MAIN_TASKS_PATH = ROLE_PATH / "tasks/main.yml"
+SETUP_TASKS_PATH = ROLE_PATH / "tasks/sub_tasks/backup_restore_validation_setup.yml"
+ACTION_TASKS_PATH = ROLE_PATH / "tasks/sub_tasks/backup_restore_validation_action.yml"
+RUNNER_TEMPLATE_PATH = ROLE_PATH / "templates/postgres-logical-backup-restore-validate.sh.j2"
+GROUP_VARS_PATH = REPO_ROOT / "ansible/group_vars/tags_postgres.yml"
+PLAYBOOK_PATH = REPO_ROOT / "ansible/playbook.yml"
+SKYNET_TEMPLATE_PATH = REPO_ROOT / "ansible/roles/ubuntu/templates/skynet.j2"
+SKYNET_DOC_PATH = REPO_ROOT / "docs/cheat_sheets/skynet.md"
+BACKUP_DOC_PATH = REPO_ROOT / "docs/postgresql-logical-backups.md"
+SYSTEMD_SERVICE_TEMPLATE = REPO_ROOT / "ansible/roles/systemd_jobs/templates/systemd-job.service.j2"
+SYSTEMD_TIMER_TEMPLATE = REPO_ROOT / "ansible/roles/systemd_jobs/templates/systemd-job.timer.j2"
+SNAPSHOT_ID_A = "a" * 64
+SNAPSHOT_ID_B = "b" * 64
+BACKUP_ID_A = "20260811T030412Z"
+BACKUP_ID_B = "20260812T030412Z"
+
+
+def task_named(tasks: list[dict], name: str) -> dict:
+    return next(task for task in tasks if task.get("name") == name)
+
+
+def render_jinja(path: Path, **variables) -> str:
+    environment = Environment(
+        trim_blocks=True,
+        lstrip_blocks=True,
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+    environment.filters["quote"] = lambda value: shlex.quote(str(value))
+    return environment.from_string(path.read_text()).render(**variables)
+
+
+def write_executable(path: Path, source: str) -> None:
+    path.write_text(source)
+    path.chmod(0o755)
+
+
+def snapshot(
+    backup_root: Path,
+    *,
+    snapshot_id: str = SNAPSHOT_ID_A,
+    backup_id: str = BACKUP_ID_A,
+    snapshot_time: datetime.datetime | None = None,
+    hostname: str = "pg-cluster",
+    tags: list[str] | None = None,
+    paths: list[str] | None = None,
+) -> dict:
+    timestamp = snapshot_time or (datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=10))
+    return {
+        "time": timestamp.isoformat().replace("+00:00", "Z"),
+        "tree": "c" * 64,
+        "paths": paths if paths is not None else [f"{backup_root}/{backup_id}"],
+        "hostname": hostname,
+        "username": "root",
+        "uid": 0,
+        "gid": 0,
+        "tags": (
+            tags
+            if tags is not None
+            else [
+                "postgres-logical-backup",
+                "cluster=pg-cluster",
+                f"backup-id={backup_id}",
+                "source-member=pg95",
+            ]
+        ),
+        "id": snapshot_id,
+    }
+
+
+def make_artifact(
+    tmp_path: Path,
+    *,
+    databases: tuple[str, ...] = ("appdb", "postgres"),
+) -> Path:
+    artifact = tmp_path / "artifact-source"
+    dumps = artifact / "databases"
+    dumps.mkdir(parents=True)
+    for database in databases:
+        (dumps / f"{database}.dump").write_text(f"custom archive for {database}\n")
+    (artifact / "globals.sql").write_text("-- production globals retained but not executed\n")
+    manifest_lines = [
+        "start_utc=2026-08-11T03:04:12Z",
+        "completion_utc=2026-08-11T03:05:12Z",
+        "hostname=pg95",
+        "patroni_member=pg95",
+        "postgres_server_version=18.0-test",
+        "backup_format=custom",
+        f"database_count={len(databases)}",
+        "globals_captured=yes",
+        "archive_verification=pg_restore_list_passed",
+        *(f"database={database}\tdump=databases/{database}.dump" for database in databases),
+    ]
+    (artifact / "manifest.txt").write_text("\n".join(manifest_lines) + "\n")
+    rewrite_checksums(artifact)
+    (artifact / "SUCCESS").touch()
+    return artifact
+
+
+def rewrite_checksums(artifact: Path) -> None:
+    payloads = sorted((artifact / "databases").glob("*.dump"))
+    payloads.extend((artifact / "globals.sql", artifact / "manifest.txt"))
+    lines = []
+    for payload in payloads:
+        digest = hashlib.sha256(payload.read_bytes()).hexdigest()
+        lines.append(f"{digest}  {payload.relative_to(artifact).as_posix()}")
+    (artifact / "SHA256SUMS").write_text("\n".join(lines) + "\n")
+
+
+def render_validator(
+    tmp_path: Path,
+    *,
+    snapshots: list[dict] | None = None,
+    artifact: Path | None = None,
+    max_age_hours: int = 48,
+    min_free_bytes: int = 0,
+) -> Path:
+    backup_root = tmp_path / "backups"
+    work_root = tmp_path / "work"
+    config_dir = tmp_path / "config"
+    metrics_file = tmp_path / "textfile/postgres_logical_backup_restore_validation.prom"
+    fake_bin = tmp_path / "fake-bin"
+    fake_proc = tmp_path / "proc"
+    runtime_state = tmp_path / "runtime-state"
+    for directory in (
+        backup_root,
+        work_root,
+        config_dir,
+        metrics_file.parent,
+        fake_bin,
+        fake_proc,
+        runtime_state,
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    (config_dir / "repository").write_text("local:test-repository\n")
+    (config_dir / "password").write_text("TEST_REPOSITORY_PASSWORD\n")
+    (config_dir / "backend.env").write_text("")
+    metrics_file.write_text("")
+    artifact = artifact or make_artifact(tmp_path)
+    snapshots_file = tmp_path / "snapshots.json"
+    snapshots_file.write_text(json.dumps(snapshots or [snapshot(backup_root)]))
+
+    write_executable(
+        fake_bin / "restic",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'RESTIC' >> "$FAKE_COMMAND_LOG"
+printf '\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\n' >> "$FAKE_COMMAND_LOG"
+command=''
+previous=''
+for argument in "$@"; do
+  if [[ "$previous" == cat && "$argument" == config ]]; then command='cat-config'; break; fi
+  case "$argument" in snapshots|restore) command="$argument"; break ;; esac
+  previous="$argument"
+done
+case "$command:${FAKE_RESTIC_MODE:-available}" in
+  cat-config:missing) exit 10 ;;
+  cat-config:wrong-password) exit 12 ;;
+  cat-config:backend-fail) exit 20 ;;
+  cat-config:*) printf '{"version":2,"id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}\n' ;;
+  snapshots:snapshots-fail) exit 21 ;;
+  snapshots:*) cat "$FAKE_SNAPSHOTS_FILE" ;;
+  restore:restore-fail) exit 22 ;;
+  restore:*)
+    target=''
+    previous=''
+    for argument in "$@"; do
+      if [[ "$previous" == --target ]]; then target="$argument"; break; fi
+      previous="$argument"
+    done
+    [[ -n "$target" ]]
+    cp -a "$FAKE_ARTIFACT_SOURCE/." "$target/"
+    ;;
+esac
+""",
+    )
+    write_executable(
+        fake_bin / "runuser",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'RUNUSER' >> "$FAKE_COMMAND_LOG"
+printf '\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\n' >> "$FAKE_COMMAND_LOG"
+[[ "$1" == -u && "$2" == postgres && "$3" == -- ]]
+shift 3
+exec "$@"
+""",
+    )
+    write_executable(
+        fake_bin / "initdb",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'INITDB' >> "$FAKE_COMMAND_LOG"
+printf '\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\n' >> "$FAKE_COMMAND_LOG"
+pgdata=''
+previous=''
+for argument in "$@"; do
+  if [[ "$previous" == -D ]]; then pgdata="$argument"; fi
+  previous="$argument"
+done
+[[ -n "$pgdata" ]]
+[[ "${FAKE_INITDB_FAIL:-0}" != 1 ]]
+: > "$pgdata/postgresql.conf"
+""",
+    )
+    write_executable(
+        fake_bin / "pg_ctl",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'PG_CTL' >> "$FAKE_COMMAND_LOG"
+printf '\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\n' >> "$FAKE_COMMAND_LOG"
+pgdata=''
+previous=''
+for argument in "$@"; do
+  if [[ "$previous" == -D ]]; then pgdata="$argument"; fi
+  previous="$argument"
+done
+[[ -n "$pgdata" ]]
+case "$*" in
+  *" start")
+    [[ "${FAKE_PG_CTL_START_FAIL:-0}" != 1 ]]
+    printf '%s\n' "$pgdata" > "$FAKE_RUNTIME_STATE/pgdata"
+    sed -n "s/^unix_socket_directories = '\\(.*\\)'$/\\1/p" "$pgdata/postgresql.conf" > "$FAKE_RUNTIME_STATE/socket"
+    sed -n 's/^port = //p' "$pgdata/postgresql.conf" > "$FAKE_RUNTIME_STATE/port"
+    touch "$pgdata/postmaster.pid"
+    ;;
+  *" stop")
+    [[ "${FAKE_PG_CTL_STOP_FAIL:-0}" != 1 ]]
+    if [[ -s "$pgdata/postmaster.pid" ]]; then
+      IFS= read -r stopped_pid < "$pgdata/postmaster.pid"
+      if [[ "$stopped_pid" =~ ^[1-9][0-9]*$ ]]; then
+        rm -rf -- "$FAKE_PROC_ROOT/$stopped_pid"
+      fi
+    fi
+    rm -f "$pgdata/postmaster.pid"
+    ;;
+  *) exit 2 ;;
+esac
+""",
+    )
+    for command in ("createdb", "dropdb"):
+        write_executable(
+            fake_bin / command,
+            f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '{command.upper()}' >> "$FAKE_COMMAND_LOG"
+printf '\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\n' >> "$FAKE_COMMAND_LOG"
+""",
+        )
+    write_executable(
+        fake_bin / "pg_restore",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'PG_RESTORE' >> "$FAKE_COMMAND_LOG"
+printf '\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\n' >> "$FAKE_COMMAND_LOG"
+if [[ -n "${FAKE_PG_RESTORE_SLEEP:-}" ]]; then sleep "$FAKE_PG_RESTORE_SLEEP"; fi
+[[ "${FAKE_PG_RESTORE_FAIL:-0}" != 1 ]]
+""",
+    )
+    write_executable(
+        fake_bin / "psql",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'PSQL' >> "$FAKE_COMMAND_LOG"
+printf '\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\n' >> "$FAKE_COMMAND_LOG"
+query=''
+for argument in "$@"; do
+  case "$argument" in --command=*) query="${argument#*=}" ;; esac
+done
+case "$query" in
+  "SHOW data_directory;")
+    if [[ "${FAKE_PSQL_MODE:-safe}" == wrong-data ]]; then printf '/var/lib/postgresql/18/main\n'; else cat "$FAKE_RUNTIME_STATE/pgdata"; fi
+    ;;
+  "SHOW listen_addresses;")
+    if [[ "${FAKE_PSQL_MODE:-safe}" == tcp ]]; then printf '127.0.0.1\n'; else printf '\n'; fi
+    ;;
+  "SHOW unix_socket_directories;")
+    if [[ "${FAKE_PSQL_MODE:-safe}" == wrong-socket ]]; then printf '/var/run/postgresql\n'; else cat "$FAKE_RUNTIME_STATE/socket"; fi
+    ;;
+  "SHOW port;")
+    if [[ "${FAKE_PSQL_MODE:-safe}" == wrong-port ]]; then printf '5432\n'; else cat "$FAKE_RUNTIME_STATE/port"; fi
+    ;;
+  "SELECT 1;"*)
+    [[ "${FAKE_PSQL_MODE:-safe}" != sql-fail ]]
+    printf '1\n0\n'
+    ;;
+  *) exit 3 ;;
+esac
+""",
+    )
+    write_executable(
+        fake_bin / "install",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'INSTALL' >> "$FAKE_COMMAND_LOG"
+printf '\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\n' >> "$FAKE_COMMAND_LOG"
+for argument in "$@"; do
+  case "$argument" in /*) mkdir -p "$argument" ;; esac
+done
+""",
+    )
+    write_executable(fake_bin / "chown", "#!/usr/bin/env bash\nexit 0\n")
+    write_executable(fake_bin / "id", "#!/usr/bin/env bash\nprintf '999\\n'\n")
+    write_executable(fake_bin / "postgres", "#!/usr/bin/env bash\nexit 0\n")
+    write_executable(fake_bin / "sleep", "#!/usr/bin/env bash\nexit 0\n")
+
+    script = render_jinja(
+        RUNNER_TEMPLATE_PATH,
+        postgres_backup_root=str(backup_root),
+        postgres_backup_restore_validation_work_root=str(work_root),
+        postgres_backup_restore_validation_metrics_file=str(metrics_file),
+        postgres_backup_remote_restic_path=str(fake_bin / "restic"),
+        postgres_backup_remote_repository_file=str(config_dir / "repository"),
+        postgres_backup_remote_password_file=str(config_dir / "password"),
+        postgres_backup_remote_environment_file=str(config_dir / "backend.env"),
+        postgres_backup_remote_snapshot_host="pg-cluster",
+        postgres_patroni_scope="pg-cluster",
+        postgres_patroni_bin_dir=str(fake_bin),
+        postgres_backup_remote_retry_lock="10m",
+        postgres_backup_restore_validation_port=55432,
+        postgres_backup_restore_validation_max_snapshot_age_hours=max_age_hours,
+        postgres_backup_restore_validation_min_free_bytes=min_free_bytes,
+        postgres_backup_restore_validation_runuser_path=str(fake_bin / "runuser"),
+        postgres_backup_remote_options=[],
+    )
+    script_path = tmp_path / "postgres-logical-backup-restore-validate"
+    write_executable(script_path, script)
+    environment = {
+        "FAKE_COMMAND_LOG": str(tmp_path / "commands.log"),
+        "FAKE_SNAPSHOTS_FILE": str(snapshots_file),
+        "FAKE_ARTIFACT_SOURCE": str(artifact),
+        "FAKE_RUNTIME_STATE": str(runtime_state),
+        "FAKE_PROC_ROOT": str(fake_proc),
+        "POSTGRES_BACKUP_RESTORE_VALIDATION_PROC_ROOT": str(fake_proc),
+    }
+    (tmp_path / "environment.json").write_text(json.dumps(environment))
+    return script_path
+
+
+def run_validator(
+    script: Path,
+    **environment_overrides: str,
+) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment.update(json.loads((script.parent / "environment.json").read_text()))
+    environment.update(environment_overrides)
+    return subprocess.run(
+        [str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+
+def command_log(tmp_path: Path) -> list[str]:
+    path = tmp_path / "commands.log"
+    return path.read_text().splitlines() if path.exists() else []
+
+
+def metrics(tmp_path: Path) -> str:
+    return (tmp_path / "textfile/postgres_logical_backup_restore_validation.prom").read_text()
+
+
+def make_stale_workspace(
+    tmp_path: Path,
+    *,
+    pid: str | None = None,
+    recorded_pgdata: str | None = None,
+) -> tuple[Path, Path]:
+    stale = tmp_path / "work/run-20260811T030412Z-123456-Ab12Cd"
+    stale_pgdata = stale / "cluster/data"
+    stale_pgdata.mkdir(parents=True)
+    if pid is not None:
+        lines = [pid]
+        if recorded_pgdata is not None:
+            lines.append(recorded_pgdata)
+        (stale_pgdata / "postmaster.pid").write_text("\n".join(lines) + "\n")
+    return stale, stale_pgdata
+
+
+def make_fake_process(
+    tmp_path: Path,
+    *,
+    pid: str,
+    executable: str,
+    arguments: list[str],
+    uid: int = 999,
+) -> None:
+    process_dir = tmp_path / "proc" / pid
+    process_dir.mkdir(parents=True)
+    (process_dir / "status").write_text(f"Name:\t{executable}\nUid:\t{uid}\t{uid}\t{uid}\t{uid}\n")
+    (process_dir / "exe").symlink_to(tmp_path / "fake-bin" / executable)
+    (process_dir / "cmdline").write_bytes(b"\0".join(argument.encode() for argument in arguments) + b"\0")
+
+
+def test_restore_validation_defaults_are_disabled_and_reuse_remote_contract():
+    defaults = yaml.safe_load(DEFAULTS_PATH.read_text())
+    group_vars = yaml.safe_load(GROUP_VARS_PATH.read_text())
+
+    assert defaults["postgres_backup_restore_validation_manage"] is False
+    assert defaults["postgres_backup_restore_validation_enabled"] is False
+    assert defaults["postgres_backup_restore_validation_host"] == "{{ postgres_backup_remote_maintenance_host }}"
+    assert defaults["postgres_backup_restore_validation_timer_on_calendar"] == "Sun *-*-* 07:00:00"
+    assert defaults["postgres_backup_restore_validation_max_snapshot_age_hours"] == 48
+    assert defaults["postgres_backup_restore_validation_min_free_bytes"] == 5368709120
+    assert not any(key.startswith("postgres_backup_restore_validation_") for key in group_vars)
+
+
+def test_validation_host_and_remote_capability_are_required_before_mutation():
+    tasks = yaml.safe_load(SETUP_TASKS_PATH.read_text())
+    validation = task_named(tasks, "Backup restore validation | Validate configuration")
+    work_root = task_named(tasks, "Backup restore validation | Create protected work root")
+    conditions = " ".join(validation["ansible.builtin.assert"]["that"])
+
+    assert "groups['tags_postgres'] | default([])" in conditions
+    assert "postgres_backup_remote_manage" in conditions
+    assert "postgres_backup_remote_repository | trim | length > 0" in conditions
+    assert "not postgres_backup_restore_validation_enabled or postgres_backup_restore_validation_manage" in conditions
+    assert "postgres_backup_root | regex_escape" in conditions
+    assert work_root["when"] == [
+        "postgres_backup_restore_validation_manage",
+        "inventory_hostname == postgres_backup_restore_validation_host",
+    ]
+    assert work_root["ansible.builtin.file"]["owner"] == "root"
+    assert work_root["ansible.builtin.file"]["group"] == "postgres"
+    assert work_root["ansible.builtin.file"]["mode"] == "0710"
+    assert (work_root["ansible.builtin.file"]["group"], work_root["ansible.builtin.file"]["mode"]) != (
+        "root",
+        "0700",
+    )
+    runner = RUNNER_TEMPLATE_PATH.read_text()
+    assert 'chown root:postgres "$RUN_DIR"' in runner
+    assert 'chmod 0710 "$RUN_DIR"' in runner
+    assert 'install -d -o postgres -g postgres -m 0700 "$CLUSTER_DIR" "$PGDATA" "$SOCKET_DIR"' in runner
+
+
+def test_systemd_job_exists_only_on_designated_host_and_uses_network_online():
+    tasks = yaml.safe_load(SETUP_TASKS_PATH.read_text())
+    include = task_named(tasks, "Backup restore validation | Manage systemd job")
+    job = include["vars"]["systemd_jobs"][0]
+
+    assert include["ansible.builtin.include_role"]["name"] == "systemd_jobs"
+    assert "inventory_hostname == postgres_backup_restore_validation_host" in include["when"]
+    assert job["service"]["user"] == "root"
+    assert job["service"]["group"] == "root"
+    assert job["service"]["wants"] == ["network-online.target"]
+    assert job["service"]["after"] == ["network-online.target"]
+    assert job["timer"]["on_calendar"] == "{{ postgres_backup_restore_validation_timer_on_calendar }}"
+    assert job["enabled"] == "{{ postgres_backup_restore_validation_enabled }}"
+    rendered = render_jinja(SYSTEMD_SERVICE_TEMPLATE, systemd_jobs_job=job)
+    assert "Wants=network-online.target" in rendered
+    assert "After=network-online.target" in rendered
+
+
+def test_manual_action_and_check_mode_do_not_run_during_normal_role_execution():
+    tasks = yaml.safe_load(MAIN_TASKS_PATH.read_text())
+    run = task_named(tasks, "Run PostgreSQL backup restore validation manually")
+    check = task_named(tasks, "Report PostgreSQL backup restore validation check-mode plan")
+    action_tasks = yaml.safe_load(ACTION_TASKS_PATH.read_text())
+    invoke = task_named(action_tasks, "Backup restore validation action | Invoke host-local runner")
+
+    assert "'postgres_backup_restore_validation_run' in" in " ".join(run["when"])
+    assert "not ansible_check_mode" in run["when"]
+    assert "inventory_hostname == postgres_backup_restore_validation_host" in run["when"]
+    assert "ansible_check_mode" in check["when"]
+    assert "would select a recent PostgreSQL Restic snapshot" in check["ansible.builtin.debug"]["msg"]
+    assert invoke["become_user"] == "root"
+    assert invoke["ansible.builtin.command"]["argv"] == ["{{ postgres_backup_restore_validation_script_path }}"]
+
+
+def test_restore_validation_tags_and_commands_are_wired_and_documented():
+    sources = (
+        PLAYBOOK_PATH.read_text(),
+        SKYNET_TEMPLATE_PATH.read_text(),
+        SKYNET_DOC_PATH.read_text(),
+        BACKUP_DOC_PATH.read_text(),
+    )
+    for action in ("setup", "run"):
+        tag = f"postgres_backup_restore_validation_{action}"
+        command = f"backup-restore-validation-{action}"
+        assert all(tag in source for source in sources)
+        assert command in sources[1]
+        assert command in sources[2]
+
+
+def test_runner_preserves_restic_and_production_safety_boundaries():
+    source = RUNNER_TEMPLATE_PATH.read_text()
+
+    assert "run_restic cat config" in source
+    assert "run_restic snapshots" in source
+    assert "--json" in source
+    assert '--host "$SNAPSHOT_HOST"' in source
+    assert '--tag "postgres-logical-backup,cluster=$CLUSTER_SCOPE"' in source
+    assert "--tag postgres-logical-backup" not in source
+    assert "source-member=" not in source
+    assert "inventory_hostname" not in source
+    assert "run_restic init" not in source
+    assert "run_restic forget" not in source
+    assert "run_restic prune" not in source
+    assert "--delete" not in source
+    assert "patronictl" not in source.lower()
+    assert "/leader" not in source
+    assert "systemctl stop patroni" not in source.lower()
+    assert "systemctl" not in source
+    assert "globals.sql" in source
+    assert "psql_value" in source
+    assert "--file=globals.sql" not in source
+    assert "5432" not in source
+    assert "/var/run/postgresql" not in source
+
+
+def test_successful_validation_restores_every_database_sequentially_and_emits_metrics(
+    tmp_path: Path,
+):
+    script = render_validator(tmp_path)
+
+    result = run_validator(script)
+    log = command_log(tmp_path)
+    joined = "\n".join(log)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "POSTGRES_BACKUP_RESTORE_VALIDATION_RESULT=VALIDATED" in result.stdout
+    assert sum(line.startswith("PG_RESTORE\t") for line in log) == 2
+    assert sum(line.startswith("CREATEDB\t") for line in log) == 2
+    assert sum(line.startswith("DROPDB\t") for line in log) == 2
+    lifecycle = [line.split("\t", 1)[0] for line in log if line.startswith(("CREATEDB\t", "PG_RESTORE\t", "DROPDB\t"))]
+    assert lifecycle == [
+        "CREATEDB",
+        "PG_RESTORE",
+        "DROPDB",
+        "CREATEDB",
+        "PG_RESTORE",
+        "DROPDB",
+    ]
+    snapshots_call = next(line for line in log if line.startswith("RESTIC\t") and "\tsnapshots\t" in line)
+    assert "\t--tag\tpostgres-logical-backup,cluster=pg-cluster" in snapshots_call
+    assert snapshots_call.count("\t--tag\t") == 1
+    install_call = next(line for line in log if line.startswith("INSTALL\t"))
+    assert "\t-o\tpostgres\t-g\tpostgres\t-m\t0700" in install_call
+    for directory in ("/cluster", "/cluster/data", "/cluster/socket"):
+        assert directory in install_call
+    for line in [line for line in log if line.startswith(("PSQL\t", "CREATEDB\t", "DROPDB\t", "PG_RESTORE\t"))]:
+        assert "--host=" in line and "/cluster/socket" in line
+        assert "--port=55432" in line
+        assert "--username=postgres" in line
+    restore_lines = [line for line in log if line.startswith("PG_RESTORE\t")]
+    assert any(line.endswith("/appdb.dump") for line in restore_lines)
+    assert any(line.endswith("/postgres.dump") for line in restore_lines)
+    for line in restore_lines:
+        for option in ("--exit-on-error", "--no-owner", "--no-acl", "--no-tablespaces"):
+            assert option in line
+    first_safety_query = next(index for index, line in enumerate(log) if "SHOW data_directory;" in line)
+    first_restore = next(index for index, line in enumerate(log) if line.startswith("PG_RESTORE\t"))
+    assert first_safety_query < first_restore
+    assert "RUNUSER\t-u\tpostgres\t--" in joined
+    assert "INITDB\t" in joined
+    assert "PG_CTL\t" in joined and "\tstart" in joined and "\tstop" in joined
+    assert "--auth-local=trust" in joined
+    assert "--auth-host=reject" in joined
+    assert "--template=template0" in joined
+    for line in [line for line in log if line.startswith(("CREATEDB\t", "DROPDB\t"))]:
+        assert line.endswith("\tpostgres_restore_validation")
+    assert "--port=5432" not in joined
+    assert "/var/run/postgresql" not in joined
+    assert "globals.sql" not in joined
+    assert not list((tmp_path / "work").glob("run-*"))
+    metric_text = metrics(tmp_path)
+    assert "postgres_backup_restore_validation_last_run_success 1" in metric_text
+    assert "postgres_backup_restore_validation_last_database_count 2" in metric_text
+    assert "postgres_backup_restore_validation_last_snapshot_timestamp_seconds 0" not in metric_text
+    assert not list((tmp_path / "textfile").glob("*.tmp.*"))
+
+
+def test_newest_valid_matching_snapshot_is_selected_and_unrelated_snapshot_is_ignored(
+    tmp_path: Path,
+):
+    backup_root = tmp_path / "backups"
+    now = datetime.datetime.now(datetime.UTC)
+    snapshots = [
+        snapshot(
+            backup_root,
+            snapshot_id="d" * 64,
+            backup_id="20260813T030412Z",
+            snapshot_time=now,
+            hostname="pg95",
+        ),
+        snapshot(
+            backup_root,
+            snapshot_id=SNAPSHOT_ID_A,
+            backup_id=BACKUP_ID_A,
+            snapshot_time=now - datetime.timedelta(hours=2),
+        ),
+        snapshot(
+            backup_root,
+            snapshot_id=SNAPSHOT_ID_B,
+            backup_id=BACKUP_ID_B,
+            snapshot_time=now - datetime.timedelta(minutes=5),
+        ),
+    ]
+    script = render_validator(tmp_path, snapshots=snapshots)
+
+    result = run_validator(script)
+    restore = next(line for line in command_log(tmp_path) if "\trestore\t" in line)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"{SNAPSHOT_ID_B}:{backup_root}/{BACKUP_ID_B}" in restore
+    assert SNAPSHOT_ID_A not in restore
+    assert "d" * 64 not in restore
+
+
+@pytest.mark.parametrize(
+    ("mutator", "expected_message"),
+    [
+        (lambda item, root: item.update({"id": "../../unsafe"}), "unsafe ID"),
+        (
+            lambda item, root: item.update({"tags": ["postgres-logical-backup", "cluster=pg-cluster"]}),
+            "exactly one backup-id",
+        ),
+        (
+            lambda item, root: item.update(
+                {
+                    "tags": [
+                        "postgres-logical-backup",
+                        "cluster=pg-cluster",
+                        "backup-id=../../unsafe",
+                    ]
+                }
+            ),
+            "invalid backup ID",
+        ),
+        (
+            lambda item, root: item.update({"paths": [f"{root}/unexpected"]}),
+            "unexpected source path",
+        ),
+        (lambda item, root: item.update({"tags": "malformed"}), "malformed tags"),
+    ],
+)
+def test_malformed_matching_snapshot_metadata_is_rejected_before_restore(
+    tmp_path: Path,
+    mutator,
+    expected_message: str,
+):
+    backup_root = tmp_path / "backups"
+    item = snapshot(backup_root)
+    mutator(item, backup_root)
+    script = render_validator(tmp_path, snapshots=[item])
+
+    result = run_validator(script)
+    joined = "\n".join(command_log(tmp_path))
+
+    assert result.returncode != 0
+    assert expected_message in result.stderr
+    assert "\trestore\t" not in joined
+    assert "INITDB\t" not in joined
+
+
+def test_no_matching_snapshot_and_stale_snapshot_fail_without_restore(tmp_path: Path):
+    unrelated = snapshot(tmp_path / "no-match/backups", hostname="pg95")
+    stale = snapshot(
+        tmp_path / "stale/backups",
+        snapshot_time=datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=49),
+    )
+
+    no_match_script = render_validator(tmp_path / "no-match", snapshots=[unrelated])
+    no_match = run_validator(no_match_script)
+    stale_script = render_validator(tmp_path / "stale", snapshots=[stale])
+    stale_result = run_validator(stale_script)
+
+    assert no_match.returncode != 0
+    assert "no matching PostgreSQL" in no_match.stderr
+    assert stale_result.returncode != 0
+    assert "older than 48 hours" in stale_result.stderr
+    assert not any("\trestore\t" in line for line in command_log(tmp_path / "stale"))
+
+
+@pytest.mark.parametrize(
+    ("restic_mode", "message"),
+    [
+        ("missing", "not initialized"),
+        ("wrong-password", "rejected its password"),
+        ("backend-fail", "exit code 20"),
+        ("snapshots-fail", "restore validation failed"),
+        ("restore-fail", "restore validation failed"),
+    ],
+)
+def test_restic_failures_are_loud_and_never_modify_repository(
+    tmp_path: Path,
+    restic_mode: str,
+    message: str,
+):
+    script = render_validator(tmp_path)
+
+    result = run_validator(script, FAKE_RESTIC_MODE=restic_mode)
+    joined = "\n".join(command_log(tmp_path))
+
+    assert result.returncode != 0
+    assert message in result.stderr
+    assert "\tinit" not in joined
+    assert "\tforget" not in joined
+    assert "\tprune" not in joined
+    assert "--delete" not in joined
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_message"),
+    [
+        ("missing-success", "missing SUCCESS"),
+        ("missing-globals", "missing globals.sql"),
+        ("tampered-dump", "FAILED"),
+        ("malformed-manifest", "unsafe database mapping"),
+        ("count-mismatch", "database count does not match"),
+        ("missing-dump", "missing databases/appdb.dump"),
+        ("unexpected-dump", "do not exactly match the manifest"),
+    ],
+)
+def test_invalid_restored_artifacts_fail_before_postgresql_starts(
+    tmp_path: Path,
+    mutation: str,
+    expected_message: str,
+):
+    artifact = make_artifact(tmp_path)
+    if mutation == "missing-success":
+        (artifact / "SUCCESS").unlink()
+    elif mutation == "missing-globals":
+        (artifact / "globals.sql").unlink()
+    elif mutation == "tampered-dump":
+        (artifact / "databases/appdb.dump").write_text("tampered after checksum\n")
+    elif mutation == "malformed-manifest":
+        manifest = (artifact / "manifest.txt").read_text()
+        (artifact / "manifest.txt").write_text(
+            manifest.replace(
+                "database=appdb\tdump=databases/appdb.dump",
+                "database=appdb\tdump=../appdb.dump",
+            )
+        )
+        rewrite_checksums(artifact)
+    elif mutation == "count-mismatch":
+        manifest = (artifact / "manifest.txt").read_text()
+        (artifact / "manifest.txt").write_text(manifest.replace("database_count=2", "database_count=3"))
+        rewrite_checksums(artifact)
+    elif mutation == "missing-dump":
+        (artifact / "databases/appdb.dump").unlink()
+    elif mutation == "unexpected-dump":
+        (artifact / "databases/unexpected.dump").write_text("unexpected\n")
+
+    script = render_validator(tmp_path, artifact=artifact)
+    result = run_validator(script)
+    joined = "\n".join(command_log(tmp_path))
+
+    assert result.returncode != 0
+    assert expected_message in result.stdout + result.stderr
+    assert "INITDB\t" not in joined
+    assert "PG_RESTORE\t" not in joined
+    assert not list((tmp_path / "work").glob("run-*"))
+
+
+@pytest.mark.parametrize(
+    ("psql_mode", "expected_message"),
+    [
+        ("wrong-data", "unexpected data directory"),
+        ("tcp", "TCP listening enabled"),
+        ("wrong-socket", "unexpected socket directory"),
+        ("wrong-port", "unexpected port"),
+    ],
+)
+def test_temporary_cluster_identity_mismatch_prevents_database_restore_and_cleans_up(
+    tmp_path: Path,
+    psql_mode: str,
+    expected_message: str,
+):
+    script = render_validator(tmp_path)
+
+    result = run_validator(script, FAKE_PSQL_MODE=psql_mode)
+    log = command_log(tmp_path)
+    joined = "\n".join(log)
+
+    assert result.returncode != 0
+    assert expected_message in result.stderr
+    assert "PG_RESTORE\t" not in joined
+    assert "CREATEDB\t" not in joined
+    assert any(line.startswith("PG_CTL\t") and line.endswith("\tstop") for line in log)
+    assert not list((tmp_path / "work").glob("run-*"))
+
+
+def test_free_space_floor_fails_before_restic_restore(tmp_path: Path):
+    script = render_validator(tmp_path, min_free_bytes=10**18)
+
+    result = run_validator(script)
+    joined = "\n".join(command_log(tmp_path))
+
+    assert result.returncode != 0
+    assert "below the configured free-space floor" in result.stderr
+    assert "\trestore\t" not in joined
+    assert "INITDB\t" not in joined
+    assert "postgres_backup_restore_validation_last_run_success 0" in metrics(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected_log"),
+    [
+        ({"FAKE_INITDB_FAIL": "1"}, "INITDB\t"),
+        ({"FAKE_PG_CTL_START_FAIL": "1"}, "PG_CTL\t"),
+        ({"FAKE_PSQL_MODE": "sql-fail"}, "PSQL\t"),
+    ],
+)
+def test_postgresql_startup_and_sql_failures_fail_the_validation(
+    tmp_path: Path,
+    environment: dict[str, str],
+    expected_log: str,
+):
+    script = render_validator(tmp_path)
+
+    result = run_validator(script, **environment)
+    joined = "\n".join(command_log(tmp_path))
+
+    assert result.returncode != 0
+    assert expected_log in joined
+    assert "postgres_backup_restore_validation_last_run_success 0" in metrics(tmp_path)
+    assert not list((tmp_path / "work").glob("run-*"))
+
+
+def test_cleanup_stop_failure_is_reported_and_preserves_the_workspace(tmp_path: Path):
+    script = render_validator(tmp_path)
+
+    result = run_validator(script, FAKE_PG_CTL_STOP_FAIL="1")
+
+    assert result.returncode != 0
+    assert "Failed to stop the temporary PostgreSQL validation cluster" in result.stderr
+    assert "postgres_backup_restore_validation_last_run_success 0" in metrics(tmp_path)
+    assert len(list((tmp_path / "work").glob("run-*"))) == 1
+
+
+def test_pg_restore_failure_fails_run_preserves_last_success_and_cleans_cluster(
+    tmp_path: Path,
+):
+    script = render_validator(tmp_path)
+    metrics_file = tmp_path / "textfile/postgres_logical_backup_restore_validation.prom"
+    metrics_file.write_text(
+        "\n".join(
+            (
+                "postgres_backup_restore_validation_last_success_timestamp_seconds 123",
+                "postgres_backup_restore_validation_last_database_count 7",
+                "postgres_backup_restore_validation_last_snapshot_timestamp_seconds 456",
+            )
+        )
+        + "\n"
+    )
+
+    result = run_validator(script, FAKE_PG_RESTORE_FAIL="1")
+    log = command_log(tmp_path)
+    metric_text = metrics(tmp_path)
+
+    assert result.returncode != 0
+    assert "postgres_backup_restore_validation_last_run_success 0" in metric_text
+    assert "postgres_backup_restore_validation_last_success_timestamp_seconds 123" in metric_text
+    assert "postgres_backup_restore_validation_last_database_count 7" in metric_text
+    assert "postgres_backup_restore_validation_last_snapshot_timestamp_seconds 456" in metric_text
+    assert any(line.startswith("PG_CTL\t") and line.endswith("\tstop") for line in log)
+    assert not list((tmp_path / "work").glob("run-*"))
+
+
+def test_overlap_skip_does_not_overwrite_health_metrics(tmp_path: Path):
+    script = render_validator(tmp_path)
+    environment = os.environ.copy()
+    environment.update(json.loads((tmp_path / "environment.json").read_text()))
+    environment["FAKE_PG_RESTORE_SLEEP"] = "1"
+    first = subprocess.Popen(
+        [str(script)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=environment,
+    )
+    try:
+        for _ in range(150):
+            if any(line.startswith("PG_RESTORE\t") for line in command_log(tmp_path)):
+                break
+            if first.poll() is not None:
+                break
+            time.sleep(0.02)
+        metrics_before = metrics(tmp_path)
+        overlap = run_validator(script)
+        metrics_after = metrics(tmp_path)
+        first_stdout, first_stderr = first.communicate(timeout=15)
+    finally:
+        if first.poll() is None:
+            first.terminate()
+            first.wait(timeout=5)
+
+    assert first.returncode == 0, first_stdout + first_stderr
+    assert overlap.returncode == 0, overlap.stdout + overlap.stderr
+    assert "POSTGRES_BACKUP_RESTORE_VALIDATION_RESULT=SKIPPED_OVERLAP" in overlap.stdout
+    assert metrics_after == metrics_before
+
+
+def test_stale_workspace_without_pid_is_removed_without_stop_and_remains_root_bounded(tmp_path: Path):
+    script = render_validator(tmp_path)
+    stale, _ = make_stale_workspace(tmp_path)
+    invalid = tmp_path / "work/run-operator-notes"
+    outside = tmp_path / "must-remain"
+    invalid.mkdir()
+    outside.mkdir()
+
+    result = run_validator(script, FAKE_RESTIC_MODE="backend-fail")
+
+    assert result.returncode != 0
+    assert not stale.exists()
+    assert not any(line.startswith("PG_CTL\t") for line in command_log(tmp_path))
+    assert invalid.is_dir()
+    assert outside.is_dir()
+    source = RUNNER_TEMPLATE_PATH.read_text()
+    assert '[[ "$(dirname -- "$candidate")" == "$WORK_ROOT" ]]' in source
+    assert "^run-[0-9]{8}T[0-9]{6}Z-[0-9]+-[A-Za-z0-9]{6}$" in source
+    assert "pg_ctl -D" not in source
+    assert "pg_ctl status" not in source
+    assert "\nkill " not in source
+    assert "\nkillall " not in source
+    assert "\npkill " not in source
+    assert source.count("process_belongs_to_validator_pgdata \\") == 2
+
+
+def test_dead_stale_pid_is_removed_without_postgresql_stop(tmp_path: Path):
+    script = render_validator(tmp_path)
+    stale, stale_pgdata = make_stale_workspace(tmp_path, pid="4242")
+    (stale_pgdata / "postmaster.pid").write_text(f"4242\n{stale_pgdata}\n")
+
+    result = run_validator(script, FAKE_RESTIC_MODE="backend-fail")
+
+    assert result.returncode != 0
+    assert "PID 4242 is not alive; no stop is required" in result.stdout
+    assert not stale.exists()
+    assert not any(line.startswith("PG_CTL\t") for line in command_log(tmp_path))
+
+
+def test_exact_live_stale_validator_process_is_stopped_before_removal(tmp_path: Path):
+    script = render_validator(tmp_path)
+    stale, stale_pgdata = make_stale_workspace(tmp_path, pid="4242")
+    (stale_pgdata / "postmaster.pid").write_text(f"4242\n{stale_pgdata}\n")
+    make_fake_process(
+        tmp_path,
+        pid="4242",
+        executable="postgres",
+        arguments=[str(tmp_path / "fake-bin/postgres"), "-D", str(stale_pgdata)],
+    )
+
+    result = run_validator(script, FAKE_RESTIC_MODE="backend-fail")
+    stop_calls = [line for line in command_log(tmp_path) if line.startswith("PG_CTL\t")]
+
+    assert result.returncode != 0
+    assert not stale.exists()
+    assert len(stop_calls) == 1
+    assert f"\t-D\t{stale_pgdata}\t-m\tfast\t-w\t-t\t60\tstop" in stop_calls[0]
+
+
+@pytest.mark.parametrize(
+    ("executable", "process_pgdata", "uid", "recorded_pgdata"),
+    [
+        ("sleep", None, 999, None),
+        ("postgres", "/var/lib/postgresql/18/main", 999, None),
+        ("postgres", "/tmp/different-validation-run/cluster/data", 999, None),
+        ("postgres", None, 1000, None),
+        ("postgres", None, 999, "/var/lib/postgresql/18/main"),
+    ],
+)
+def test_ambiguous_live_stale_pid_fails_closed_without_stop_or_removal(
+    tmp_path: Path,
+    executable: str,
+    process_pgdata: str | None,
+    uid: int,
+    recorded_pgdata: str | None,
+):
+    script = render_validator(tmp_path)
+    stale, stale_pgdata = make_stale_workspace(tmp_path, pid="4242")
+    recorded = recorded_pgdata or str(stale_pgdata)
+    (stale_pgdata / "postmaster.pid").write_text(f"4242\n{recorded}\n")
+    arguments = [str(tmp_path / f"fake-bin/{executable}")]
+    if executable == "postgres":
+        arguments.extend(("-D", process_pgdata or str(stale_pgdata)))
+    else:
+        arguments.append("60")
+    make_fake_process(
+        tmp_path,
+        pid="4242",
+        executable=executable,
+        arguments=arguments,
+        uid=uid,
+    )
+
+    result = run_validator(script)
+
+    assert result.returncode != 0
+    assert "Refusing to stop live PID 4242" in result.stderr
+    assert stale.is_dir()
+    assert not any(line.startswith("PG_CTL\t") for line in command_log(tmp_path))
+    assert "postgres_backup_restore_validation_last_run_success 0" in metrics(tmp_path)
+
+
+@pytest.mark.parametrize("malformed_pid", ["", "not-a-pid", "0", "-12"])
+def test_malformed_stale_pid_never_causes_a_stop(tmp_path: Path, malformed_pid: str):
+    script = render_validator(tmp_path)
+    stale, stale_pgdata = make_stale_workspace(tmp_path, pid="placeholder")
+    (stale_pgdata / "postmaster.pid").write_text(f"{malformed_pid}\n{stale_pgdata}\n")
+
+    result = run_validator(script)
+
+    assert result.returncode != 0
+    assert "malformed postmaster.pid" in result.stderr
+    assert stale.is_dir()
+    assert not any(line.startswith("PG_CTL\t") for line in command_log(tmp_path))
+
+
+def test_metrics_are_atomic_low_cardinality_and_failure_aware():
+    source = RUNNER_TEMPLATE_PATH.read_text()
+
+    assert 'mktemp "${METRICS_FILE}.tmp.XXXXXX"' in source
+    assert 'mv -f -- "$metrics_tmp" "$METRICS_FILE"' in source
+    assert "postgres_backup_restore_validation_last_run_success{" not in source
+    assert "postgres_backup_restore_validation_last_database_count{" not in source
+    for metric_name in (
+        "last_attempt_timestamp_seconds",
+        "last_success_timestamp_seconds",
+        "last_run_success",
+        "last_duration_seconds",
+        "last_database_count",
+        "last_snapshot_timestamp_seconds",
+    ):
+        assert f"postgres_backup_restore_validation_{metric_name}" in source
+
+
+def test_rendered_validator_passes_bash_syntax(tmp_path: Path):
+    script = render_validator(tmp_path)
+
+    result = subprocess.run(
+        ["bash", "-n", str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(shutil.which("shellcheck") is None, reason="shellcheck is unavailable")
+def test_rendered_validator_passes_shellcheck(tmp_path: Path):
+    script = render_validator(tmp_path)
+
+    result = subprocess.run(
+        ["shellcheck", str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_restore_validation_systemd_units_pass_systemd_analyze_verify(tmp_path: Path):
+    if shutil.which("systemd-analyze") is None:
+        pytest.skip("systemd-analyze is unavailable")
+    runner = tmp_path / "postgres-logical-backup-restore-validate"
+    write_executable(runner, "#!/bin/sh\nexit 0\n")
+    job = {
+        "name": "postgres-logical-backup-restore-validation",
+        "description": "Validate PostgreSQL logical backups restored from Restic",
+        "service": {
+            "type": "oneshot",
+            "exec_start": str(runner),
+            "user": "root",
+            "group": "root",
+            "working_directory": str(tmp_path),
+            "wants": ["network-online.target"],
+            "after": ["network-online.target"],
+            "nice": 10,
+            "io_scheduling_class": "best-effort",
+            "io_scheduling_priority": 7,
+        },
+        "timer": {
+            "description": "Validate PostgreSQL logical backups restored from Restic",
+            "on_calendar": "Sun *-*-* 07:00:00",
+            "randomized_delay_sec": "30m",
+            "persistent": True,
+        },
+        "enabled": False,
+    }
+    service_path = tmp_path / f"{job['name']}.service"
+    timer_path = tmp_path / f"{job['name']}.timer"
+    service_path.write_text(render_jinja(SYSTEMD_SERVICE_TEMPLATE, systemd_jobs_job=job))
+    timer_path.write_text(render_jinja(SYSTEMD_TIMER_TEMPLATE, systemd_jobs_job=job))
+
+    result = subprocess.run(
+        ["systemd-analyze", "verify", str(service_path), str(timer_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/unit/test_service_common_static.py
+++ b/tests/unit/test_service_common_static.py
@@ -148,7 +148,7 @@ def test_common_operational_code_has_no_runtime_role_variables_or_resources():
     assert "quadlet" not in OPERATIONAL_TEXT.lower()
 
 
-def test_infisical_lookup_and_schema_are_common_owned_without_adapter_wrappers():
+def test_infisical_lookup_sites_are_explicit_and_adapter_free():
     production_files = [
         path
         for path in Path("ansible").rglob("*")
@@ -156,7 +156,10 @@ def test_infisical_lookup_and_schema_are_common_owned_without_adapter_wrappers()
     ]
     orchestration_files = [path for path in production_files if "ansible/collections/" not in path.as_posix()]
     lookup_sites = [path for path in orchestration_files if "infisical.vault.read_secrets" in path.read_text()]
-    assert lookup_sites == [Path("ansible/roles/service_common/tasks/infisical.yml")]
+    assert set(lookup_sites) == {
+        Path("ansible/roles/service_common/tasks/infisical.yml"),
+        Path("ansible/roles/postgres/tasks/sub_tasks/backup_remote_setup.yml"),
+    }
 
     for role in ("docker_services", "podman_services"):
         adapter_files = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional remote PostgreSQL logical backups with Restic, including repository initialization, uploads, retention maintenance, scheduling, metrics, and secure credential handling.
  * Added automated restore validation with snapshot checks, isolated database restoration, safety checks, cleanup, and scheduled execution.
  * Added Ansible tags and command mappings for backup and restore-validation operations.

* **Documentation**
  * Documented configuration, commands, check mode, metrics, recovery boundaries, and restore-validation workflows.

* **Tests**
  * Added comprehensive coverage for backup, restore validation, security, failure handling, systemd integration, and shell safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->