### PR TITLE
ci(renovate): fast-path Docker tag-only updates

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -47,18 +47,41 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Classify Renovate Docker tag-only change
+        id: classify
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python scripts/ci/classify_renovate_docker_tag_only.py \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --pr-author "$PR_AUTHOR" \
+            --base-sha "$PR_BASE_SHA" \
+            --head-sha "$PR_HEAD_SHA" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Renovate Docker tag-only fast path
+        if: fromJSON(steps.classify.outputs.renovate_docker_tag_only)
+        run: echo "Checkov is not required for a proven Docker tag-only Renovate change."
 
       - name: Set up Python
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14.7"
 
       - name: Install Checkov
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install checkov
 
       - name: Run Checkov
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         run: |
           checkov \
             --directory . \
@@ -69,7 +92,7 @@ jobs:
             --soft-fail
 
       - name: Upload Checkov SARIF
-        if: success() || failure()
+        if: (success() || failure()) && !fromJSON(steps.classify.outputs.renovate_docker_tag_only)
         uses: github/codeql-action/upload-sarif@v4.37.6
         with:
           sarif_file: checkov.sarif

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,12 +6,14 @@ on:
   push:
     paths:
       - "ansible/**"
+      - "scripts/ci/**"
       - "tests/**"
       - "pyproject.toml"
       - ".github/workflows/lint.yml"
   pull_request:
     paths:
       - "ansible/**"
+      - "scripts/ci/**"
       - "tests/**"
       - "pyproject.toml"
       - ".github/workflows/lint.yml"
@@ -30,13 +32,34 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Classify Renovate Docker tag-only change
+        id: classify
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python scripts/ci/classify_renovate_docker_tag_only.py \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --pr-author "$PR_AUTHOR" \
+            --base-sha "$PR_BASE_SHA" \
+            --head-sha "$PR_HEAD_SHA" \
+            >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14.7"
 
+      - name: Install fast-path tooling
+        if: fromJSON(steps.classify.outputs.renovate_docker_tag_only)
+        run: python -m pip install yamllint
+
       - name: Install Python tooling
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         run: |
           python -m pip install --upgrade pip
 
@@ -47,9 +70,11 @@ jobs:
           python -m pip install ansible-core ansible-lint yamllint ruff pytest
 
       - name: Prepare ansible log dir
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         run: mkdir -p .ansible
 
       - name: Install Ansible collections
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         run: |
           if [ -f ansible/requirements.yml ]; then
             ansible-galaxy collection install \
@@ -59,6 +84,7 @@ jobs:
           fi
 
       - name: yamllint (tracked YAML files only)
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         run: |
           files=$(git ls-files '*.yml' '*.yaml')
           if [ -z "$files" ]; then
@@ -67,7 +93,19 @@ jobs:
           fi
           yamllint $files
 
+      - name: Renovate Docker tag-only validation
+        if: fromJSON(steps.classify.outputs.renovate_docker_tag_only)
+        env:
+          CHANGED_FILES: ${{ steps.classify.outputs.changed_files }}
+          COMPARISON_BASE: ${{ steps.classify.outputs.comparison_base }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mapfile -t changed_files <<< "$CHANGED_FILES"
+          git diff --check "$COMPARISON_BASE" "$PR_HEAD_SHA"
+          yamllint "${changed_files[@]}"
+
       - name: ruff check
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         run: |
           ruff check --output-format=github \
             ansible/action_plugins \
@@ -78,9 +116,11 @@ jobs:
             ansible/roles/service_common/filter_plugins \
             ansible/roles/service_prepare/filter_plugins \
             ansible/roles/service_prepare/library \
+            scripts/ci \
             tests/unit
 
       - name: ruff format check
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         run: |
           ruff format --check --diff \
             ansible/action_plugins \
@@ -91,12 +131,15 @@ jobs:
             ansible/roles/service_common/filter_plugins \
             ansible/roles/service_prepare/filter_plugins \
             ansible/roles/service_prepare/library \
+            scripts/ci \
             tests/unit
 
       - name: pytest
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         run: |
           python -m pytest tests/unit
 
       - name: ansible-lint
+        if: ${{ !fromJSON(steps.classify.outputs.renovate_docker_tag_only) }}
         run: |
           ansible-lint --format=pep8 ansible

--- a/renovate.json
+++ b/renovate.json
@@ -18,9 +18,8 @@
         "**/ansible/collections/**",
         "**/.ansible/**"
     ],
-    "prConcurrentLimit": 5,
-    "prHourlyLimit": 1,
-    "branchConcurrentLimit": 5,
+    "prConcurrentLimit": 10,
+    "prHourlyLimit": 3,
     "rangeStrategy": "pin",
     "semanticCommits": "enabled",
     "semanticCommitType": "chore",
@@ -199,7 +198,7 @@
             ]
         },
         {
-            "description": "Weekly batch for non-critical Docker minor/patch updates",
+            "description": "Nightly batch for non-critical Docker minor/patch updates",
             "matchDatasources": [
                 "docker"
             ],
@@ -210,10 +209,10 @@
             "groupName": "weekly non-critical docker image updates",
             "groupSlug": "weekly-docker-minor-patch",
             "schedule": [
-                "* 3-7 * * 1"
+                "* 3-7 * * *"
             ],
             "minimumGroupSize": 2,
-            "prPriority": -5,
+            "prPriority": 0,
             "addLabels": [
                 "docker",
                 "batch"

--- a/scripts/ci/classify_renovate_docker_tag_only.py
+++ b/scripts/ci/classify_renovate_docker_tag_only.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Classify a pull request as a Renovate Docker image tag-only change."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+RENOVATE_AUTHOR = "renovate[bot]"
+SERVICE_FILE_RE = re.compile(r"^ansible/group_vars/all/services/[A-Za-z0-9][A-Za-z0-9_.-]*\.ya?ml$")
+GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40,64}$")
+IMAGE_LINE_RE = re.compile(
+    r"^(?P<prefix> *image: +)"
+    r"(?P<quote>['\"]?)"
+    r"(?P<repository>[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*)"
+    r":(?P<tag>[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})"
+    r"(?:@(?P<digest>sha256:[a-f0-9]{64}))?"
+    r"(?P=quote)(?P<suffix> *(?:\r?\n)?)$"
+)
+
+
+@dataclass(frozen=True)
+class Classification:
+    renovate_docker_tag_only: bool
+    changed_files: tuple[str, ...] = ()
+    comparison_base: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class ImageReference:
+    prefix: str
+    quote: str
+    repository: str
+    tag: str
+    digest: str | None
+    suffix: str
+
+
+def _run_git(repository: Path, *args: str) -> bytes:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+    ).stdout
+
+
+def _parse_image_line(line: str) -> ImageReference | None:
+    match = IMAGE_LINE_RE.fullmatch(line)
+    if match is None:
+        return None
+    return ImageReference(**match.groupdict())
+
+
+def _is_tag_only_file_change(base_content: str, head_content: str) -> bool:
+    base_lines = base_content.splitlines(keepends=True)
+    head_lines = head_content.splitlines(keepends=True)
+    if len(base_lines) != len(head_lines):
+        return False
+
+    found_image_change = False
+    for base_line, head_line in zip(base_lines, head_lines, strict=True):
+        if base_line == head_line:
+            continue
+
+        base_image = _parse_image_line(base_line)
+        head_image = _parse_image_line(head_line)
+        if base_image is None or head_image is None:
+            return False
+        if (
+            base_image.prefix != head_image.prefix
+            or base_image.quote != head_image.quote
+            or base_image.repository != head_image.repository
+            or base_image.suffix != head_image.suffix
+        ):
+            return False
+        if (base_image.tag, base_image.digest) == (head_image.tag, head_image.digest):
+            return False
+        found_image_change = True
+
+    return found_image_change
+
+
+def _modified_files(repository: Path, comparison_base: str, head_sha: str) -> tuple[str, ...] | None:
+    raw_status = _run_git(
+        repository,
+        "diff",
+        "--name-status",
+        "-z",
+        "--no-renames",
+        comparison_base,
+        head_sha,
+        "--",
+    )
+    fields = raw_status.decode("utf-8").split("\0")
+    if fields[-1:] == [""]:
+        fields.pop()
+    if not fields or len(fields) % 2 != 0:
+        return None
+
+    changed_files: list[str] = []
+    for status, path in zip(fields[::2], fields[1::2], strict=True):
+        if status != "M" or SERVICE_FILE_RE.fullmatch(path) is None:
+            return None
+        changed_files.append(path)
+
+    return tuple(changed_files)
+
+
+def classify(
+    *,
+    event_name: str,
+    pr_author: str,
+    base_sha: str,
+    head_sha: str,
+    repository: Path,
+) -> Classification:
+    """Return true only for a proven Renovate service image tag-only diff."""
+    if event_name != "pull_request":
+        return Classification(False, reason="event is not pull_request")
+    if pr_author != RENOVATE_AUTHOR:
+        return Classification(False, reason="pull request author is not Renovate")
+    if GIT_SHA_RE.fullmatch(base_sha) is None or GIT_SHA_RE.fullmatch(head_sha) is None:
+        return Classification(False, reason="base or head SHA is malformed")
+
+    try:
+        comparison_base = _run_git(repository, "merge-base", base_sha, head_sha).decode("ascii").strip()
+        if GIT_SHA_RE.fullmatch(comparison_base) is None:
+            return Classification(False, reason="merge base is malformed")
+
+        changed_files = _modified_files(repository, comparison_base, head_sha)
+        if not changed_files:
+            return Classification(False, reason="diff has no eligible modified service files")
+
+        for path in changed_files:
+            base_content = _run_git(repository, "show", f"{comparison_base}:{path}").decode("utf-8")
+            head_content = _run_git(repository, "show", f"{head_sha}:{path}").decode("utf-8")
+            if not _is_tag_only_file_change(base_content, head_content):
+                return Classification(False, reason=f"{path} contains a non-image or non-tag change")
+    except (OSError, subprocess.CalledProcessError, UnicodeDecodeError, ValueError) as error:
+        return Classification(False, reason=f"unable to inspect diff: {type(error).__name__}")
+
+    return Classification(True, changed_files, comparison_base)
+
+
+def _emit_github_outputs(classification: Classification) -> None:
+    value = str(classification.renovate_docker_tag_only).lower()
+    print(f"renovate_docker_tag_only={value}")
+    if classification.renovate_docker_tag_only:
+        print(f"comparison_base={classification.comparison_base}")
+        print("changed_files<<RENOVATE_DOCKER_CHANGED_FILES")
+        print("\n".join(classification.changed_files))
+        print("RENOVATE_DOCKER_CHANGED_FILES")
+    else:
+        print("comparison_base=")
+        print("changed_files=")
+        print(f"classification_reason={classification.reason}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-name", default="")
+    parser.add_argument("--pr-author", default="")
+    parser.add_argument("--base-sha", default="")
+    parser.add_argument("--head-sha", default="")
+    parser.add_argument("--repository", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+
+    classification = classify(
+        event_name=args.event_name,
+        pr_author=args.pr_author,
+        base_sha=args.base_sha,
+        head_sha=args.head_sha,
+        repository=args.repository,
+    )
+    _emit_github_outputs(classification)
+    if not classification.renovate_docker_tag_only:
+        print(f"Renovate Docker fast path disabled: {classification.reason}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_classify_renovate_docker_tag_only.py
+++ b/tests/unit/test_classify_renovate_docker_tag_only.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.ci.classify_renovate_docker_tag_only import RENOVATE_AUTHOR, classify
+from scripts.ci.classify_renovate_docker_tag_only import RENOVATE_AUTHOR, classify, main
 
 QUI_PATH = "ansible/group_vars/all/services/qui.yml"
 DOZZLE_PATH = "ansible/group_vars/all/services/dozzle.yml"
@@ -105,6 +105,95 @@ def test_digest_only_change_uses_fast_path(git_repository: tuple[Path, str]) -> 
     head_sha = _commit(repository, "update digest", {QUI_PATH: base_content.replace("a" * 64, "b" * 64)})
 
     assert _classify(repository, base_sha, head_sha).renovate_docker_tag_only is True
+
+
+def test_multiple_target_image_changes_in_one_service_use_fast_path(git_repository: tuple[Path, str]) -> None:
+    repository, _ = git_repository
+    base_content = """---
+service:
+  runtime: docker
+  targets:
+    agent:
+      image: example/agent:1.0.0
+    main:
+      image: example/main:2.0.0
+"""
+    base_sha = _commit(repository, "add multi-target service", {QUI_PATH: base_content})
+    head_content = base_content.replace("example/agent:1.0.0", "example/agent:1.1.0").replace("example/main:2.0.0", "example/main:2.1.0")
+    head_sha = _commit(repository, "update target images", {QUI_PATH: head_content})
+
+    assert _classify(repository, base_sha, head_sha).renovate_docker_tag_only is True
+
+
+def test_podman_runtime_image_change_uses_fast_path(git_repository: tuple[Path, str]) -> None:
+    repository, _ = git_repository
+    base_content = """---
+service:
+  runtime: podman
+  image: example/app:1.0.0
+"""
+    base_sha = _commit(repository, "add podman service", {QUI_PATH: base_content})
+    head_sha = _commit(repository, "update podman image", {QUI_PATH: base_content.replace("1.0.0", "1.1.0")})
+
+    assert _classify(repository, base_sha, head_sha).renovate_docker_tag_only is True
+
+
+def test_cli_emits_true_github_output_contract(git_repository: tuple[Path, str], capsys: pytest.CaptureFixture[str]) -> None:
+    repository, base_sha = git_repository
+    head_sha = _commit(repository, "update qui", {QUI_PATH: SERVICE_YAML.replace("v1.20.0", "v1.25.0")})
+
+    exit_code = main(
+        [
+            "--event-name",
+            "pull_request",
+            "--pr-author",
+            RENOVATE_AUTHOR,
+            "--base-sha",
+            base_sha,
+            "--head-sha",
+            head_sha,
+            "--repository",
+            str(repository),
+        ]
+    )
+    output_lines = capsys.readouterr().out.splitlines()
+
+    assert exit_code == 0
+    assert "renovate_docker_tag_only=true" in output_lines
+    assert f"comparison_base={base_sha}" in output_lines
+    changed_files_header = next(line for line in output_lines if line.startswith("changed_files<<"))
+    changed_files_footer = changed_files_header.removeprefix("changed_files<<")
+    header_index = output_lines.index(changed_files_header)
+    footer_index = output_lines.index(changed_files_footer)
+    assert QUI_PATH in output_lines[header_index + 1 : footer_index]
+
+
+def test_cli_emits_false_github_output_contract(git_repository: tuple[Path, str], capsys: pytest.CaptureFixture[str]) -> None:
+    repository, base_sha = git_repository
+    head_sha = _commit(repository, "update qui", {QUI_PATH: SERVICE_YAML.replace("v1.20.0", "v1.25.0")})
+
+    exit_code = main(
+        [
+            "--event-name",
+            "pull_request",
+            "--pr-author",
+            "human",
+            "--base-sha",
+            base_sha,
+            "--head-sha",
+            head_sha,
+            "--repository",
+            str(repository),
+        ]
+    )
+    output_lines = capsys.readouterr().out.splitlines()
+
+    assert exit_code == 0
+    assert "renovate_docker_tag_only=false" in output_lines
+    assert "comparison_base=" in output_lines
+    assert "changed_files=" in output_lines
+    reason = next(line for line in output_lines if line.startswith("classification_reason="))
+    assert reason.removeprefix("classification_reason=")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_classify_renovate_docker_tag_only.py
+++ b/tests/unit/test_classify_renovate_docker_tag_only.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.classify_renovate_docker_tag_only import RENOVATE_AUTHOR, classify
+
+QUI_PATH = "ansible/group_vars/all/services/qui.yml"
+DOZZLE_PATH = "ansible/group_vars/all/services/dozzle.yml"
+
+SERVICE_YAML = """---
+service:
+  image: ghcr.io/autobrr/qui:v1.20.0
+  environment:
+    PUID: "1000"
+    PGID: "1000"
+  ports:
+    - "7476:7476"
+  volumes:
+    - "/data:/data"
+  labels:
+    traefik.enable: "true"
+  secrets:
+    - qui_token
+"""
+
+
+def _git(repository: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit(repository: Path, message: str, changes: dict[str, str | None]) -> str:
+    for relative_path, content in changes.items():
+        path = repository / relative_path
+        if content is None:
+            path.unlink()
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+    _git(repository, "add", "-A")
+    _git(repository, "commit", "-m", message)
+    return _git(repository, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def git_repository(tmp_path: Path) -> tuple[Path, str]:
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Renovate classifier tests")
+    _git(tmp_path, "config", "user.email", "renovate-classifier@example.invalid")
+    base_sha = _commit(tmp_path, "base", {QUI_PATH: SERVICE_YAML})
+    return tmp_path, base_sha
+
+
+def _classify(repository: Path, base_sha: str, head_sha: str, *, author: str = RENOVATE_AUTHOR):
+    return classify(
+        event_name="pull_request",
+        pr_author=author,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        repository=repository,
+    )
+
+
+def test_single_service_tag_change_uses_fast_path(git_repository: tuple[Path, str]) -> None:
+    repository, base_sha = git_repository
+    head_sha = _commit(repository, "update qui", {QUI_PATH: SERVICE_YAML.replace("v1.20.0", "v1.25.0")})
+
+    classification = _classify(repository, base_sha, head_sha)
+
+    assert classification.renovate_docker_tag_only is True
+    assert classification.changed_files == (QUI_PATH,)
+
+
+def test_multiple_service_tag_changes_use_fast_path(git_repository: tuple[Path, str]) -> None:
+    repository, base_sha = git_repository
+    dozzle_base = SERVICE_YAML.replace("ghcr.io/autobrr/qui:v1.20.0", "amir20/dozzle:v10.6.15")
+    base_sha = _commit(repository, "add dozzle", {DOZZLE_PATH: dozzle_base})
+    head_sha = _commit(
+        repository,
+        "update service images",
+        {
+            QUI_PATH: SERVICE_YAML.replace("v1.20.0", "v1.25.0"),
+            DOZZLE_PATH: dozzle_base.replace("v10.6.15", "v10.7.1"),
+        },
+    )
+
+    classification = _classify(repository, base_sha, head_sha)
+
+    assert classification.renovate_docker_tag_only is True
+    assert set(classification.changed_files) == {QUI_PATH, DOZZLE_PATH}
+
+
+def test_digest_only_change_uses_fast_path(git_repository: tuple[Path, str]) -> None:
+    repository, _ = git_repository
+    base_content = SERVICE_YAML.replace("v1.20.0", f"v1.20.0@sha256:{'a' * 64}")
+    base_sha = _commit(repository, "pin digest", {QUI_PATH: base_content})
+    head_sha = _commit(repository, "update digest", {QUI_PATH: base_content.replace("a" * 64, "b" * 64)})
+
+    assert _classify(repository, base_sha, head_sha).renovate_docker_tag_only is True
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    [
+        ("ghcr.io/autobrr/qui:v1.20.0", "evil/example:v1.20.0"),
+        ('PGID: "1000"', 'PGID: "0"'),
+        ('- "/data:/data"', '- "/tmp:/data"'),
+        ('- "7476:7476"', '- "80:7476"'),
+        ('traefik.enable: "true"', 'traefik.enable: "false"'),
+        ("- qui_token", "- root_password"),
+    ],
+    ids=["repository", "environment", "volume", "port", "traefik", "secret"],
+)
+def test_non_tag_service_changes_use_full_ci(
+    git_repository: tuple[Path, str],
+    old: str,
+    new: str,
+) -> None:
+    repository, base_sha = git_repository
+    changed = SERVICE_YAML.replace(old, new)
+    head_sha = _commit(repository, "unsafe service edit", {QUI_PATH: changed})
+
+    assert _classify(repository, base_sha, head_sha).renovate_docker_tag_only is False
+
+
+def test_added_configuration_uses_full_ci(git_repository: tuple[Path, str]) -> None:
+    repository, base_sha = git_repository
+    changed = SERVICE_YAML.replace("  environment:\n", "  privileged: true\n  environment:\n").replace("v1.20.0", "v1.25.0")
+    head_sha = _commit(repository, "update image and privilege", {QUI_PATH: changed})
+
+    assert _classify(repository, base_sha, head_sha).renovate_docker_tag_only is False
+
+
+@pytest.mark.parametrize(
+    ("path", "content"),
+    [
+        ("ansible/roles/example/tasks/main.yml", "---\n- name: Example\n  ansible.builtin.debug:\n"),
+        ("ansible/roles/example/templates/config.yml.j2", "setting: value\n"),
+        ("scripts/example.py", "print('changed')\n"),
+        ("opentofu/example/main.tf", 'resource "example" "changed" {}\n'),
+        (".github/workflows/example.yml", "---\nname: Changed\n"),
+    ],
+    ids=["task", "template", "python", "terraform", "workflow"],
+)
+def test_other_repository_change_alongside_tag_uses_full_ci(
+    git_repository: tuple[Path, str],
+    path: str,
+    content: str,
+) -> None:
+    repository, base_sha = git_repository
+    head_sha = _commit(
+        repository,
+        "update image and another file",
+        {QUI_PATH: SERVICE_YAML.replace("v1.20.0", "v1.25.0"), path: content},
+    )
+
+    assert _classify(repository, base_sha, head_sha).renovate_docker_tag_only is False
+
+
+def test_human_authored_image_change_uses_full_ci(git_repository: tuple[Path, str]) -> None:
+    repository, base_sha = git_repository
+    head_sha = _commit(repository, "human image update", {QUI_PATH: SERVICE_YAML.replace("v1.20.0", "v1.25.0")})
+
+    assert _classify(repository, base_sha, head_sha, author="human").renovate_docker_tag_only is False
+
+
+def test_multiple_commits_with_manual_change_use_full_ci(git_repository: tuple[Path, str]) -> None:
+    repository, base_sha = git_repository
+    _commit(repository, "renovate image update", {QUI_PATH: SERVICE_YAML.replace("v1.20.0", "v1.25.0")})
+    manually_changed = SERVICE_YAML.replace("v1.20.0", "v1.25.0").replace("  environment:\n", "  privileged: true\n  environment:\n")
+    head_sha = _commit(repository, "manual edit", {QUI_PATH: manually_changed})
+
+    assert _classify(repository, base_sha, head_sha).renovate_docker_tag_only is False
+
+
+def test_whitespace_change_alongside_tag_uses_full_ci(git_repository: tuple[Path, str]) -> None:
+    repository, base_sha = git_repository
+    changed = SERVICE_YAML.replace("v1.20.0", "v1.25.0").replace('    PUID: "1000"', '    PUID:  "1000"')
+    head_sha = _commit(repository, "update image and whitespace", {QUI_PATH: changed})
+
+    assert _classify(repository, base_sha, head_sha).renovate_docker_tag_only is False
+
+
+def test_no_changed_files_uses_full_ci(git_repository: tuple[Path, str]) -> None:
+    repository, base_sha = git_repository
+
+    assert _classify(repository, base_sha, base_sha).renovate_docker_tag_only is False
+
+
+def test_malformed_sha_uses_full_ci(git_repository: tuple[Path, str]) -> None:
+    repository, base_sha = git_repository
+
+    assert _classify(repository, base_sha, "not-a-sha").renovate_docker_tag_only is False
+
+
+def test_non_pull_request_event_uses_full_ci(git_repository: tuple[Path, str]) -> None:
+    repository, base_sha = git_repository
+
+    classification = classify(
+        event_name="push",
+        pr_author=RENOVATE_AUTHOR,
+        base_sha=base_sha,
+        head_sha=base_sha,
+        repository=repository,
+    )
+
+    assert classification.renovate_docker_tag_only is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Docker image tag- and digest-only updates now use a faster validation path.
  * Broader changes continue to receive full security, linting, and test checks.
  * Changes to CI scripts are now included in automated validation.
* **Automation**
  * Renovate can process more updates concurrently.
  * Non-critical Docker updates are now scheduled nightly with increased priority.
* **Testing**
  * Added comprehensive coverage for identifying eligible Docker image updates and ensuring other changes use full validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->